### PR TITLE
chore: decouple CLAUDE.md and add GCP and GitHub project skills

### DIFF
--- a/.claude/commands/gcp.md
+++ b/.claude/commands/gcp.md
@@ -1,0 +1,155 @@
+# GCP — Chamuco App
+
+You are helping with Google Cloud Platform operations for the **Chamuco App** project. You already know the full infrastructure — do not ask the user to explain it.
+
+## Project reference (memorize this, never ask the user)
+
+| Key                     | Value                                                      |
+| ----------------------- | ---------------------------------------------------------- |
+| Project ID              | `chamuco-app-mn`                                           |
+| Region                  | `us-central1`                                              |
+| Cloud SQL instance      | `chamuco-postgres`                                         |
+| Cloud SQL connection    | `chamuco-app-mn:us-central1:chamuco-postgres`              |
+| Cloud SQL DB (prod)     | `chamuco_prod`                                             |
+| Cloud SQL private IP    | `10.34.0.3`                                                |
+| VPC connector           | `chamuco-vpc-connector`                                    |
+| API service (Cloud Run) | `chamuco-api`                                              |
+| Web service (Cloud Run) | `chamuco-web`                                              |
+| API service URL         | `https://chamuco-api-393715267650.us-central1.run.app`     |
+| Web service URL         | `https://chamuco-web-393715267650.us-central1.run.app`     |
+| Artifact Registry       | `us-central1-docker.pkg.dev/chamuco-app-mn/chamuco-images` |
+| API service account     | `chamuco-api-sa@chamuco-app-mn.iam.gserviceaccount.com`    |
+| Owner email             | `manuelnt11@gmail.com`                                     |
+
+## Authentication notes
+
+- The user authenticates locally via `gcloud auth application-default login`.
+- The API uses IAM auth (service account, no password).
+- Local → production DB access requires Cloud SQL Auth Proxy on port 5433.
+- Proxy command: `cloud-sql-proxy chamuco-app-mn:us-central1:chamuco-postgres --port=5433`
+
+## Common operations — use these exact commands
+
+### View logs
+
+```bash
+# API logs (last 100 lines)
+gcloud run services logs read chamuco-api --region=us-central1 --limit=100 --project=chamuco-app-mn
+
+# Web logs
+gcloud run services logs read chamuco-web --region=us-central1 --limit=100 --project=chamuco-app-mn
+```
+
+### Service status
+
+```bash
+# Service details
+gcloud run services describe chamuco-api --region=us-central1 --project=chamuco-app-mn
+gcloud run services describe chamuco-web --region=us-central1 --project=chamuco-app-mn
+
+# List revisions
+gcloud run revisions list --service=chamuco-api --region=us-central1 --project=chamuco-app-mn
+gcloud run revisions list --service=chamuco-web --region=us-central1 --project=chamuco-app-mn
+
+# Health check
+curl -sf https://chamuco-api-393715267650.us-central1.run.app/health
+```
+
+### Rollback
+
+```bash
+# Rollback API to a specific SHA image
+gcloud run deploy chamuco-api \
+  --image=us-central1-docker.pkg.dev/chamuco-app-mn/chamuco-images/api:<SHA> \
+  --region=us-central1 \
+  --project=chamuco-app-mn
+```
+
+### Cloud SQL
+
+```bash
+# Instance status
+gcloud sql instances describe chamuco-postgres --project=chamuco-app-mn
+
+# Recent operations
+gcloud sql operations list --instance=chamuco-postgres --limit=10 --project=chamuco-app-mn
+
+# Start proxy (background)
+cloud-sql-proxy chamuco-app-mn:us-central1:chamuco-postgres --port=5433 &
+
+# Stop proxy
+pkill cloud-sql-proxy
+
+# Manual backup
+gcloud sql backups create \
+  --instance=chamuco-postgres \
+  --description="Manual backup - $(date +%Y-%m-%d)" \
+  --project=chamuco-app-mn
+
+# List backups
+gcloud sql backups list --instance=chamuco-postgres --project=chamuco-app-mn
+```
+
+### Run migrations on production (via proxy)
+
+```bash
+cloud-sql-proxy chamuco-app-mn:us-central1:chamuco-postgres --port=5433 &
+DATABASE_URL=postgresql://manuelnt11@gmail.com@localhost:5433/chamuco_prod \
+  pnpm --filter api db:migrate
+pkill cloud-sql-proxy
+```
+
+### Open Drizzle Studio on production
+
+```bash
+cloud-sql-proxy chamuco-app-mn:us-central1:chamuco-postgres --port=5433 &
+DATABASE_URL=postgresql://manuelnt11@gmail.com@localhost:5433/chamuco_prod \
+  pnpm --filter api db:studio
+# pkill cloud-sql-proxy when done
+```
+
+### Secrets Manager
+
+```bash
+# List secrets
+gcloud secrets list --project=chamuco-app-mn
+
+# View a secret version
+gcloud secrets versions access latest --secret=DATABASE_URL --project=chamuco-app-mn
+
+# Add a new secret version
+echo -n "<value>" | gcloud secrets versions add <SECRET_NAME> --data-file=- --project=chamuco-app-mn
+
+# Create a new secret
+echo -n "<value>" | gcloud secrets create <SECRET_NAME> --data-file=- --project=chamuco-app-mn
+```
+
+### Artifact Registry — list images
+
+```bash
+gcloud artifacts docker images list \
+  us-central1-docker.pkg.dev/chamuco-app-mn/chamuco-images \
+  --include-tags \
+  --project=chamuco-app-mn
+```
+
+### Monitoring
+
+```bash
+# Check VPC connector status
+gcloud compute networks vpc-access connectors describe chamuco-vpc-connector \
+  --region=us-central1 \
+  --project=chamuco-app-mn
+```
+
+## How to respond
+
+The user will tell you what they want to do (e.g. "check API logs", "rollback to last deploy", "start the SQL proxy", "add a secret").
+
+- Pick the right command(s) from above.
+- If arguments are needed (like a SHA for rollback), ask only for what's missing.
+- After running a command, interpret the output and summarize the result clearly.
+- If an operation could affect production data or is irreversible, confirm with the user before running.
+- Never ask the user to explain what chamuco-api is, what the project ID is, or how Cloud Run works — you already know.
+
+$ARGUMENTS

--- a/.claude/commands/gh.md
+++ b/.claude/commands/gh.md
@@ -1,0 +1,195 @@
+# GitHub — Chamuco App
+
+You are helping with GitHub operations for the **Chamuco App** project. You already know the full project setup — do not ask the user to explain it.
+
+## Project reference (memorize this, never ask the user)
+
+| Key            | Value                                          |
+| -------------- | ---------------------------------------------- |
+| Repo           | `manuelnt11/chamuco-app`                       |
+| Default branch | `main`                                         |
+| GitHub user    | `manuelnt11`                                   |
+| Project board  | `#4` (owner: `manuelnt11`)                     |
+| Project URL    | https://github.com/users/manuelnt11/projects/4 |
+
+### Project board — field IDs
+
+| Field    | Options                                                                              |
+| -------- | ------------------------------------------------------------------------------------ |
+| Status   | `Backlog` · `In Progress` · `In Review` · `Done`                                     |
+| Area     | `Backend` · `Frontend` · `Infrastructure` · `Database` · `Documentation` · `Testing` |
+| Priority | `High` · `Medium` · `Low`                                                            |
+| Size     | `XS` · `S` · `M` · `L` · `XL`                                                        |
+
+### Labels
+
+`bug` · `documentation` · `duplicate` · `enhancement` · `good first issue` · `help wanted` · `invalid` · `question` · `wontfix` · `epic`
+
+### Epics
+
+Epics are issues with the `epic` label. Sub-issues are linked using GitHub's native parent-child relationship via GraphQL `addSubIssue` mutation.
+
+---
+
+## Workflow skills already available
+
+These dedicated skills handle the main dev workflow — prefer them over manual commands:
+
+- `/take-issue` — assign issue to self, create branch, move to In Progress
+- `/to-review` — create PR, move issue to In Review
+
+Use this `/gh` skill for everything else.
+
+---
+
+## Common operations
+
+### Issues
+
+```bash
+# List open issues
+gh issue list --repo manuelnt11/chamuco-app
+
+# List by area/priority label or status
+gh issue list --repo manuelnt11/chamuco-app --label "enhancement"
+
+# List epics
+gh issue list --repo manuelnt11/chamuco-app --label epic
+
+# View an issue
+gh issue view <NUMBER> --repo manuelnt11/chamuco-app
+
+# Create an issue
+gh issue create \
+  --repo manuelnt11/chamuco-app \
+  --title "<title>" \
+  --body "<body>" \
+  --label "<label>"
+
+# Create an epic
+gh issue create \
+  --repo manuelnt11/chamuco-app \
+  --title "Epic: <name>" \
+  --label epic \
+  --body "<description>"
+
+# Close an issue
+gh issue close <NUMBER> --repo manuelnt11/chamuco-app
+
+# Add a sub-issue to an epic (requires node IDs)
+gh api graphql -f query='
+  mutation {
+    addSubIssue(input: { issueId: "<PARENT_NODE_ID>", subIssueId: "<CHILD_NODE_ID>" }) {
+      issue { title }
+    }
+  }
+'
+
+# Get node ID for an issue
+gh issue view <NUMBER> --repo manuelnt11/chamuco-app --json id --jq '.id'
+```
+
+### Pull Requests
+
+```bash
+# List open PRs
+gh pr list --repo manuelnt11/chamuco-app
+
+# View a PR (including CI status)
+gh pr view <NUMBER> --repo manuelnt11/chamuco-app
+
+# Check PR checks/CI status
+gh pr checks <NUMBER> --repo manuelnt11/chamuco-app
+
+# Review a PR
+gh pr review <NUMBER> --approve --repo manuelnt11/chamuco-app
+gh pr review <NUMBER> --request-changes --body "<comment>" --repo manuelnt11/chamuco-app
+
+# Merge a PR
+gh pr merge <NUMBER> --squash --repo manuelnt11/chamuco-app
+```
+
+### Project board
+
+```bash
+# List all items on the board
+gh project item-list 4 --owner manuelnt11
+
+# Add an issue to the board
+gh project item-add 4 --owner manuelnt11 --url https://github.com/manuelnt11/chamuco-app/issues/<NUMBER>
+
+# Move an item to a different status
+# (requires item ID from item-list output)
+gh project item-edit \
+  --project-id <PROJECT_NODE_ID> \
+  --id <ITEM_ID> \
+  --field-id <STATUS_FIELD_ID> \
+  --single-select-option-id <OPTION_ID>
+```
+
+### CI/CD workflows
+
+```bash
+# List recent workflow runs
+gh run list --repo manuelnt11/chamuco-app
+
+# View a specific run
+gh run view <RUN_ID> --repo manuelnt11/chamuco-app
+
+# View run logs
+gh run view <RUN_ID> --log --repo manuelnt11/chamuco-app
+
+# Re-run failed jobs
+gh run rerun <RUN_ID> --failed --repo manuelnt11/chamuco-app
+
+# List workflow runs for a specific workflow
+gh run list --workflow=api.yml --repo manuelnt11/chamuco-app
+gh run list --workflow=web.yml --repo manuelnt11/chamuco-app
+```
+
+### Branches
+
+```bash
+# List branches
+gh api repos/manuelnt11/chamuco-app/branches --jq '.[].name'
+
+# Delete a remote branch
+gh api -X DELETE repos/manuelnt11/chamuco-app/git/refs/heads/<BRANCH>
+```
+
+### Releases & tags
+
+```bash
+# List releases
+gh release list --repo manuelnt11/chamuco-app
+
+# Create a release
+gh release create <TAG> \
+  --repo manuelnt11/chamuco-app \
+  --title "<title>" \
+  --notes "<notes>"
+```
+
+---
+
+## Conventions to follow when creating issues or PRs
+
+- **Issue title**: imperative verb, sentence case (e.g. `Add user registration endpoint`)
+- **Epic title**: `Epic: <feature name>` with label `epic`
+- **Branch name**: derived from issue number and title (e.g. `42-add-user-registration`)
+- **PR title**: matches the issue title or summarizes the change (≤70 chars)
+- **PR body**: `## Summary`, `## Test plan`, `🤖 Generated with Claude Code` footer
+- **Every issue on the board**: assign Status, Area, Priority, Size
+- **Epics**: no Size field — only sub-issues get sized
+
+---
+
+## How to respond
+
+The user will describe what they want to do. Pick the right command(s) from above, fill in the known values (repo, owner, project number), and only ask for what's truly missing (e.g. an issue number, a title).
+
+- For destructive actions (merge, close, delete branch), confirm before running.
+- After running, summarize the result clearly.
+- Never ask what the repo name is, what the project number is, or what the conventions are.
+
+$ARGUMENTS

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,11 @@
 
 This file provides essential context for working on Chamuco App. Read it in full before making any code or documentation changes. For detailed specs, refer to the files under `documentation/`.
 
+**Package-specific instructions** — read the relevant file when working inside a sub-package:
+
+- `apps/web/CLAUDE.md` — Next.js frontend: i18n namespaces, env variable sync, translation validation
+- `apps/api/CLAUDE.md` — NestJS backend: OpenAPI decorators, Drizzle migration generation
+
 ---
 
 ## What Is Chamuco App
@@ -22,112 +27,7 @@ The project is currently in the **design and documentation phase** — no source
 - **All documentation is in English**.
 - **No hardcoded user-facing strings on the frontend**. Every visible text must use `i18next` `t()` references. Enforced by `eslint-plugin-i18next` at lint and CI level. This is a hard requirement, not a guideline.
 
-### i18n Namespace Usage
-
-**Configuration:**
-
-- Location: `apps/web/src/lib/i18n/config.ts`
-- Default namespace: `common`
-- Available namespaces: `common`, `auth`, `trips`, `groups`, `profile`, `errors`
-- Translation files: `apps/web/src/locales/{en|es}.json`
-
-**Namespace Rules:**
-
-1. **When to use the default namespace (`common`):**
-   - Shared UI elements across the entire app (navigation, actions, status messages)
-   - Generic validation messages
-   - Time/date formatting
-   - Home page content
-   - Offline page content
-
-   ```tsx
-   // ✅ Correct - uses default 'common' namespace
-   const { t } = useTranslation();
-
-   <h1>{t('home.title')}</h1>              // resolves to common.home.title
-   <button>{t('actions.save')}</button>    // resolves to common.actions.save
-   <span>{t('navigation.trips')}</span>    // resolves to common.navigation.trips
-   ```
-
-2. **When to use specific namespaces:**
-   - Feature-specific pages should use their own namespace
-   - Each major section (trips, groups, profile, etc.) has its own namespace
-   - Auth flows use the `auth` namespace
-   - Error messages use the `errors` namespace
-
-   ```tsx
-   // ✅ Correct - trips page uses 'trips' namespace
-   const { t } = useTranslation('trips');
-
-   <h1>{t('title')}</h1>           // resolves to trips.title
-   <p>{t('myTrips')}</p>           // resolves to trips.myTrips
-   <span>{t('status.draft')}</span> // resolves to trips.status.draft
-   ```
-
-   ```tsx
-   // ✅ Correct - groups page uses 'groups' namespace
-   const { t } = useTranslation('groups');
-
-   <h1>{t('title')}</h1>      // resolves to groups.title
-   <p>{t('myGroups')}</p>     // resolves to groups.myGroups
-   ```
-
-3. **What NOT to do:**
-
-   ```tsx
-   // ❌ WRONG - using fully qualified keys when a namespace is available
-   const { t } = useTranslation();
-   <h1>{t('trips.title')}</h1>  // This will look in common.trips.title (doesn't exist!)
-
-   // ❌ WRONG - using fully qualified keys with specific namespace
-   const { t } = useTranslation('trips');
-   <h1>{t('trips.title')}</h1>  // This will look in trips.trips.title (doesn't exist!)
-
-   // ❌ WRONG - hardcoded strings
-   <h1>Trips</h1>  // Fails eslint-plugin-i18next check
-   ```
-
-4. **Cross-namespace references:**
-
-   If you need to reference keys from a different namespace within a component:
-
-   ```tsx
-   // ✅ Correct - access multiple namespaces
-   const { t } = useTranslation(['trips', 'common']);
-
-   <h1>{t('title')}</h1>                    // from trips namespace
-   <button>{t('common:actions.save')}</button>  // explicitly from common namespace
-   ```
-
-5. **Validation:**
-
-   Always run the i18n validation script after modifying translation keys:
-
-   ```bash
-   ./scripts/validate-i18n-keys.sh
-   ```
-
-   The script automatically detects the namespace from `useTranslation('namespace')` calls and validates that all keys exist in the corresponding JSON files.
-
-**File Organization Pattern:**
-
-```
-apps/web/src/
-├── app/
-│   ├── trips/page.tsx        → useTranslation('trips')
-│   ├── groups/page.tsx       → useTranslation('groups')
-│   ├── profile/page.tsx      → useTranslation('profile')
-│   └── page.tsx              → useTranslation() = 'common'
-├── components/
-│   ├── navigation/           → useTranslation() = 'common'
-│   ├── header/               → useTranslation() = 'common'
-│   └── layout/               → useTranslation() = 'common'
-└── locales/
-    ├── en.json               → { common: {...}, trips: {...}, groups: {...}, ... }
-    └── es.json               → { common: {...}, trips: {...}, groups: {...}, ... }
-```
-
-**Key takeaway:** Match the `useTranslation()` namespace to the feature you're working in, and use keys relative to that namespace. The validation script enforces this convention.
+> i18n namespace conventions, translation file structure, and the validation script are documented in `apps/web/CLAUDE.md`.
 
 ---
 
@@ -353,23 +253,7 @@ import { UsersService } from '../../users/users.service';
 
 See `documentation/architecture/monorepo-structure.md` — "Import Aliases" section for the full spec.
 
-### 3. OpenAPI documentation on every backend change
-
-Every NestJS controller endpoint must be fully documented with `@nestjs/swagger` decorators. When any of the following are modified:
-
-- A controller method (new endpoint, changed path, changed HTTP method)
-- A request DTO or response DTO
-- An enum used in a request or response
-
-Then verify and update:
-
-- `@ApiTags`, `@ApiOperation`, `@ApiResponse` on the controller
-- `@ApiProperty` on all DTO fields (type, description, example, required/optional)
-- `@ApiBearerAuth()` if the endpoint requires authentication
-
-No endpoint may be left without a summary (`@ApiOperation`), at least one `@ApiResponse`, and fully annotated DTO fields.
-
-### 4. Pre-commit quality gates are non-negotiable
+### 3. Pre-commit quality gates are non-negotiable
 
 Every commit must pass all five gates enforced by the Husky pre-commit hook:
 
@@ -393,17 +277,7 @@ When writing new code:
 - New tests must be added in the same commit as the code they cover — never defer test writing to a later commit.
 - Coverage thresholds are configured in `apps/api/jest.config.ts` (backend) and `apps/web/vitest.config.ts` (frontend).
 
-### 5. Migration file on every schema change
-
-When any Drizzle schema file (`*.schema.ts`) is modified — new table, new column, renamed column, dropped column, new index, constraint change — a migration file must be generated:
-
-```bash
-pnpm --filter db drizzle-kit generate
-```
-
-The generated `.sql` file must be committed alongside the schema change in the same PR. No schema change may be merged without its corresponding migration file. Destructive operations (column drops, renames) require a multi-step migration strategy — document the steps in the PR description.
-
-### 6. Truncate test and lint output to conserve context
+### 4. Truncate test and lint output to conserve context
 
 When running tests or linters via the Bash tool, always pipe the output through `tail` to display only the **last 50–100 lines**. As the codebase grows, full test suite output can consume thousands of lines, but only the final summary and any errors are actionable.
 
@@ -440,7 +314,7 @@ pnpm --filter api lint:check
 
 The final lines contain the test summary (passed/failed counts, coverage percentages) and any error messages or stack traces. Earlier output (individual test progress, file processing) is usually noise. If an error is truncated, the user will ask for the full output explicitly.
 
-### 7. Strict TypeScript typing — avoid `any` and `unknown`
+### 5. Strict TypeScript typing — avoid `any` and `unknown`
 
 TypeScript's type system is a critical safety net. **Never use `any` or `unknown` unless absolutely necessary.** These types bypass type checking and should be treated as code smells.
 
@@ -516,64 +390,12 @@ TypeScript's type system is a critical safety net. **Never use `any` or `unknown
 - If a better-typed alternative exists, request changes.
 - Temporary workarounds with `@ts-expect-error` should reference a tracking issue or version number.
 
-### 8. Frontend environment variables — three files must always stay in sync
+### Package-specific standing rules
 
-All frontend environment variables are validated at startup by `apps/web/src/config/env.ts`. Adding a new `NEXT_PUBLIC_` variable requires updating **three files together** — missing any one of them will cause either a runtime crash or a failing test:
+Additional standing rules that apply only within a specific package are kept close to the code they govern:
 
-| File                                   | What to do                                                                                                                                       |
-| -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `apps/web/src/config/env.constants.ts` | Add the key to the `REQUIRED_VARS` tuple                                                                                                         |
-| `apps/web/src/config/env.ts`           | Add `KEY: process.env.KEY` to the `raw` object (literal access is required — Next.js does not replace `process.env[variable]` in client bundles) |
-| `apps/web/src/config/env.test.ts`      | Add the key to `setAllEnv()` and `clearAllEnv()`, and update the `toEqual` assertion in "returns all env vars when all are set"                  |
-
-Also update `.env.example` with the new key (empty value) so other developers know to set it.
-
-**Current required variables:**
-
-| Variable                                   | Purpose                                                    |
-| ------------------------------------------ | ---------------------------------------------------------- |
-| `NEXT_PUBLIC_FIREBASE_API_KEY`             | Firebase client SDK                                        |
-| `NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN`         | Firebase client SDK                                        |
-| `NEXT_PUBLIC_FIREBASE_PROJECT_ID`          | Firebase client SDK                                        |
-| `NEXT_PUBLIC_FIREBASE_APP_ID`              | Firebase client SDK                                        |
-| `NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID` | Firebase client SDK                                        |
-| `NEXT_PUBLIC_API_URL`                      | NestJS API base URL (e.g. `http://localhost:3001` locally) |
-
-### 9. Validate i18n keys when modifying translations
-
-When any of the following changes are made to the frontend codebase:
-
-- Adding or modifying `t('key')` calls in components
-- Adding, removing, or modifying keys in translation files (`locales/en.json`, `locales/es.json`)
-- Refactoring components that use i18n
-
-**You must run the i18n validation script:**
-
-```bash
-./scripts/validate-i18n-keys.sh
-```
-
-**The script validates:**
-
-1. **Missing keys** — Keys used in code (`t('key')`) but not defined in `en.json`
-2. **Translation parity** — Keys in `en.json` that don't exist in `es.json`
-3. **Unused keys** — Keys defined in translation files but not referenced in code (informational only)
-
-**Key conventions:**
-
-- The default namespace is `common` (configured in `apps/web/src/lib/i18n/config.ts`)
-- When using `t('home.title')`, it resolves to `common.home.title` in the JSON
-- For other namespaces, use explicit prefixes: `t('auth.signIn')`, `t('trips.title')`, `t('groups.members')`
-- Never use hardcoded strings in user-facing components — use i18n keys instead
-- Brand name "Chamuco" and proper nouns can have `eslint-disable-next-line i18next/no-literal-string` comments
-
-**Fix workflow:**
-
-- If keys are missing in `en.json`, add them to the appropriate namespace
-- If keys are missing in `es.json`, translate and add them (maintain parity with `en.json`)
-- If many unused keys are reported, it's informational — no action required unless keys are confirmed obsolete
-
-**The script exits with code 1 if any keys are missing**, blocking commits via pre-commit hooks if integrated. All i18n keys must be valid before merging.
+- `apps/api/CLAUDE.md` — OpenAPI decorator requirements, Drizzle migration file generation
+- `apps/web/CLAUDE.md` — Frontend env variable sync, i18n key validation
 
 ---
 

--- a/apps/api/CLAUDE.md
+++ b/apps/api/CLAUDE.md
@@ -1,0 +1,33 @@
+# Chamuco API — AI Assistant Instructions
+
+This file extends the root `CLAUDE.md` with rules specific to the `apps/api` NestJS package. Read the root `CLAUDE.md` first.
+
+---
+
+## Standing Rules
+
+### 1. OpenAPI documentation on every backend change
+
+Every NestJS controller endpoint must be fully documented with `@nestjs/swagger` decorators. When any of the following are modified:
+
+- A controller method (new endpoint, changed path, changed HTTP method)
+- A request DTO or response DTO
+- An enum used in a request or response
+
+Then verify and update:
+
+- `@ApiTags`, `@ApiOperation`, `@ApiResponse` on the controller
+- `@ApiProperty` on all DTO fields (type, description, example, required/optional)
+- `@ApiBearerAuth()` if the endpoint requires authentication
+
+No endpoint may be left without a summary (`@ApiOperation`), at least one `@ApiResponse`, and fully annotated DTO fields.
+
+### 2. Migration file on every schema change
+
+When any Drizzle schema file (`*.schema.ts`) is modified — new table, new column, renamed column, dropped column, new index, constraint change — a migration file must be generated:
+
+```bash
+pnpm --filter db drizzle-kit generate
+```
+
+The generated `.sql` file must be committed alongside the schema change in the same PR. No schema change may be merged without its corresponding migration file. Destructive operations (column drops, renames) require a multi-step migration strategy — document the steps in the PR description.

--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -1,0 +1,179 @@
+# Chamuco Web — AI Assistant Instructions
+
+This file extends the root `CLAUDE.md` with rules specific to the `apps/web` Next.js package. Read the root `CLAUDE.md` first.
+
+---
+
+## Language Rules — i18n
+
+**No hardcoded user-facing strings.** Every visible text must use `i18next` `t()` references. Enforced by `eslint-plugin-i18next` at lint and CI level. This is a hard requirement, not a guideline.
+
+### i18n Namespace Usage
+
+**Configuration:**
+
+- Location: `apps/web/src/lib/i18n/config.ts`
+- Default namespace: `common`
+- Available namespaces: `common`, `auth`, `trips`, `groups`, `profile`, `errors`
+- Translation files: `apps/web/src/locales/{en|es}.json`
+
+**Namespace Rules:**
+
+1. **When to use the default namespace (`common`):**
+   - Shared UI elements across the entire app (navigation, actions, status messages)
+   - Generic validation messages
+   - Time/date formatting
+   - Home page content
+   - Offline page content
+
+   ```tsx
+   // ✅ Correct - uses default 'common' namespace
+   const { t } = useTranslation();
+
+   <h1>{t('home.title')}</h1>              // resolves to common.home.title
+   <button>{t('actions.save')}</button>    // resolves to common.actions.save
+   <span>{t('navigation.trips')}</span>    // resolves to common.navigation.trips
+   ```
+
+2. **When to use specific namespaces:**
+   - Feature-specific pages should use their own namespace
+   - Each major section (trips, groups, profile, etc.) has its own namespace
+   - Auth flows use the `auth` namespace
+   - Error messages use the `errors` namespace
+
+   ```tsx
+   // ✅ Correct - trips page uses 'trips' namespace
+   const { t } = useTranslation('trips');
+
+   <h1>{t('title')}</h1>           // resolves to trips.title
+   <p>{t('myTrips')}</p>           // resolves to trips.myTrips
+   <span>{t('status.draft')}</span> // resolves to trips.status.draft
+   ```
+
+   ```tsx
+   // ✅ Correct - groups page uses 'groups' namespace
+   const { t } = useTranslation('groups');
+
+   <h1>{t('title')}</h1>      // resolves to groups.title
+   <p>{t('myGroups')}</p>     // resolves to groups.myGroups
+   ```
+
+3. **What NOT to do:**
+
+   ```tsx
+   // ❌ WRONG - using fully qualified keys when a namespace is available
+   const { t } = useTranslation();
+   <h1>{t('trips.title')}</h1>  // This will look in common.trips.title (doesn't exist!)
+
+   // ❌ WRONG - using fully qualified keys with specific namespace
+   const { t } = useTranslation('trips');
+   <h1>{t('trips.title')}</h1>  // This will look in trips.trips.title (doesn't exist!)
+
+   // ❌ WRONG - hardcoded strings
+   <h1>Trips</h1>  // Fails eslint-plugin-i18next check
+   ```
+
+4. **Cross-namespace references:**
+
+   If you need to reference keys from a different namespace within a component:
+
+   ```tsx
+   // ✅ Correct - access multiple namespaces
+   const { t } = useTranslation(['trips', 'common']);
+
+   <h1>{t('title')}</h1>                    // from trips namespace
+   <button>{t('common:actions.save')}</button>  // explicitly from common namespace
+   ```
+
+5. **Validation:**
+
+   Always run the i18n validation script after modifying translation keys:
+
+   ```bash
+   ./scripts/validate-i18n-keys.sh
+   ```
+
+   The script automatically detects the namespace from `useTranslation('namespace')` calls and validates that all keys exist in the corresponding JSON files.
+
+**File Organization Pattern:**
+
+```
+apps/web/src/
+├── app/
+│   ├── trips/page.tsx        → useTranslation('trips')
+│   ├── groups/page.tsx       → useTranslation('groups')
+│   ├── profile/page.tsx      → useTranslation('profile')
+│   └── page.tsx              → useTranslation() = 'common'
+├── components/
+│   ├── navigation/           → useTranslation() = 'common'
+│   ├── header/               → useTranslation() = 'common'
+│   └── layout/               → useTranslation() = 'common'
+└── locales/
+    ├── en.json               → { common: {...}, trips: {...}, groups: {...}, ... }
+    └── es.json               → { common: {...}, trips: {...}, groups: {...}, ... }
+```
+
+**Key takeaway:** Match the `useTranslation()` namespace to the feature you're working in, and use keys relative to that namespace. The validation script enforces this convention.
+
+---
+
+## Standing Rules
+
+### 1. Frontend environment variables — three files must always stay in sync
+
+All frontend environment variables are validated at startup by `apps/web/src/config/env.ts`. Adding a new `NEXT_PUBLIC_` variable requires updating **three files together** — missing any one of them will cause either a runtime crash or a failing test:
+
+| File                                   | What to do                                                                                                                                       |
+| -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `apps/web/src/config/env.constants.ts` | Add the key to the `REQUIRED_VARS` tuple                                                                                                         |
+| `apps/web/src/config/env.ts`           | Add `KEY: process.env.KEY` to the `raw` object (literal access is required — Next.js does not replace `process.env[variable]` in client bundles) |
+| `apps/web/src/config/env.test.ts`      | Add the key to `setAllEnv()` and `clearAllEnv()`, and update the `toEqual` assertion in "returns all env vars when all are set"                  |
+
+Also update `.env.example` with the new key (empty value) so other developers know to set it.
+
+**Current required variables:**
+
+| Variable                                   | Purpose                                                    |
+| ------------------------------------------ | ---------------------------------------------------------- |
+| `NEXT_PUBLIC_FIREBASE_API_KEY`             | Firebase client SDK                                        |
+| `NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN`         | Firebase client SDK                                        |
+| `NEXT_PUBLIC_FIREBASE_PROJECT_ID`          | Firebase client SDK                                        |
+| `NEXT_PUBLIC_FIREBASE_APP_ID`              | Firebase client SDK                                        |
+| `NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID` | Firebase client SDK                                        |
+| `NEXT_PUBLIC_API_URL`                      | NestJS API base URL (e.g. `http://localhost:3001` locally) |
+
+### 2. Validate i18n keys when modifying translations
+
+When any of the following changes are made to the frontend codebase:
+
+- Adding or modifying `t('key')` calls in components
+- Adding, removing, or modifying keys in translation files (`locales/en.json`, `locales/es.json`)
+- Refactoring components that use i18n
+
+**You must run the i18n validation script:**
+
+```bash
+./scripts/validate-i18n-keys.sh
+```
+
+**The script validates:**
+
+1. **Missing keys** — Keys used in code (`t('key')`) but not defined in `en.json`
+2. **Translation parity** — Keys in `en.json` that don't exist in `es.json`
+3. **Unused keys** — Keys defined in translation files but not referenced in code (informational only)
+
+**Key conventions:**
+
+- The default namespace is `common` (configured in `apps/web/src/lib/i18n/config.ts`)
+- When using `t('home.title')`, it resolves to `common.home.title` in the JSON
+- For other namespaces, use explicit prefixes: `t('auth.signIn')`, `t('trips.title')`, `t('groups.members')`
+- Never use hardcoded strings in user-facing components — use i18n keys instead
+- Brand name "Chamuco" and proper nouns can have `eslint-disable-next-line i18next/no-literal-string` comments
+
+**Fix workflow:**
+
+- If keys are missing in `en.json`, add them to the appropriate namespace
+- If keys are missing in `es.json`, translate and add them (maintain parity with `en.json`)
+- If many unused keys are reported, it's informational — no action required unless keys are confirmed obsolete
+
+**The script exits with code 1 if any keys are missing**, blocking commits via pre-commit hooks if integrated. All i18n keys must be valid before merging.

--- a/documentation/features/users.md
+++ b/documentation/features/users.md
@@ -63,18 +63,30 @@ A 1:1 extension of the `users` table that holds display and UX preferences. Crea
 
 Extended personal data for the person behind the account. This is a 1:1 extension of the `users` table, kept separate to avoid bloating the core auth record.
 
-| Field           | Type              | Description                                                                                                                                                                                      |
-| --------------- | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `user_id`       | UUID              | FK → `users.id`                                                                                                                                                                                  |
-| `first_name`    | String            | Legal first name (as on travel document).                                                                                                                                                        |
-| `last_name`     | String            | Legal last name.                                                                                                                                                                                 |
-| `date_of_birth` | JSONB             | `{ day, month, year, year_visible }`. See format below.                                                                                                                                          |
-| `birth_country` | String (nullable) | ISO 3166-1 alpha-2. Country of birth.                                                                                                                                                            |
-| `birth_city`    | String (nullable) | City of birth.                                                                                                                                                                                   |
-| `home_country`  | String            | ISO 3166-1 alpha-2. Country of current residence. May differ from any declared nationality.                                                                                                      |
-| `home_city`     | String (nullable) | City of current residence. Used as the origin point for LP distance calculations (see [`features/gamification.md`](./gamification.md)). Falls back to the centroid of `home_country` if not set. |
-| `phone_number`  | String            | Mobile number in international format (e.g., `+573001234567`).                                                                                                                                   |
-| `bio`           | Text (nullable)   | Short public bio shown on the user's public profile.                                                                                                                                             |
+In addition to personal fields, `user_profiles` consolidates all data that is always fetched per-user, never queried cross-user, and has no external FK dependencies: health data, emergency contacts, and loyalty programs. These are stored as JSONB columns instead of separate tables. See each section below for the JSONB structure and enum definitions.
+
+| Field                   | Type                     | Description                                                                                                                                                                                      |
+| ----------------------- | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `user_id`               | UUID                     | PK + FK → `users.id`                                                                                                                                                                             |
+| `first_name`            | String                   | Legal first name (as on travel document).                                                                                                                                                        |
+| `last_name`             | String                   | Legal last name.                                                                                                                                                                                 |
+| `date_of_birth`         | JSONB                    | `{ day, month, year, year_visible }`. See format below.                                                                                                                                          |
+| `birth_country`         | char(2) (nullable)       | ISO 3166-1 alpha-2. Country of birth.                                                                                                                                                            |
+| `birth_city`            | String (nullable)        | City of birth.                                                                                                                                                                                   |
+| `home_country`          | char(2)                  | ISO 3166-1 alpha-2. Country of current residence. May differ from any declared nationality.                                                                                                      |
+| `home_city`             | String (nullable)        | City of current residence. Used as the origin point for LP distance calculations (see [`features/gamification.md`](./gamification.md)). Falls back to the centroid of `home_country` if not set. |
+| `phone_number`          | String                   | Mobile number in international format (e.g., `+573001234567`).                                                                                                                                   |
+| `bio`                   | Text (nullable)          | Short public bio shown on the user's public profile.                                                                                                                                             |
+| `dietary_preference`    | Enum `DietaryPreference` | Declared baseline diet. Default: `OMNIVORE`.                                                                                                                                                     |
+| `dietary_notes`         | Text (nullable)          | Additional dietary context (e.g., "no pork for religious reasons", "keto").                                                                                                                      |
+| `general_medical_notes` | Text (nullable)          | Free text for any other medical context the user chooses to share that does not fit the structured categories. Opt-in sharing per trip — see Visibility below.                                   |
+| `food_allergies`        | JSONB                    | Array of `{ allergen: FoodAllergen, description: string \| null }`. Default: `[]`.                                                                                                               |
+| `phobias`               | JSONB                    | Array of `{ phobia: PhobiaType, description: string \| null }`. Default: `[]`.                                                                                                                   |
+| `physical_limitations`  | JSONB                    | Array of `{ limitation: PhysicalLimitationType, description: string \| null }`. Default: `[]`.                                                                                                   |
+| `medical_conditions`    | JSONB                    | Array of `{ condition: MedicalConditionType, description: string \| null }`. Default: `[]`.                                                                                                      |
+| `emergency_contacts`    | JSONB                    | Array of emergency contact objects. See [Emergency Contacts](#emergency-contacts) below. Default: `[]`.                                                                                          |
+| `loyalty_programs`      | JSONB                    | Array of loyalty program objects. See [Loyalty Programs](#loyalty-programs) below. Default: `[]`.                                                                                                |
+| `updated_at`            | Timestamp                |                                                                                                                                                                                                  |
 
 ### Date of Birth Format
 
@@ -117,7 +129,7 @@ CONSTRAINT passport_data_consistency CHECK (
 | ---------------------- | --------------------- | -------------------------------------------------------------------------------------------------------- |
 | `id`                   | UUID                  |                                                                                                          |
 | `user_id`              | UUID                  | FK → `users.id`                                                                                          |
-| `country_code`         | String                | ISO 3166-1 alpha-2 (e.g., `CO`, `ES`). Unique per user.                                                  |
+| `country_code`         | char(2)               | ISO 3166-1 alpha-2 (e.g., `CO`, `ES`). Unique per user.                                                  |
 | `is_primary`           | Boolean               | The nationality/passport to use as default for international trips. Exactly one per user must be `true`. |
 | `national_id_number`   | String (nullable)     | National ID / Cédula / DNI / SSN for this citizenship.                                                   |
 | `passport_number`      | String (nullable)     | Passport document number.                                                                                |
@@ -171,49 +183,52 @@ The NestJS job iterates the returned rows and queues an FCM notification for eac
 
 ---
 
-## Emergency Contacts (`user_emergency_contacts`)
+## Emergency Contacts
 
 A user must have **at least one emergency contact**. Multiple contacts are supported.
 
-| Field          | Type    | Description                                                                                   |
-| -------------- | ------- | --------------------------------------------------------------------------------------------- |
-| `id`           | UUID    |                                                                                               |
-| `user_id`      | UUID    | FK → `users.id`                                                                               |
-| `full_name`    | String  |                                                                                               |
-| `phone_number` | String  | International format.                                                                         |
-| `relationship` | String  | Free text (e.g., "mother", "spouse", "best friend").                                          |
-| `is_primary`   | Boolean | Marks the contact to show first in emergency situations. Exactly one per user must be `true`. |
+Emergency contacts are stored as a JSONB array in `user_profiles.emergency_contacts`. This data is always fetched per-user, is never queried cross-user, and has no FK dependencies — a JSONB column avoids the overhead of a separate table.
+
+**JSONB element shape:**
+
+```typescript
+{
+  id: string; // client-generated UUID, used to target individual items in PATCH operations
+  full_name: string;
+  phone_number: string; // international format (e.g., +573001234567)
+  relationship: string; // free text (e.g., "mother", "spouse", "best friend")
+  is_primary: boolean; // exactly one element must be true
+}
+```
 
 **Rule:** A user with zero emergency contacts cannot be marked as a confirmed participant on international trips (enforced by the pre-trip checklist, not as a hard DB constraint).
 
 ---
 
-## Loyalty Programs (`user_loyalty_programs`)
+## Loyalty Programs
 
 Reference data only — loyalty program IDs are stored on the user profile as a convenience for manual entry when making reservations. They are **not linked to reservation records** in the system.
 
-| Field          | Type              | Description                                                                   |
-| -------------- | ----------------- | ----------------------------------------------------------------------------- |
-| `id`           | UUID              |                                                                               |
-| `user_id`      | UUID              | FK → `users.id`                                                               |
-| `program_name` | String            | Name of the program (e.g., "LifeMiles", "Delta SkyMiles", "Marriott Bonvoy"). |
-| `member_id`    | String            | The membership / account number in that program.                              |
-| `notes`        | String (nullable) | Tier level, expiry, or other notes.                                           |
+Stored as a JSONB array in `user_profiles.loyalty_programs`. Visible only to the user themselves — never exposed to organizers or other participants.
+
+**JSONB element shape:**
+
+```typescript
+{
+  id: string; // client-generated UUID, used to target individual items in PATCH operations
+  program_name: string; // e.g., "LifeMiles", "Delta SkyMiles", "Marriott Bonvoy"
+  member_id: string; // membership / account number
+  notes: string | null; // tier level, expiry, or other notes
+}
+```
 
 ---
 
-## Health Profile (`user_health_profiles`)
+## Health Profile
 
 Health and dietary data used by organizers to plan meals, activities, and manage emergency situations. Each category uses a **structured selection list** so organizers can filter and search effectively. Every category includes an `OTHER` option with a required `description` field for cases not covered by the standard list.
 
-### `user_health_profiles` (1:1 — dietary baseline)
-
-| Field                   | Type                     | Description                                                                                                                                                    |
-| ----------------------- | ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `user_id`               | UUID                     | PK + FK → `users.id`                                                                                                                                           |
-| `dietary_preference`    | Enum `DietaryPreference` | Declared baseline diet.                                                                                                                                        |
-| `dietary_notes`         | Text (nullable)          | Additional dietary context (e.g., "no pork for religious reasons", "keto").                                                                                    |
-| `general_medical_notes` | Text (nullable)          | Free text for any other medical context the user chooses to share that does not fit the structured categories. Opt-in sharing per trip — see Visibility below. |
+All health data is stored directly on `user_profiles` (see table above). Scalar fields (`dietary_preference`, `dietary_notes`, `general_medical_notes`) are typed columns. The four multi-value categories (food allergies, phobias, physical limitations, medical conditions) are JSONB arrays — each element has the shape `{ <field>: <enum>, description: string | null }`, where `description` is required when the enum value is `OTHER`.
 
 ### Dietary Preference (enum: `DietaryPreference`)
 
@@ -228,16 +243,9 @@ Health and dietary data used by organizers to plan meals, activities, and manage
 
 ---
 
-### Food Allergies (`user_food_allergies`)
+### Food Allergies (enum: `FoodAllergen`)
 
-| Field         | Type                | Description                                                           |
-| ------------- | ------------------- | --------------------------------------------------------------------- |
-| `id`          | UUID                |                                                                       |
-| `user_id`     | UUID                | FK → `users.id`                                                       |
-| `allergen`    | Enum `FoodAllergen` | Selected allergen from the standard list.                             |
-| `description` | Text (nullable)     | Additional detail or severity note. Required when `allergen = OTHER`. |
-
-### Food Allergens (enum: `FoodAllergen`)
+Stored in `user_profiles.food_allergies` as `{ allergen: FoodAllergen, description: string | null }[]`. `description` is required when `allergen = OTHER`.
 
 Covers the most common internationally recognized allergens.
 
@@ -261,16 +269,9 @@ Covers the most common internationally recognized allergens.
 
 ---
 
-### Phobias (`user_phobias`)
+### Phobias (enum: `PhobiaType`)
 
-| Field         | Type              | Description                                         |
-| ------------- | ----------------- | --------------------------------------------------- |
-| `id`          | UUID              |                                                     |
-| `user_id`     | UUID              | FK → `users.id`                                     |
-| `phobia`      | Enum `PhobiaType` | Selected phobia from the standard list.             |
-| `description` | Text (nullable)   | Additional context. Required when `phobia = OTHER`. |
-
-### Phobia Types (enum: `PhobiaType`)
+Stored in `user_profiles.phobias` as `{ phobia: PhobiaType, description: string | null }[]`. `description` is required when `phobia = OTHER`.
 
 Travel-relevant phobias and strong aversions.
 
@@ -292,16 +293,9 @@ Travel-relevant phobias and strong aversions.
 
 ---
 
-### Physical Limitations (`user_physical_limitations`)
+### Physical Limitations (enum: `PhysicalLimitationType`)
 
-| Field         | Type                          | Description                                                                                     |
-| ------------- | ----------------------------- | ----------------------------------------------------------------------------------------------- |
-| `id`          | UUID                          |                                                                                                 |
-| `user_id`     | UUID                          | FK → `users.id`                                                                                 |
-| `limitation`  | Enum `PhysicalLimitationType` | Selected limitation from the standard list.                                                     |
-| `description` | Text (nullable)               | Specifics (e.g., "can walk max 2 km", "uses hearing aids"). Required when `limitation = OTHER`. |
-
-### Physical Limitation Types (enum: `PhysicalLimitationType`)
+Stored in `user_profiles.physical_limitations` as `{ limitation: PhysicalLimitationType, description: string | null }[]`. `description` is required when `limitation = OTHER`.
 
 | Value                   | Description                                                    |
 | ----------------------- | -------------------------------------------------------------- |
@@ -321,18 +315,9 @@ Travel-relevant phobias and strong aversions.
 
 ---
 
-### Medical Conditions (`user_medical_conditions`)
+### Medical Conditions (enum: `MedicalConditionType`)
 
-Conditions relevant to emergency response or trip planning.
-
-| Field         | Type                        | Description                                                                                 |
-| ------------- | --------------------------- | ------------------------------------------------------------------------------------------- |
-| `id`          | UUID                        |                                                                                             |
-| `user_id`     | UUID                        | FK → `users.id`                                                                             |
-| `condition`   | Enum `MedicalConditionType` | Selected condition from the standard list.                                                  |
-| `description` | Text (nullable)             | Specifics (e.g., "carries EpiPen", "insulin-dependent"). Required when `condition = OTHER`. |
-
-### Medical Condition Types (enum: `MedicalConditionType`)
+Conditions relevant to emergency response or trip planning. Stored in `user_profiles.medical_conditions` as `{ condition: MedicalConditionType, description: string | null }[]`. `description` is required when `condition = OTHER`.
 
 | Value                     | Description                                                            |
 | ------------------------- | ---------------------------------------------------------------------- |

--- a/documentation/overview/mvp.md
+++ b/documentation/overview/mvp.md
@@ -35,11 +35,8 @@ Full implementation of the authentication layer as designed.
 Full implementation of the user profile module as designed.
 
 - Core user record (`users`): username, display name, avatar, auth provider, timezone
-- Personal profile (`user_profiles`): legal name, date of birth (JSONB with year visibility flag), birth country and city, home country and city, phone, bio
+- Personal profile (`user_profiles`): legal name, date of birth (JSONB with year visibility flag), birth/home country (char(2)) and city, phone, bio; plus health data (dietary preference, food allergies, phobias, physical limitations, medical conditions), emergency contacts, and loyalty programs — all stored as typed columns or JSONB arrays on the same table
 - Nationalities & travel documents (`user_nationalities`): multiple nationalities, national ID, passport number, issue date, expiry date, pre-computed `PassportStatus`, daily job for status updates and expiry notifications
-- Emergency contacts (`user_emergency_contacts`): 1:many, at least one required
-- Loyalty programs (`user_loyalty_programs`): reference data, user-only visibility
-- Health profile: dietary preference and notes (`user_health_profiles`), food allergies (`user_food_allergies`), phobias (`user_phobias`), physical limitations (`user_physical_limitations`), medical conditions (`user_medical_conditions`)
 - User preferences (`user_preferences`): language, currency, theme
 - Profile visibility controls (`ProfileVisibility`)
 


### PR DESCRIPTION
## Summary

- Splits the root `CLAUDE.md` into package-specific files to reduce noise when working inside a single app — each file only loads the rules that apply to that context.
- Adds two custom Claude Code skills (`.claude/commands/`) preloaded with project-specific config so Claude doesn't reason from scratch on GCP or GitHub operations.
- Updates `user_profiles` schema docs to consolidate health data, emergency contacts, and loyalty programs as JSONB columns on the same table instead of separate tables.

## Changes

**CLAUDE.md restructure**
- Root `CLAUDE.md` keeps project overview, tech stack, architecture, domain rules, and general standing rules
- `apps/api/CLAUDE.md` — OpenAPI decorator requirements, Drizzle migration generation
- `apps/web/CLAUDE.md` — i18n namespace conventions, env variable sync, translation key validation

**New Claude Code skills**
- `.claude/commands/gcp.md` (`/gcp`) — preloaded with project ID, service names, regions, connection strings, and ready-to-run commands for logs, deploy, rollback, Cloud SQL, secrets, and Artifact Registry
- `.claude/commands/gh.md` (`/gh`) — preloaded with repo, board number, field options, labels, and conventions for issues, PRs, epics, CI/CD, and project board operations

**Documentation**
- `docs/features/users.md` — consolidates health tables into JSONB columns on `user_profiles`; adds `dietary_preference`, `dietary_notes`, `general_medical_notes`, `food_allergies`, `phobias`, `physical_limitations`, `medical_conditions`, `emergency_contacts`, `loyalty_programs`
- `docs/overview/mvp.md` — reflects the simplified schema (no separate health/emergency/loyalty tables)

## Testing

- No source code changed — no tests required
- Pre-commit hooks passed on both commits (typecheck, lint, coverage)