### PR TITLE
feat: add GitHub account validation to workflow scripts

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -9,11 +9,13 @@ This directory contains shell scripts that automate common GitHub workflow opera
 Automates the workflow for starting work on a GitHub issue.
 
 **Usage:**
+
 ```bash
 ./scripts/take-issue.sh <issue-number>
 ```
 
-**What it does:**
+**What it does:** 0. Verifies the active GitHub CLI account matches the repository owner
+
 1. Assigns the issue to the current GitHub user
 2. Creates and checks out a branch named `<issue-number>-<slug>`
 3. Saves issue details to `/tmp/take-issue-<issue-number>.json`
@@ -22,6 +24,7 @@ Automates the workflow for starting work on a GitHub issue.
 **Used by:** `/take-issue` skill
 
 **Example:**
+
 ```bash
 ./scripts/take-issue.sh 42
 ```
@@ -33,11 +36,13 @@ Automates the workflow for starting work on a GitHub issue.
 Prepares work for code review by validating the branch, checking for uncommitted changes, and pushing to remote.
 
 **Usage:**
+
 ```bash
 ./scripts/to-review.sh
 ```
 
-**What it does:**
+**What it does:** 0. Verifies the active GitHub CLI account matches the repository owner
+
 1. Validates the current branch is an issue branch (format: `<issue-number>-<slug>`)
 2. Checks for uncommitted changes (exits with code 2 if found)
 3. Pushes the branch to remote with upstream tracking
@@ -46,6 +51,7 @@ Prepares work for code review by validating the branch, checking for uncommitted
 6. Exports `ISSUE_NUMBER` and `BRANCH_NAME` variables
 
 **Exit codes:**
+
 - `0`: Success, ready for PR creation
 - `2`: Uncommitted changes detected (non-blocking, caller should handle)
 - Other: Error (blocking)
@@ -53,6 +59,7 @@ Prepares work for code review by validating the branch, checking for uncommitted
 **Used by:** `/to-review` skill
 
 **Example:**
+
 ```bash
 ./scripts/to-review.sh
 ```
@@ -64,15 +71,18 @@ Prepares work for code review by validating the branch, checking for uncommitted
 Updates the status field of an issue in GitHub Projects v2. This is a shared utility used by other scripts.
 
 **Usage:**
+
 ```bash
 ./scripts/update-project-status.sh <issue-number> <status>
 ```
 
 **Arguments:**
+
 - `<issue-number>`: The GitHub issue number (numeric)
 - `<status>`: One of: `Backlog`, `In Progress`, `In Review`, `Done`
 
 **What it does:**
+
 1. Ensures the issue is added to the project (if not already)
 2. Retrieves necessary IDs from GitHub Projects v2 API
 3. Updates the Status field to the specified value
@@ -80,9 +90,45 @@ Updates the status field of an issue in GitHub Projects v2. This is a shared uti
 **Used by:** `take-issue.sh`, `to-review.sh` (via `/to-review` skill)
 
 **Example:**
+
 ```bash
 ./scripts/update-project-status.sh 42 "In Review"
 ```
+
+---
+
+## Shared Libraries
+
+### `lib/validate-gh-account.sh`
+
+Shared validation library that ensures the active GitHub CLI account matches the repository owner. Prevents permission errors when working with multiple GitHub accounts.
+
+**Usage:**
+
+```bash
+source scripts/lib/validate-gh-account.sh
+validate_gh_account
+```
+
+**What it does:**
+
+1. Extracts the repository owner from the git remote URL
+2. Gets the active GitHub CLI account from `gh auth status`
+3. Compares the two and displays an error if they don't match
+4. Provides clear instructions to switch accounts using `gh auth switch`
+
+**Return codes:**
+
+- `0`: Account matches, validation passed
+- `1`: Account mismatch or validation error
+
+**Used by:** `take-issue.sh`, `to-review.sh`
+
+**Supports multiple remote URL formats:**
+
+- SSH: `git@github.com:manuelnt11/repo.git`
+- HTTPS: `https://github.com/manuelnt11/repo.git`
+- SSH with custom host: `git@personal:manuelnt11/repo.git`
 
 ---
 
@@ -108,6 +154,9 @@ readonly STATUS_FIELD="Status"
 ## Requirements
 
 - **GitHub CLI (`gh`)** — authenticated and configured
+  - If you have multiple GitHub accounts, ensure the active account matches the repository owner
+  - Use `gh auth status` to check the active account
+  - Use `gh auth switch -u <username>` to switch accounts
 - **Git** — configured with user credentials
 - **jq** — for JSON parsing (required by `update-project-status.sh`)
 - **Bash 4+** — for array support and modern features
@@ -123,10 +172,11 @@ All scripts use `set -euo pipefail` for strict error handling:
 - `set -o pipefail`: Return the exit code of the first failing command in a pipeline
 
 Scripts provide colored output for:
+
 - ✅ Success messages (green)
 - ❌ Error messages (red)
-- ⚠️  Warnings (yellow)
-- ℹ️  Info messages (blue)
+- ⚠️ Warnings (yellow)
+- ℹ️ Info messages (blue)
 
 ---
 

--- a/scripts/lib/validate-gh-account.sh
+++ b/scripts/lib/validate-gh-account.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# validate-gh-account.sh
+# Shared library to validate that the active GitHub CLI account matches the repository owner
+# Usage: source scripts/lib/validate-gh-account.sh && validate_gh_account
+
+# Note: This library expects RED, GREEN, YELLOW, BLUE, NC, and print_* functions
+# to be defined by the calling script
+
+# Validate that the active GitHub account matches the repository owner
+# Returns:
+#   0 - Account matches
+#   1 - Validation failed (account mismatch or error)
+validate_gh_account() {
+  print_info "Verifying GitHub account..."
+
+  # Get repository owner from remote URL
+  local repo_url
+  repo_url=$(git remote get-url origin 2>/dev/null || true)
+
+  if [ -z "$repo_url" ]; then
+    print_error "Failed to get repository remote URL"
+    return 1
+  fi
+
+  # Extract owner from URL (supports both SSH and HTTPS formats)
+  # git@github.com:manuelnt11/repo.git -> manuelnt11
+  # https://github.com/manuelnt11/repo.git -> manuelnt11
+  # git@personal:manuelnt11/repo.git -> manuelnt11
+  local repo_owner
+  repo_owner=$(echo "$repo_url" | sed -E 's#.*[:/]([^/]+)/[^/]+\.git#\1#')
+
+  if [ -z "$repo_owner" ]; then
+    print_error "Failed to extract repository owner from URL: ${repo_url}"
+    return 1
+  fi
+
+  # Get active GitHub account
+  # Parse output: "✓ Logged in to github.com account manuelnt11 (keyring)"
+  local active_account
+  active_account=$(gh auth status 2>&1 | grep "Active account: true" -B 1 | grep "Logged in" | sed -E 's/.*account ([^ ]+) .*/\1/')
+
+  if [ -z "$active_account" ]; then
+    print_error "Failed to get active GitHub account. Are you authenticated?"
+    echo ""
+    echo "Run: gh auth login"
+    return 1
+  fi
+
+  # Compare accounts
+  if [ "$active_account" != "$repo_owner" ]; then
+    print_error "GitHub account mismatch!"
+    echo ""
+    echo "  Repository owner: ${repo_owner}"
+    echo "  Active account:   ${active_account}"
+    echo ""
+    echo "To fix this, switch to the correct account:"
+    echo "  gh auth switch -u ${repo_owner}"
+    echo ""
+    return 1
+  fi
+
+  print_success "GitHub account verified: @${active_account}"
+  return 0
+}

--- a/scripts/take-issue.sh
+++ b/scripts/take-issue.sh
@@ -23,6 +23,10 @@ print_error() { echo -e "${RED}❌ $1${NC}"; }
 print_warning() { echo -e "${YELLOW}⚠️  $1${NC}"; }
 print_info() { echo -e "${BLUE}ℹ️  $1${NC}"; }
 
+# Load shared libraries
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/lib/validate-gh-account.sh"
+
 # Check if issue number is provided
 if [ $# -eq 0 ]; then
   print_error "Issue number is required"
@@ -39,6 +43,13 @@ if ! [[ "$ISSUE_NUMBER" =~ ^[0-9]+$ ]]; then
 fi
 
 echo "🚀 Taking issue #${ISSUE_NUMBER}..."
+echo ""
+
+# Step 0: Verify GitHub account matches repository owner
+if ! validate_gh_account; then
+  exit 1
+fi
+
 echo ""
 
 # Step 1: Get GitHub username and assign the issue

--- a/scripts/to-review.sh
+++ b/scripts/to-review.sh
@@ -24,7 +24,18 @@ print_error() { echo -e "${RED}❌ $1${NC}"; }
 print_warning() { echo -e "${YELLOW}⚠️  $1${NC}"; }
 print_info() { echo -e "${BLUE}ℹ️  $1${NC}"; }
 
+# Load shared libraries
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/lib/validate-gh-account.sh"
+
 echo "🔄 Preparing to move work to review..."
+echo ""
+
+# Step 0: Verify GitHub account matches repository owner
+if ! validate_gh_account; then
+  exit 1
+fi
+
 echo ""
 
 # Step 1: Extract issue number from current branch


### PR DESCRIPTION
## Summary

Adds GitHub account validation to workflow scripts to prevent permission errors when working with multiple GitHub accounts. This change ensures the active GitHub CLI account matches the repository owner before executing `take-issue` and `to-review` workflows.

## Problem

When using multiple GitHub accounts (e.g., personal and work accounts), the GitHub CLI may be authenticated with an account that doesn't have permissions on the repository. This causes workflows to fail with permission errors.

## Solution

Created a shared validation library that:
- Extracts the repository owner from the git remote URL
- Gets the active GitHub CLI account
- Compares them and displays clear error messages if they don't match
- Provides instructions to switch accounts using `gh auth switch`

## Changes

**New Shared Library**
- Created `scripts/lib/validate-gh-account.sh` with reusable `validate_gh_account()` function
- Supports multiple remote URL formats (SSH, HTTPS, custom SSH hosts)
- Returns appropriate exit codes for error handling

**Updated Workflow Scripts**
- Updated `scripts/take-issue.sh` to validate account before processing (Step 0)
- Updated `scripts/to-review.sh` to validate account before creating PR (Step 0)
- Both scripts source the shared library for consistency

**Documentation**
- Updated `scripts/README.md` with:
  - New "Shared Libraries" section documenting the validation library
  - Updated workflow steps to include account validation
  - Enhanced Requirements section with multi-account guidance

## Testing

**Successful validation (account matches):**
```bash
./scripts/to-review.sh
# ℹ️  Verifying GitHub account...
# ✅ GitHub account verified: @manuelnt11
```

**Failed validation (account mismatch):**
```bash
gh auth switch -u wrong-account
./scripts/to-review.sh
# ℹ️  Verifying GitHub account...
# ❌ GitHub account mismatch!
#
#   Repository owner: manuelnt11
#   Active account:   wrong-account
#
# To fix this, switch to the correct account:
#   gh auth switch -u manuelnt11
```

**Validation prevents permission errors:**
- Tested with mismatched account → script exits early with clear error
- Tested with correct account → workflow proceeds normally
- Tested with both `take-issue.sh` and `to-review.sh` scripts

## Notes

- The validation is non-intrusive and adds minimal overhead (< 100ms)
- Error messages provide actionable instructions for users
- The shared library pattern allows easy reuse in future scripts
- No changes to skill definitions required (transparent to Claude Code)