### PR TITLE
fix: upgrade to Cloud SQL Proxy v2 to resolve IAM authentication issues

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -150,16 +150,17 @@ jobs:
         run: |
           set -e  # Exit on any error
 
-          # Download Cloud SQL Proxy
-          echo "📥 Downloading Cloud SQL Proxy..."
-          wget -q https://dl.google.com/cloudsql/cloud_sql_proxy.linux.amd64 -O cloud_sql_proxy
+          # Download Cloud SQL Proxy v2
+          echo "📥 Downloading Cloud SQL Proxy v2..."
+          wget -q https://storage.googleapis.com/cloud-sql-connectors/cloud-sql-proxy/v2.14.2/cloud-sql-proxy.linux.amd64 -O cloud_sql_proxy
           chmod +x cloud_sql_proxy
 
-          # Start Cloud SQL Proxy with verbose logging
-          echo "🔌 Starting Cloud SQL Proxy..."
-          ./cloud_sql_proxy chamuco-app-mn:us-central1:chamuco-postgres \
-            --port=5433 \
-            --quiet &
+          # Start Cloud SQL Proxy v2
+          echo "🔌 Starting Cloud SQL Proxy v2..."
+          ./cloud_sql_proxy \
+            --port 5433 \
+            --quiet \
+            chamuco-app-mn:us-central1:chamuco-postgres &
           PROXY_PID=$!
 
           echo "⏳ Waiting for Cloud SQL Proxy to be ready (PID: $PROXY_PID)..."


### PR DESCRIPTION
## Problem

The CI/CD migration step (from PR #48) was failing with this error:

```
Error 403: The client is not authorized to make this request., notAuthorized
Error listing instances in chamuco-app-mn: googleapi: Error 403
no Cloud SQL Instances found in these projects: [chamuco-app-mn]
```

**Root Cause:**
Cloud SQL Proxy **v1** attempts to list all Cloud SQL instances in the project before connecting. This requires IAM permissions beyond `roles/cloudsql.client` (specifically `cloudsql.instances.list`), which the `github-actions` service account does not have for security reasons.

---

## Solution

Upgrade to **Cloud SQL Proxy v2**, which:

- ✅ Does **not** require listing instances
- ✅ Works with just `roles/cloudsql.client` permission (already granted)
- ✅ Has improved performance and authentication flow
- ✅ Is the currently maintained version (v1 is deprecated since 2024)

---

## Changes

### Download URL
```diff
- wget -q https://dl.google.com/cloudsql/cloud_sql_proxy.linux.amd64
+ wget -q https://storage.googleapis.com/cloud-sql-connectors/cloud-sql-proxy/v2.14.2/cloud-sql-proxy.linux.amd64
```

### Command Syntax
```diff
- ./cloud_sql_proxy chamuco-app-mn:us-central1:chamuco-postgres \
-   --port=5433 \
-   --quiet &

+ ./cloud_sql_proxy \
+   --port 5433 \
+   --quiet \
+   chamuco-app-mn:us-central1:chamuco-postgres &
```

**Key differences in v2:**
- `--port` flag uses space instead of `=`
- Instance connection name moved to the end (positional argument)

---

## Testing

This will be validated in the CI/CD pipeline when this PR is merged:

1. ✅ Cloud SQL Proxy v2 downloads successfully
2. ✅ Proxy connects without requiring instance list permissions
3. ✅ IAM authentication works with `github-actions@chamuco-app-mn.iam`
4. ✅ Database migrations execute successfully
5. ✅ API deploys to Cloud Run

---

## IAM Permissions Status

| Service Account | Role | Status |
|----------------|------|--------|
| `github-actions@chamuco-app-mn.iam` | `roles/cloudsql.client` | ✅ Granted |
| `chamuco-api-sa@chamuco-app-mn.iam` | `roles/cloudsql.client` | ✅ Granted |

| Database User | Permissions | Status |
|--------------|-------------|--------|
| `github-actions@chamuco-app-mn.iam` | CONNECT, USAGE, SELECT, INSERT, UPDATE, DELETE | ✅ Granted |
| `chamuco-api-sa@chamuco-app-mn.iam` | CONNECT, USAGE, SELECT, INSERT, UPDATE, DELETE | ✅ Granted |

---

## Related

- Follows up on: PR #48 (Initial CI/CD migration improvements)
- Cloud SQL Proxy v2 migration guide: https://github.com/GoogleCloudPlatform/cloud-sql-proxy/blob/main/migration-guide.md
- Cloud SQL Proxy v2 releases: https://github.com/GoogleCloudPlatform/cloud-sql-proxy/releases

---

## Next Steps After Merge

Once this PR is merged, the CI/CD pipeline will:
1. Download Cloud SQL Proxy v2
2. Connect to Cloud SQL successfully
3. Run database migrations (which will create the first migration table)
4. Deploy the API to Cloud Run
5. API will be able to connect to the database using IAM authentication

🤖 Generated with [Claude Code](https://claude.com/claude-code)