### PR TITLE
fix: remove --private-ip flag from Cloud SQL Proxy

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -155,11 +155,10 @@ jobs:
           wget -q https://storage.googleapis.com/cloud-sql-connectors/cloud-sql-proxy/v2.14.2/cloud-sql-proxy.linux.amd64 -O cloud_sql_proxy
           chmod +x cloud_sql_proxy
 
-          # Start Cloud SQL Proxy v2 (using private IP)
-          echo "🔌 Starting Cloud SQL Proxy v2 (private IP)..."
+          # Start Cloud SQL Proxy v2 (connects via Cloud SQL API, no public IP needed)
+          echo "🔌 Starting Cloud SQL Proxy v2..."
           ./cloud_sql_proxy \
             --port 5433 \
-            --private-ip \
             --quiet \
             chamuco-app-mn:us-central1:chamuco-postgres &
           PROXY_PID=$!


### PR DESCRIPTION
## Problem

The migration step was still failing after adding `--private-ip` flag (PR #50):

```
dial tcp 10.34.0.3:3307: i/o timeout
```

**Root Cause:**
I misunderstood how Cloud SQL Proxy works. The `--private-ip` flag tells the proxy to connect **DIRECTLY** to the instance's private IP address, which GitHub Actions runners cannot reach (they're outside the GCP VPC).

---

## How Cloud SQL Proxy Actually Works

Cloud SQL Proxy does **NOT** connect directly to the database instance IP. Instead:

```
┌──────────────────┐
│ GitHub Runner    │
│ (Outside GCP)    │
└────────┬─────────┘
         │
         ▼
┌──────────────────────┐
│ Cloud SQL Proxy      │
│ (Local on runner)    │
└────────┬─────────────┘
         │ HTTPS
         ▼
┌──────────────────────────────┐
│ Cloud SQL API                │
│ (Public endpoint)            │
│ Handles IAM authentication   │
└────────┬─────────────────────┘
         │ Internal GCP network
         ▼
┌──────────────────────────────┐
│ Cloud SQL Backend            │
│ (Manages connections)        │
└────────┬─────────────────────┘
         │
         ▼
┌──────────────────────────────┐
│ chamuco-postgres             │
│ Private IP: 10.34.0.3        │
│ NO public IP needed! ✅      │
└──────────────────────────────┘
```

**Key Points:**
1. ✅ Proxy connects to **Cloud SQL API** via HTTPS (public internet)
2. ✅ API handles authentication and authorization (IAM)
3. ✅ API routes the connection internally to the instance
4. ✅ **No public IP is needed on the database instance**
5. ✅ Works from **anywhere** (GitHub Actions, local dev, anywhere with internet)

---

## When to Use `--private-ip` Flag

The `--private-ip` flag should **ONLY** be used when:

| Scenario | Use --private-ip? | Reason |
|----------|-------------------|--------|
| **GitHub Actions** (outside GCP) | ❌ NO | Runner cannot reach VPC private IPs |
| **Local development** (outside GCP) | ❌ NO | Your machine cannot reach VPC private IPs |
| **Cloud Run** (inside GCP, VPC connector) | ✅ YES | Lower latency via direct private connection |
| **GCE VM** (inside VPC) | ✅ YES | Direct private network access available |
| **Cloud Build** (inside GCP) | ✅ YES | Runs within GCP infrastructure |

---

## The Fix

Remove the `--private-ip` flag:

```diff
  # Start Cloud SQL Proxy v2
- echo "🔌 Starting Cloud SQL Proxy v2 (private IP)..."
+ echo "🔌 Starting Cloud SQL Proxy v2..."
  ./cloud_sql_proxy \
    --port 5433 \
-   --private-ip \
    --quiet \
    chamuco-app-mn:us-central1:chamuco-postgres &
```

Without the flag, the proxy:
- ✅ Connects via Cloud SQL API (accessible from anywhere)
- ✅ Works with instances that have NO public IP
- ✅ Maintains security through IAM authentication
- ✅ Works from GitHub Actions runners

---

## Testing

This will be validated in the CI/CD pipeline:

1. ✅ Cloud SQL Proxy v2 downloads successfully
2. ✅ Proxy connects via **Cloud SQL API** (no direct IP connection)
3. ✅ IAM authentication succeeds with `github-actions@chamuco-app-mn.iam`
4. ✅ Database migrations execute successfully
5. ✅ API deploys to Cloud Run

Expected log output:
```
🔌 Starting Cloud SQL Proxy v2...
⏳ Waiting for Cloud SQL Proxy to be ready (PID: xxxx)...
✅ Cloud SQL Proxy is ready on port 5433
🚀 Running database migrations...
✅ Migrations completed successfully
```

---

## Security Posture Unchanged

The database instance configuration remains secure:
- ✅ **No public IP** on the instance
- ✅ **Private IP only** (`10.34.0.3`)
- ✅ **IAM authentication** required for all connections
- ✅ **No exposure** to public internet

The proxy provides secure access via the Cloud SQL API without requiring a public IP.

---

## Related

- Corrects: PR #50 (which incorrectly added --private-ip)
- Follows up on: PR #49 (Cloud SQL Proxy v2 upgrade)
- Follows up on: PR #48 (Initial CI/CD migration improvements)
- Cloud SQL Proxy docs: https://cloud.google.com/sql/docs/postgres/connect-instance-auth-proxy
- Private IP configuration: https://cloud.google.com/sql/docs/postgres/configure-private-ip#proxy

---

## Apology

Sorry for the confusion on PR #50. I misunderstood how Cloud SQL Proxy works. This PR corrects that mistake with the proper understanding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)