### PR TITLE
feat(legal): add Privacy Policy and Terms of Service pages with notification consent

### DIFF
--- a/apps/web/src/app/onboarding/page.test.tsx
+++ b/apps/web/src/app/onboarding/page.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen, waitFor, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import type { ReactNode } from 'react';
 import type { User } from 'firebase/auth';
 import type { AuthContextValue } from '@/store/auth';
 
@@ -54,6 +55,7 @@ vi.mock('react-i18next', () => ({
     t: (key: string) => key,
     i18n: { language: 'en' },
   }),
+  Trans: ({ children }: { children?: ReactNode }) => <>{children}</>,
 }));
 
 import { useAuth } from '@/hooks/useAuth';
@@ -226,6 +228,43 @@ describe('OnboardingPage', () => {
       await renderForm();
       expect(screen.getByTestId('cancel-btn')).toBeInTheDocument();
     });
+
+    it('renders the terms acceptance checkbox unchecked by default', async () => {
+      await renderForm();
+      expect(screen.getByTestId<HTMLInputElement>('terms-checkbox').checked).toBe(false);
+    });
+
+    it('submit button is disabled when terms are not accepted', async () => {
+      await renderForm({ currentUser: makeUser({ displayName: 'Test User' }) });
+      // Even with a pre-filled display name, the button is disabled without terms
+      expect(screen.getByTestId('submit-btn')).toBeDisabled();
+    });
+
+    it('checking the terms checkbox enables the submit button when all other fields are valid', async () => {
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+      vi.mocked(useAuth).mockReturnValue(
+        makeAuth({ currentUser: makeUser({ displayName: 'Test User' }) }),
+      );
+      mockGetByUrl();
+      const user = userEvent.setup({
+        advanceTimers: vi.advanceTimersByTime.bind(vi),
+        delay: null,
+      });
+      render(<OnboardingPage />);
+      await waitFor(() => expect(screen.getByTestId('username-input')).toBeInTheDocument());
+      await user.clear(screen.getByTestId('username-input'));
+      await user.type(screen.getByTestId('username-input'), 'testuser');
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(300);
+      });
+      await waitFor(() =>
+        expect(screen.getByText('onboarding.username.available')).toBeInTheDocument(),
+      );
+      expect(screen.getByTestId('submit-btn')).toBeDisabled();
+      await user.click(screen.getByTestId('terms-checkbox'));
+      expect(screen.getByTestId('submit-btn')).not.toBeDisabled();
+      vi.useRealTimers();
+    });
   });
 
   describe('cancel button', () => {
@@ -256,6 +295,7 @@ describe('OnboardingPage', () => {
         expect(screen.getByText('onboarding.username.available')).toBeInTheDocument(),
       );
       await user.type(screen.getByTestId('displayname-input'), 'Test');
+      await user.click(screen.getByTestId('terms-checkbox'));
       await act(async () => {
         await user.click(screen.getByTestId('submit-btn'));
       });
@@ -384,6 +424,7 @@ describe('OnboardingPage', () => {
       await waitFor(() =>
         expect(screen.getByText('onboarding.username.available')).toBeInTheDocument(),
       );
+      await user.click(screen.getByTestId('terms-checkbox'));
       return user;
     }
 

--- a/apps/web/src/app/onboarding/page.tsx
+++ b/apps/web/src/app/onboarding/page.tsx
@@ -203,8 +203,9 @@ export default function OnboardingPage() {
             />
           </div>
 
-          <label className="flex cursor-pointer items-start gap-3">
+          <label htmlFor="terms-checkbox" className="flex cursor-pointer items-start gap-3">
             <input
+              id="terms-checkbox"
               type="checkbox"
               checked={termsAccepted}
               onChange={(e) => setTermsAccepted(e.target.checked)}

--- a/apps/web/src/app/onboarding/page.tsx
+++ b/apps/web/src/app/onboarding/page.tsx
@@ -1,8 +1,9 @@
 'use client';
 
 import { type FormEvent, useEffect, useState } from 'react';
+import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 import { isAxiosError } from 'axios';
 
 import { useAuth } from '@/hooks/useAuth';
@@ -47,6 +48,7 @@ export default function OnboardingPage() {
   const [username, setUsername] = useState('');
   const [displayName, setDisplayName] = useState('');
   const [usernameStatus, setUsernameStatus] = useState<UsernameStatus>('idle');
+  const [termsAccepted, setTermsAccepted] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isCheckingRegistration, setIsCheckingRegistration] = useState(true);
 
@@ -201,10 +203,49 @@ export default function OnboardingPage() {
             />
           </div>
 
+          <label className="flex cursor-pointer items-start gap-3">
+            <input
+              type="checkbox"
+              checked={termsAccepted}
+              onChange={(e) => setTermsAccepted(e.target.checked)}
+              className="mt-0.5 h-4 w-4 shrink-0 accent-primary"
+              data-testid="terms-checkbox"
+            />
+            <span className="text-sm leading-snug text-muted-foreground">
+              <Trans
+                i18nKey="onboarding.terms.accept"
+                ns="auth"
+                components={{
+                  privacyLink: (
+                    <Link
+                      href="/privacy-policy"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-foreground underline underline-offset-2 hover:text-primary"
+                    />
+                  ),
+                  termsLink: (
+                    <Link
+                      href="/terms-of-service"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-foreground underline underline-offset-2 hover:text-primary"
+                    />
+                  ),
+                }}
+              />
+            </span>
+          </label>
+
           <Button
             type="submit"
             size="lg"
-            disabled={usernameStatus !== 'available' || !displayName.trim() || isSubmitting}
+            disabled={
+              usernameStatus !== 'available' ||
+              !displayName.trim() ||
+              !termsAccepted ||
+              isSubmitting
+            }
             className="mt-2 h-11"
             data-testid="submit-btn"
           >

--- a/apps/web/src/app/privacy-policy/page.test.tsx
+++ b/apps/web/src/app/privacy-policy/page.test.tsx
@@ -1,0 +1,119 @@
+import { render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { CONTACT_EMAIL } from '@/config/app.constants';
+
+vi.mock('next/link', () => ({
+  default: ({
+    href,
+    children,
+    ...props
+  }: {
+    href: string;
+    children: ReactNode;
+    [key: string]: unknown;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock('@/components/header/Logo', () => ({
+  Logo: () => <div data-testid="logo">Logo</div>,
+}));
+
+vi.mock('@/components/LanguageToggle', () => ({
+  LanguageToggle: () => <button data-testid="language-toggle">Lang</button>,
+}));
+
+vi.mock('@/components/ThemeToggle', () => ({
+  ThemeToggle: () => <button data-testid="theme-toggle">Theme</button>,
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: 'en' },
+  }),
+}));
+
+import PrivacyPolicyPage from './page';
+
+describe('PrivacyPolicyPage', () => {
+  beforeEach(() => {
+    render(<PrivacyPolicyPage />);
+  });
+
+  describe('header', () => {
+    it('renders the logo', () => {
+      expect(screen.getByTestId('logo')).toBeInTheDocument();
+    });
+
+    it('renders the language toggle', () => {
+      expect(screen.getByTestId('language-toggle')).toBeInTheDocument();
+    });
+
+    it('renders the theme toggle', () => {
+      expect(screen.getByTestId('theme-toggle')).toBeInTheDocument();
+    });
+  });
+
+  describe('page title', () => {
+    it('renders an h1 with the privacy title key', () => {
+      expect(screen.getByRole('heading', { level: 1, name: 'privacy.title' })).toBeInTheDocument();
+    });
+  });
+
+  describe('sections', () => {
+    it('renders all 13 section headings', () => {
+      expect(screen.getAllByRole('heading', { level: 2 })).toHaveLength(13);
+    });
+
+    it('renders the Data Controller section', () => {
+      expect(
+        screen.getByRole('heading', { level: 2, name: 'privacy.sections.controller.title' }),
+      ).toBeInTheDocument();
+    });
+
+    it('renders the Sensitive Data section', () => {
+      expect(
+        screen.getByRole('heading', { level: 2, name: 'privacy.sections.sensitiveData.title' }),
+      ).toBeInTheDocument();
+    });
+
+    it('renders the Rights section', () => {
+      expect(
+        screen.getByRole('heading', { level: 2, name: 'privacy.sections.rights.title' }),
+      ).toBeInTheDocument();
+    });
+
+    it('renders the Contact section', () => {
+      expect(
+        screen.getByRole('heading', { level: 2, name: 'privacy.sections.contact.title' }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('contact', () => {
+    it('renders a mailto link with the correct contact email', () => {
+      const link = screen.getByRole('link', { name: 'privacy.sections.contact.email' });
+      expect(link).toHaveAttribute('href', `mailto:${CONTACT_EMAIL}`);
+    });
+  });
+
+  describe('footer navigation', () => {
+    it('renders a link back to /sign-in', () => {
+      expect(screen.getByRole('link', { name: 'common:actions.backToSignIn' })).toHaveAttribute(
+        'href',
+        '/sign-in',
+      );
+    });
+
+    it('renders a cross-link to /terms-of-service', () => {
+      expect(screen.getByRole('link', { name: 'terms.title' })).toHaveAttribute(
+        'href',
+        '/terms-of-service',
+      );
+    });
+  });
+});

--- a/apps/web/src/app/privacy-policy/page.tsx
+++ b/apps/web/src/app/privacy-policy/page.tsx
@@ -2,12 +2,13 @@
 
 import Link from 'next/link';
 import { useTranslation } from 'react-i18next';
+import { CONTACT_EMAIL } from '@/config/app.constants';
 import { Logo } from '@/components/header/Logo';
 import { LanguageToggle } from '@/components/LanguageToggle';
 import { ThemeToggle } from '@/components/ThemeToggle';
 
 export default function PrivacyPolicyPage() {
-  const { t } = useTranslation('legal');
+  const { t } = useTranslation(['legal', 'common']);
 
   return (
     <div className="min-h-screen bg-background">
@@ -261,7 +262,7 @@ export default function PrivacyPolicyPage() {
             {t('privacy.sections.contact.p1')}
           </p>
           <a
-            href="mailto:admin@chamucotravel.com"
+            href={`mailto:${CONTACT_EMAIL}`}
             className="mb-3 block font-medium text-primary hover:underline"
           >
             {t('privacy.sections.contact.email')}
@@ -275,7 +276,7 @@ export default function PrivacyPolicyPage() {
             href="/sign-in"
             className="text-sm text-muted-foreground hover:text-foreground hover:underline"
           >
-            {t('backToSignIn')}
+            {t('common:actions.backToSignIn')}
           </Link>
           <Link
             href="/terms-of-service"

--- a/apps/web/src/app/privacy-policy/page.tsx
+++ b/apps/web/src/app/privacy-policy/page.tsx
@@ -1,0 +1,290 @@
+'use client';
+
+import Link from 'next/link';
+import { useTranslation } from 'react-i18next';
+import { Logo } from '@/components/header/Logo';
+import { LanguageToggle } from '@/components/LanguageToggle';
+import { ThemeToggle } from '@/components/ThemeToggle';
+
+export default function PrivacyPolicyPage() {
+  const { t } = useTranslation('legal');
+
+  return (
+    <div className="min-h-screen bg-background">
+      {/* Minimal header */}
+      <header className="sticky top-0 z-50 border-b border-border bg-background/80 backdrop-blur-sm">
+        <div className="mx-auto flex max-w-4xl items-center justify-between px-4 py-3">
+          <Logo />
+          <div className="flex items-center gap-2">
+            <LanguageToggle />
+            <ThemeToggle />
+          </div>
+        </div>
+      </header>
+
+      <main className="mx-auto max-w-4xl px-4 py-10 md:py-16">
+        {/* Page header */}
+        <div className="mb-10 border-b border-border pb-8">
+          <h1 className="mb-2 text-3xl font-bold tracking-tight text-foreground md:text-4xl">
+            {t('privacy.title')}
+          </h1>
+          <p className="text-sm text-muted-foreground">{t('privacy.subtitle')}</p>
+        </div>
+
+        {/* Preamble */}
+        <p className="mb-10 leading-relaxed text-foreground/90">{t('privacy.preamble')}</p>
+
+        {/* Section 1 — Data Controller */}
+        <section className="mb-8">
+          <h2 className="mb-4 text-xl font-semibold text-foreground">
+            {t('privacy.sections.controller.title')}
+          </h2>
+          <p className="mb-3 leading-relaxed text-foreground/90">
+            {t('privacy.sections.controller.p1')}
+          </p>
+          <p className="leading-relaxed text-foreground/90">
+            {t('privacy.sections.controller.p2')}
+          </p>
+        </section>
+
+        {/* Section 2 — Data Collected */}
+        <section className="mb-8">
+          <h2 className="mb-4 text-xl font-semibold text-foreground">
+            {t('privacy.sections.dataCollected.title')}
+          </h2>
+          <p className="mb-4 leading-relaxed text-foreground/90">
+            {t('privacy.sections.dataCollected.intro')}
+          </p>
+          <div className="space-y-4 pl-4">
+            {(
+              [
+                'account',
+                'profile',
+                'documents',
+                'health',
+                'emergency',
+                'loyalty',
+                'activity',
+                'technical',
+              ] as const
+            ).map((key) => (
+              <div key={key}>
+                <h3 className="mb-1 font-medium text-foreground">
+                  {t(`privacy.sections.dataCollected.${key}.title`)}
+                </h3>
+                <p className="leading-relaxed text-foreground/80">
+                  {t(`privacy.sections.dataCollected.${key}.body`)}
+                </p>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* Section 3 — Purposes */}
+        <section className="mb-8">
+          <h2 className="mb-4 text-xl font-semibold text-foreground">
+            {t('privacy.sections.purposes.title')}
+          </h2>
+          <p className="mb-4 leading-relaxed text-foreground/90">
+            {t('privacy.sections.purposes.intro')}
+          </p>
+          <ul className="space-y-2 pl-4">
+            {(
+              [
+                'auth',
+                'profile',
+                'trips',
+                'gamification',
+                'notifications',
+                'sharing',
+                'export',
+                'support',
+                'legal',
+              ] as const
+            ).map((key) => (
+              <li key={key} className="flex gap-2 leading-relaxed text-foreground/80">
+                <span className="mt-2 h-1.5 w-1.5 shrink-0 rounded-full bg-foreground/40" />
+                {t(`privacy.sections.purposes.${key}`)}
+              </li>
+            ))}
+          </ul>
+        </section>
+
+        {/* Section 4 — Sensitive Data */}
+        <section className="mb-8 rounded-lg border border-amber-200 bg-amber-50 p-5 dark:border-amber-800/40 dark:bg-amber-950/20">
+          <h2 className="mb-4 text-xl font-semibold text-foreground">
+            {t('privacy.sections.sensitiveData.title')}
+          </h2>
+          {(['p1', 'p2', 'p3', 'p4'] as const).map((p) => (
+            <p key={p} className="mb-3 leading-relaxed text-foreground/90 last:mb-0">
+              {t(`privacy.sections.sensitiveData.${p}`)}
+            </p>
+          ))}
+        </section>
+
+        {/* Section 5 — Third Parties */}
+        <section className="mb-8">
+          <h2 className="mb-4 text-xl font-semibold text-foreground">
+            {t('privacy.sections.thirdParties.title')}
+          </h2>
+          <p className="mb-4 leading-relaxed text-foreground/90">
+            {t('privacy.sections.thirdParties.p1')}
+          </p>
+          <div className="space-y-4 pl-4">
+            <div>
+              <h3 className="mb-1 font-medium text-foreground">
+                {t('privacy.sections.thirdParties.googleTitle')}
+              </h3>
+              <p className="leading-relaxed text-foreground/80">
+                {t('privacy.sections.thirdParties.googleBody')}
+              </p>
+            </div>
+            <div>
+              <h3 className="mb-1 font-medium text-foreground">
+                {t('privacy.sections.thirdParties.facebookTitle')}
+              </h3>
+              <p className="leading-relaxed text-foreground/80">
+                {t('privacy.sections.thirdParties.facebookBody')}
+              </p>
+            </div>
+          </div>
+          <p className="mt-4 leading-relaxed text-foreground/90">
+            {t('privacy.sections.thirdParties.noSale')}
+          </p>
+        </section>
+
+        {/* Section 6 — International Transfers */}
+        <section className="mb-8">
+          <h2 className="mb-4 text-xl font-semibold text-foreground">
+            {t('privacy.sections.internationalTransfers.title')}
+          </h2>
+          {(['p1', 'p2', 'p3'] as const).map((p) => (
+            <p key={p} className="mb-3 leading-relaxed text-foreground/90 last:mb-0">
+              {t(`privacy.sections.internationalTransfers.${p}`)}
+            </p>
+          ))}
+        </section>
+
+        {/* Section 7 — Minors */}
+        <section className="mb-8">
+          <h2 className="mb-4 text-xl font-semibold text-foreground">
+            {t('privacy.sections.minors.title')}
+          </h2>
+          {(['p1', 'p2'] as const).map((p) => (
+            <p key={p} className="mb-3 leading-relaxed text-foreground/90 last:mb-0">
+              {t(`privacy.sections.minors.${p}`)}
+            </p>
+          ))}
+        </section>
+
+        {/* Section 8 — Retention */}
+        <section className="mb-8">
+          <h2 className="mb-4 text-xl font-semibold text-foreground">
+            {t('privacy.sections.retention.title')}
+          </h2>
+          {(['p1', 'p2', 'p3'] as const).map((p) => (
+            <p key={p} className="mb-3 leading-relaxed text-foreground/90 last:mb-0">
+              {t(`privacy.sections.retention.${p}`)}
+            </p>
+          ))}
+        </section>
+
+        {/* Section 9 — Rights */}
+        <section className="mb-8">
+          <h2 className="mb-4 text-xl font-semibold text-foreground">
+            {t('privacy.sections.rights.title')}
+          </h2>
+          <p className="mb-4 leading-relaxed text-foreground/90">
+            {t('privacy.sections.rights.intro')}
+          </p>
+          <ul className="mb-4 space-y-2 pl-4">
+            {(
+              ['access', 'correction', 'deletion', 'revocation', 'complaint', 'freeAccess'] as const
+            ).map((key) => (
+              <li key={key} className="flex gap-2 leading-relaxed text-foreground/80">
+                <span className="mt-2 h-1.5 w-1.5 shrink-0 rounded-full bg-foreground/40" />
+                {t(`privacy.sections.rights.${key}`)}
+              </li>
+            ))}
+          </ul>
+          <p className="leading-relaxed text-foreground/90">{t('privacy.sections.rights.howTo')}</p>
+        </section>
+
+        {/* Section 10 — Security */}
+        <section className="mb-8">
+          <h2 className="mb-4 text-xl font-semibold text-foreground">
+            {t('privacy.sections.security.title')}
+          </h2>
+          <p className="mb-4 leading-relaxed text-foreground/90">
+            {t('privacy.sections.security.intro')}
+          </p>
+          <ul className="space-y-2 pl-4">
+            {(['https', 'auth', 'secrets', 'audit', 'rbac', 'sensitive'] as const).map((key) => (
+              <li key={key} className="flex gap-2 leading-relaxed text-foreground/80">
+                <span className="mt-2 h-1.5 w-1.5 shrink-0 rounded-full bg-foreground/40" />
+                {t(`privacy.sections.security.${key}`)}
+              </li>
+            ))}
+          </ul>
+        </section>
+
+        {/* Section 11 — Organizer Export */}
+        <section className="mb-8">
+          <h2 className="mb-4 text-xl font-semibold text-foreground">
+            {t('privacy.sections.organizers.title')}
+          </h2>
+          {(['p1', 'p2', 'p3'] as const).map((p) => (
+            <p key={p} className="mb-3 leading-relaxed text-foreground/90 last:mb-0">
+              {t(`privacy.sections.organizers.${p}`)}
+            </p>
+          ))}
+        </section>
+
+        {/* Section 12 — Changes */}
+        <section className="mb-8">
+          <h2 className="mb-4 text-xl font-semibold text-foreground">
+            {t('privacy.sections.changes.title')}
+          </h2>
+          {(['p1', 'p2'] as const).map((p) => (
+            <p key={p} className="mb-3 leading-relaxed text-foreground/90 last:mb-0">
+              {t(`privacy.sections.changes.${p}`)}
+            </p>
+          ))}
+        </section>
+
+        {/* Section 13 — Contact */}
+        <section className="mb-12 rounded-lg border border-border bg-muted/40 p-5">
+          <h2 className="mb-4 text-xl font-semibold text-foreground">
+            {t('privacy.sections.contact.title')}
+          </h2>
+          <p className="mb-3 leading-relaxed text-foreground/90">
+            {t('privacy.sections.contact.p1')}
+          </p>
+          <a
+            href="mailto:admin@chamucotravel.com"
+            className="mb-3 block font-medium text-primary hover:underline"
+          >
+            {t('privacy.sections.contact.email')}
+          </a>
+          <p className="leading-relaxed text-foreground/90">{t('privacy.sections.contact.p2')}</p>
+        </section>
+
+        {/* Footer navigation */}
+        <div className="flex flex-col items-start gap-3 border-t border-border pt-6 sm:flex-row sm:items-center sm:justify-between">
+          <Link
+            href="/sign-in"
+            className="text-sm text-muted-foreground hover:text-foreground hover:underline"
+          >
+            {t('backToSignIn')}
+          </Link>
+          <Link
+            href="/terms-of-service"
+            className="text-sm text-muted-foreground hover:text-foreground hover:underline"
+          >
+            {t('terms.title')}
+          </Link>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/apps/web/src/app/terms-of-service/page.test.tsx
+++ b/apps/web/src/app/terms-of-service/page.test.tsx
@@ -1,0 +1,119 @@
+import { render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { CONTACT_EMAIL } from '@/config/app.constants';
+
+vi.mock('next/link', () => ({
+  default: ({
+    href,
+    children,
+    ...props
+  }: {
+    href: string;
+    children: ReactNode;
+    [key: string]: unknown;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock('@/components/header/Logo', () => ({
+  Logo: () => <div data-testid="logo">Logo</div>,
+}));
+
+vi.mock('@/components/LanguageToggle', () => ({
+  LanguageToggle: () => <button data-testid="language-toggle">Lang</button>,
+}));
+
+vi.mock('@/components/ThemeToggle', () => ({
+  ThemeToggle: () => <button data-testid="theme-toggle">Theme</button>,
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: 'en' },
+  }),
+}));
+
+import TermsOfServicePage from './page';
+
+describe('TermsOfServicePage', () => {
+  beforeEach(() => {
+    render(<TermsOfServicePage />);
+  });
+
+  describe('header', () => {
+    it('renders the logo', () => {
+      expect(screen.getByTestId('logo')).toBeInTheDocument();
+    });
+
+    it('renders the language toggle', () => {
+      expect(screen.getByTestId('language-toggle')).toBeInTheDocument();
+    });
+
+    it('renders the theme toggle', () => {
+      expect(screen.getByTestId('theme-toggle')).toBeInTheDocument();
+    });
+  });
+
+  describe('page title', () => {
+    it('renders an h1 with the terms title key', () => {
+      expect(screen.getByRole('heading', { level: 1, name: 'terms.title' })).toBeInTheDocument();
+    });
+  });
+
+  describe('sections', () => {
+    it('renders all 15 section headings', () => {
+      expect(screen.getAllByRole('heading', { level: 2 })).toHaveLength(15);
+    });
+
+    it('renders the Acceptance section', () => {
+      expect(
+        screen.getByRole('heading', { level: 2, name: 'terms.sections.acceptance.title' }),
+      ).toBeInTheDocument();
+    });
+
+    it('renders the Communications and Notifications section', () => {
+      expect(
+        screen.getByRole('heading', { level: 2, name: 'terms.sections.notifications.title' }),
+      ).toBeInTheDocument();
+    });
+
+    it('renders the Governing Law section', () => {
+      expect(
+        screen.getByRole('heading', { level: 2, name: 'terms.sections.governingLaw.title' }),
+      ).toBeInTheDocument();
+    });
+
+    it('renders the Contact section', () => {
+      expect(
+        screen.getByRole('heading', { level: 2, name: 'terms.sections.contact.title' }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('contact', () => {
+    it('renders a mailto link with the correct contact email', () => {
+      const link = screen.getByRole('link', { name: 'terms.sections.contact.email' });
+      expect(link).toHaveAttribute('href', `mailto:${CONTACT_EMAIL}`);
+    });
+  });
+
+  describe('footer navigation', () => {
+    it('renders a link back to /sign-in', () => {
+      expect(screen.getByRole('link', { name: 'common:actions.backToSignIn' })).toHaveAttribute(
+        'href',
+        '/sign-in',
+      );
+    });
+
+    it('renders a cross-link to /privacy-policy', () => {
+      expect(screen.getByRole('link', { name: 'privacy.title' })).toHaveAttribute(
+        'href',
+        '/privacy-policy',
+      );
+    });
+  });
+});

--- a/apps/web/src/app/terms-of-service/page.tsx
+++ b/apps/web/src/app/terms-of-service/page.tsx
@@ -1,0 +1,303 @@
+'use client';
+
+import Link from 'next/link';
+import { useTranslation } from 'react-i18next';
+import { Logo } from '@/components/header/Logo';
+import { LanguageToggle } from '@/components/LanguageToggle';
+import { ThemeToggle } from '@/components/ThemeToggle';
+
+export default function TermsOfServicePage() {
+  const { t } = useTranslation('legal');
+
+  return (
+    <div className="min-h-screen bg-background">
+      {/* Minimal header */}
+      <header className="sticky top-0 z-50 border-b border-border bg-background/80 backdrop-blur-sm">
+        <div className="mx-auto flex max-w-4xl items-center justify-between px-4 py-3">
+          <Logo />
+          <div className="flex items-center gap-2">
+            <LanguageToggle />
+            <ThemeToggle />
+          </div>
+        </div>
+      </header>
+
+      <main className="mx-auto max-w-4xl px-4 py-10 md:py-16">
+        {/* Page header */}
+        <div className="mb-10 border-b border-border pb-8">
+          <h1 className="mb-2 text-3xl font-bold tracking-tight text-foreground md:text-4xl">
+            {t('terms.title')}
+          </h1>
+          <p className="text-sm text-muted-foreground">{t('terms.subtitle')}</p>
+        </div>
+
+        {/* Preamble */}
+        <p className="mb-10 leading-relaxed text-foreground/90">{t('terms.preamble')}</p>
+
+        {/* Section 1 — Acceptance */}
+        <section className="mb-8">
+          <h2 className="mb-4 text-xl font-semibold text-foreground">
+            {t('terms.sections.acceptance.title')}
+          </h2>
+          {(['p1', 'p2'] as const).map((p) => (
+            <p key={p} className="mb-3 leading-relaxed text-foreground/90 last:mb-0">
+              {t(`terms.sections.acceptance.${p}`)}
+            </p>
+          ))}
+        </section>
+
+        {/* Section 2 — Service */}
+        <section className="mb-8">
+          <h2 className="mb-4 text-xl font-semibold text-foreground">
+            {t('terms.sections.service.title')}
+          </h2>
+          {(['p1', 'p2', 'p3'] as const).map((p) => (
+            <p key={p} className="mb-3 leading-relaxed text-foreground/90 last:mb-0">
+              {t(`terms.sections.service.${p}`)}
+            </p>
+          ))}
+        </section>
+
+        {/* Section 3 — Eligibility */}
+        <section className="mb-8">
+          <h2 className="mb-4 text-xl font-semibold text-foreground">
+            {t('terms.sections.eligibility.title')}
+          </h2>
+          {(['p1', 'p2'] as const).map((p) => (
+            <p key={p} className="mb-3 leading-relaxed text-foreground/90 last:mb-0">
+              {t(`terms.sections.eligibility.${p}`)}
+            </p>
+          ))}
+        </section>
+
+        {/* Section 4 — Account */}
+        <section className="mb-8">
+          <h2 className="mb-4 text-xl font-semibold text-foreground">
+            {t('terms.sections.account.title')}
+          </h2>
+          {(['p1', 'p2', 'p3'] as const).map((p) => (
+            <p key={p} className="mb-3 leading-relaxed text-foreground/90 last:mb-0">
+              {t(`terms.sections.account.${p}`)}
+            </p>
+          ))}
+        </section>
+
+        {/* Section 5 — Acceptable Use */}
+        <section className="mb-8">
+          <h2 className="mb-4 text-xl font-semibold text-foreground">
+            {t('terms.sections.acceptableUse.title')}
+          </h2>
+          <p className="mb-4 leading-relaxed text-foreground/90">
+            {t('terms.sections.acceptableUse.intro')}
+          </p>
+          <ul className="mb-4 space-y-2 pl-4">
+            {(
+              [
+                'illegal',
+                'impersonation',
+                'harmful',
+                'unauthorized',
+                'spam',
+                'scraping',
+                'interference',
+              ] as const
+            ).map((key) => (
+              <li key={key} className="flex gap-2 leading-relaxed text-foreground/80">
+                <span className="mt-2 h-1.5 w-1.5 shrink-0 rounded-full bg-foreground/40" />
+                {t(`terms.sections.acceptableUse.${key}`)}
+              </li>
+            ))}
+          </ul>
+          <p className="leading-relaxed text-foreground/90">
+            {t('terms.sections.acceptableUse.consequences')}
+          </p>
+        </section>
+
+        {/* Section 6 — Expenses */}
+        <section className="mb-8">
+          <h2 className="mb-4 text-xl font-semibold text-foreground">
+            {t('terms.sections.expenses.title')}
+          </h2>
+          {(['p1', 'p2', 'p3'] as const).map((p) => (
+            <p key={p} className="mb-3 leading-relaxed text-foreground/90 last:mb-0">
+              {t(`terms.sections.expenses.${p}`)}
+            </p>
+          ))}
+        </section>
+
+        {/* Section 7 — IP */}
+        <section className="mb-8">
+          <h2 className="mb-4 text-xl font-semibold text-foreground">
+            {t('terms.sections.ip.title')}
+          </h2>
+          {(['p1', 'p2', 'p3'] as const).map((p) => (
+            <p key={p} className="mb-3 leading-relaxed text-foreground/90 last:mb-0">
+              {t(`terms.sections.ip.${p}`)}
+            </p>
+          ))}
+        </section>
+
+        {/* Section 8 — Gamification */}
+        <section className="mb-8">
+          <h2 className="mb-4 text-xl font-semibold text-foreground">
+            {t('terms.sections.gamification.title')}
+          </h2>
+          {(['p1', 'p2', 'p3'] as const).map((p) => (
+            <p key={p} className="mb-3 leading-relaxed text-foreground/90 last:mb-0">
+              {t(`terms.sections.gamification.${p}`)}
+            </p>
+          ))}
+        </section>
+
+        {/* Section 9 — Notifications */}
+        <section className="mb-8">
+          <h2 className="mb-4 text-xl font-semibold text-foreground">
+            {t('terms.sections.notifications.title')}
+          </h2>
+          <p className="mb-4 leading-relaxed text-foreground/90">
+            {t('terms.sections.notifications.p1')}
+          </p>
+          <p className="mb-2 font-medium text-foreground">
+            {t('terms.sections.notifications.transactionalTitle')}
+          </p>
+          <ul className="mb-4 space-y-2 pl-4">
+            {(
+              [
+                'trips',
+                'feedback',
+                'passport',
+                'gamification',
+                'keyDates',
+                'announcements',
+              ] as const
+            ).map((key) => (
+              <li key={key} className="flex gap-2 leading-relaxed text-foreground/80">
+                <span className="mt-2 h-1.5 w-1.5 shrink-0 rounded-full bg-foreground/40" />
+                {t(`terms.sections.notifications.transactional.${key}`)}
+              </li>
+            ))}
+          </ul>
+          <p className="mb-2 font-medium text-foreground">
+            {t('terms.sections.notifications.platformTitle')}
+          </p>
+          <ul className="mb-4 space-y-2 pl-4">
+            {(['news', 'promotional'] as const).map((key) => (
+              <li key={key} className="flex gap-2 leading-relaxed text-foreground/80">
+                <span className="mt-2 h-1.5 w-1.5 shrink-0 rounded-full bg-foreground/40" />
+                {t(`terms.sections.notifications.platform.${key}`)}
+              </li>
+            ))}
+          </ul>
+          {(['p2', 'p3'] as const).map((p) => (
+            <p key={p} className="mb-3 leading-relaxed text-foreground/90 last:mb-0">
+              {t(`terms.sections.notifications.${p}`)}
+            </p>
+          ))}
+        </section>
+
+        {/* Section 10 — Privacy */}
+        <section className="mb-8">
+          <h2 className="mb-4 text-xl font-semibold text-foreground">
+            {t('terms.sections.privacy.title')}
+          </h2>
+          <p className="mb-3 leading-relaxed text-foreground/90">
+            {t('terms.sections.privacy.p1')}
+          </p>
+          <p className="leading-relaxed text-foreground/90">{t('terms.sections.privacy.p2')}</p>
+        </section>
+
+        {/* Section 11 — Liability */}
+        <section className="mb-8">
+          <h2 className="mb-4 text-xl font-semibold text-foreground">
+            {t('terms.sections.liability.title')}
+          </h2>
+          <p className="mb-4 leading-relaxed text-foreground/90">
+            {t('terms.sections.liability.intro')}
+          </p>
+          <ul className="mb-4 space-y-2 pl-4">
+            {(['decisions', 'userContent', 'service', 'financial', 'agreements'] as const).map(
+              (key) => (
+                <li key={key} className="flex gap-2 leading-relaxed text-foreground/80">
+                  <span className="mt-2 h-1.5 w-1.5 shrink-0 rounded-full bg-foreground/40" />
+                  {t(`terms.sections.liability.${key}`)}
+                </li>
+              ),
+            )}
+          </ul>
+          <p className="leading-relaxed text-foreground/90">
+            {t('terms.sections.liability.caveat')}
+          </p>
+        </section>
+
+        {/* Section 12 — Termination */}
+        <section className="mb-8">
+          <h2 className="mb-4 text-xl font-semibold text-foreground">
+            {t('terms.sections.termination.title')}
+          </h2>
+          {(['p1', 'p2', 'p3'] as const).map((p) => (
+            <p key={p} className="mb-3 leading-relaxed text-foreground/90 last:mb-0">
+              {t(`terms.sections.termination.${p}`)}
+            </p>
+          ))}
+        </section>
+
+        {/* Section 13 — Modifications */}
+        <section className="mb-8">
+          <h2 className="mb-4 text-xl font-semibold text-foreground">
+            {t('terms.sections.modifications.title')}
+          </h2>
+          {(['p1', 'p2'] as const).map((p) => (
+            <p key={p} className="mb-3 leading-relaxed text-foreground/90 last:mb-0">
+              {t(`terms.sections.modifications.${p}`)}
+            </p>
+          ))}
+        </section>
+
+        {/* Section 14 — Governing Law */}
+        <section className="mb-8">
+          <h2 className="mb-4 text-xl font-semibold text-foreground">
+            {t('terms.sections.governingLaw.title')}
+          </h2>
+          {(['p1', 'p2', 'p3'] as const).map((p) => (
+            <p key={p} className="mb-3 leading-relaxed text-foreground/90 last:mb-0">
+              {t(`terms.sections.governingLaw.${p}`)}
+            </p>
+          ))}
+        </section>
+
+        {/* Section 15 — Contact */}
+        <section className="mb-12 rounded-lg border border-border bg-muted/40 p-5">
+          <h2 className="mb-4 text-xl font-semibold text-foreground">
+            {t('terms.sections.contact.title')}
+          </h2>
+          <p className="mb-3 leading-relaxed text-foreground/90">
+            {t('terms.sections.contact.p1')}
+          </p>
+          <a
+            href="mailto:admin@chamucotravel.com"
+            className="mb-3 block font-medium text-primary hover:underline"
+          >
+            {t('terms.sections.contact.email')}
+          </a>
+          <p className="leading-relaxed text-foreground/90">{t('terms.sections.contact.p2')}</p>
+        </section>
+
+        {/* Footer navigation */}
+        <div className="flex flex-col items-start gap-3 border-t border-border pt-6 sm:flex-row sm:items-center sm:justify-between">
+          <Link
+            href="/sign-in"
+            className="text-sm text-muted-foreground hover:text-foreground hover:underline"
+          >
+            {t('backToSignIn')}
+          </Link>
+          <Link
+            href="/privacy-policy"
+            className="text-sm text-muted-foreground hover:text-foreground hover:underline"
+          >
+            {t('privacy.title')}
+          </Link>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/apps/web/src/app/terms-of-service/page.tsx
+++ b/apps/web/src/app/terms-of-service/page.tsx
@@ -2,12 +2,13 @@
 
 import Link from 'next/link';
 import { useTranslation } from 'react-i18next';
+import { CONTACT_EMAIL } from '@/config/app.constants';
 import { Logo } from '@/components/header/Logo';
 import { LanguageToggle } from '@/components/LanguageToggle';
 import { ThemeToggle } from '@/components/ThemeToggle';
 
 export default function TermsOfServicePage() {
-  const { t } = useTranslation('legal');
+  const { t } = useTranslation(['legal', 'common']);
 
   return (
     <div className="min-h-screen bg-background">
@@ -274,7 +275,7 @@ export default function TermsOfServicePage() {
             {t('terms.sections.contact.p1')}
           </p>
           <a
-            href="mailto:admin@chamucotravel.com"
+            href={`mailto:${CONTACT_EMAIL}`}
             className="mb-3 block font-medium text-primary hover:underline"
           >
             {t('terms.sections.contact.email')}
@@ -288,7 +289,7 @@ export default function TermsOfServicePage() {
             href="/sign-in"
             className="text-sm text-muted-foreground hover:text-foreground hover:underline"
           >
-            {t('backToSignIn')}
+            {t('common:actions.backToSignIn')}
           </Link>
           <Link
             href="/privacy-policy"

--- a/apps/web/src/components/layout/AppShell.tsx
+++ b/apps/web/src/components/layout/AppShell.tsx
@@ -5,8 +5,8 @@ import { usePathname } from 'next/navigation';
 import { Header } from '@/components/header';
 import { MobileBottomNav, DesktopSideNav } from '@/components/navigation';
 
-// Auth pages (/sign-in, /onboarding, etc.) render without nav chrome
-const AUTH_PATHS = ['/sign-in', '/onboarding'];
+// Auth pages and public legal pages render without nav chrome
+const AUTH_PATHS = ['/sign-in', '/onboarding', '/privacy-policy', '/terms-of-service'];
 
 interface AppShellProps {
   children: ReactNode;

--- a/apps/web/src/components/layout/AppShell.tsx
+++ b/apps/web/src/components/layout/AppShell.tsx
@@ -5,8 +5,8 @@ import { usePathname } from 'next/navigation';
 import { Header } from '@/components/header';
 import { MobileBottomNav, DesktopSideNav } from '@/components/navigation';
 
-// Auth pages and public legal pages render without nav chrome
-const AUTH_PATHS = ['/sign-in', '/onboarding', '/privacy-policy', '/terms-of-service'];
+// Pages that render without nav chrome (auth flows + public legal pages)
+const NO_CHROME_PATHS = ['/sign-in', '/onboarding', '/privacy-policy', '/terms-of-service'];
 
 interface AppShellProps {
   children: ReactNode;
@@ -15,7 +15,7 @@ interface AppShellProps {
 export function AppShell({ children }: AppShellProps) {
   const pathname = usePathname();
 
-  if (AUTH_PATHS.includes(pathname)) {
+  if (NO_CHROME_PATHS.includes(pathname)) {
     return <main className="min-h-screen">{children}</main>;
   }
 

--- a/apps/web/src/config/app.constants.ts
+++ b/apps/web/src/config/app.constants.ts
@@ -1,0 +1,1 @@
+export const CONTACT_EMAIL = 'admin@chamucotravel.com';

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -97,6 +97,10 @@
         "placeholder": "How should we call you?"
       },
       "submit": "Create my account",
+      "terms": {
+        "accept": "I accept the <privacyLink>Privacy Policy</privacyLink> and the <termsLink>Terms and Conditions</termsLink> of Chamuco Travel.",
+        "required": "You must accept the terms to continue."
+      },
       "error": {
         "failed": "Registration failed. Please try again.",
         "usernameTaken": "That username is already taken. Please choose another."
@@ -155,5 +159,257 @@
     "unauthorized": "You are not authorized to access this resource",
     "networkError": "Network error. Please check your connection.",
     "sessionExpired": "Your session has expired. Please sign in again."
+  },
+  "legal": {
+    "backToSignIn": "Back to sign in",
+    "privacy": {
+      "title": "Privacy Policy",
+      "subtitle": "Last updated: April 13, 2026",
+      "preamble": "Manuel Nuñez Torres, a natural person domiciled in Colombia, operates the Chamuco Travel platform accessible at chamucotravel.com (hereinafter, \"Chamuco Travel\" or \"the Platform\"). This Privacy Policy describes how we collect, use, store, and protect your personal data in accordance with Colombian Law 1581 of 2012 (Statutory Law on Personal Data Protection) and its implementing decrees.",
+      "sections": {
+        "controller": {
+          "title": "1. Data Controller",
+          "p1": "The Data Controller responsible for the processing of your personal data is Manuel Nuñez Torres, a natural person domiciled in Colombia, operating under the brand name Chamuco Travel.",
+          "p2": "For any questions, requests, or complaints regarding the processing of your personal data, contact us at: admin@chamucotravel.com. We will respond within the legally established timeframe (15 business days for queries; 15 business days for claims, with a one-time extension of 8 additional business days if necessary)."
+        },
+        "dataCollected": {
+          "title": "2. Personal Data We Collect",
+          "intro": "We collect and process the following categories of personal data when you register and use the Platform:",
+          "account": {
+            "title": "Account and Identity Data",
+            "body": "Full name and profile picture (pre-filled from your Google or Facebook account), email address, unique username chosen at registration, and your Firebase authentication identifier."
+          },
+          "profile": {
+            "title": "Personal Profile Data",
+            "body": "Legal first and last name, date of birth, country and city of birth, country and city of current residence, phone number in international format, and an optional public biography."
+          },
+          "documents": {
+            "title": "Travel Documents",
+            "body": "Nationality or nationalities, national identity document number (cédula, DNI, etc.), passport number, passport issue date, and passport expiry date."
+          },
+          "health": {
+            "title": "Health Data (Sensitive Personal Data)",
+            "body": "Dietary preferences and restrictions, food allergies, travel-related phobias, physical limitations, medical conditions, and optional general medical notes. This data is classified as sensitive under Article 5 of Law 1581 of 2012. See Section 4 for its special treatment."
+          },
+          "emergency": {
+            "title": "Emergency Contacts",
+            "body": "Full name, phone number, and relationship of each designated emergency contact."
+          },
+          "loyalty": {
+            "title": "Loyalty Programs",
+            "body": "Loyalty program names and membership numbers. This information is visible only to you and is never shared with organizers or other users."
+          },
+          "activity": {
+            "title": "Activity and Usage Data",
+            "body": "Trips created, joined, and completed; group memberships; travel statistics (countries visited, distance traveled, unique travel companions, trips as organizer); achievements unlocked; recognitions received; and Chamuco Points balance."
+          },
+          "technical": {
+            "title": "Technical and Preference Data",
+            "body": "Home time zone, language preference, currency preference, UI theme preference, and timestamp of last activity."
+          }
+        },
+        "purposes": {
+          "title": "3. Purposes of Data Processing",
+          "intro": "We process your personal data exclusively for the following purposes:",
+          "auth": "Authentication and identity verification at every session.",
+          "profile": "Management of your user profile, preferences, and account settings.",
+          "trips": "Trip planning, participant management, itinerary coordination, and group management.",
+          "gamification": "Calculation of travel statistics, Traveler Score, achievements, Chamuco Points, and global rankings.",
+          "notifications": "Sending push notifications via Firebase Cloud Messaging (FCM) for trip events, passport expiry alerts, achievements, announcements, key date reminders, and platform communications including feature updates and promotional content related exclusively to Chamuco Travel.",
+          "sharing": "Sharing your profile data with trip organizers who hold the explicit 'View Travel Profiles' permission, strictly to facilitate travel logistics for a specific trip.",
+          "export": "Enabling trip organizers to export participant data (name, travel documents, emergency contacts, and health profile) for logistics purposes such as accommodation check-in, transport manifests, or emergency preparedness.",
+          "support": "Customer support, resolution of technical issues, and platform integrity maintenance.",
+          "legal": "Compliance with applicable legal and regulatory obligations."
+        },
+        "sensitiveData": {
+          "title": "4. Sensitive Personal Data",
+          "p1": "Under Article 5 of Colombian Law 1581 of 2012, health-related data — including food allergies, medical conditions, physical limitations, travel-related phobias, and dietary preferences — constitutes sensitive personal data and is subject to heightened protection.",
+          "p2": "Providing health data is entirely voluntary. You may omit any or all health fields without affecting your ability to register or use the Platform. By submitting this data, you give your explicit consent to its processing for the purposes described in Section 3.",
+          "p3": "Health data is shared only with the organizer or co-organizer of a trip you have confirmed participation in, and only if that organizer holds the 'View Travel Profiles' permission. It is never visible to other participants.",
+          "p4": "Your general medical notes are private by default. You may grant a specific trip organizer access to these notes on a trip-by-trip basis through a voluntary, opt-in toggle. The organizer cannot request or demand access — only you can grant it."
+        },
+        "thirdParties": {
+          "title": "5. Disclosure to Third Parties",
+          "p1": "We share personal data only with the following service providers, strictly as necessary for the operation of the Platform:",
+          "googleTitle": "Google LLC / Firebase / Google Cloud Platform",
+          "googleBody": "Authentication (Firebase Authentication), push notifications (Firebase Cloud Messaging), file storage (Cloud Storage), relational database hosting (Cloud SQL on Google Cloud), and application hosting (Cloud Run). Google acts as a Data Processor under its Data Processing and Security Terms.",
+          "facebookTitle": "Meta Platforms, Inc. (Facebook)",
+          "facebookBody": "Authentication via Facebook Sign-In, available as an alternative to Google Sign-In. Only applicable if you choose to register or sign in using Facebook.",
+          "noSale": "We do not sell, rent, trade, or otherwise transfer your personal data to third parties for commercial, marketing, or advertising purposes."
+        },
+        "internationalTransfers": {
+          "title": "6. International Data Transfers",
+          "p1": "Google Cloud Platform and Firebase servers process and store data primarily in the United States. These transfers constitute international transfers of personal data under Article 26 of Law 1581 of 2012.",
+          "p2": "To ensure an adequate level of protection, Chamuco Travel relies on Google's Standard Contractual Clauses and its Data Processing and Security Terms, which establish contractual guarantees for the protection of personal data transferred outside Colombia.",
+          "p3": "By registering and using the Platform, you acknowledge and consent to the transfer and processing of your data in the United States under the data protection safeguards described above."
+        },
+        "minors": {
+          "title": "7. Minors",
+          "p1": "Chamuco Travel is intended exclusively for users who are 18 years of age or older. We do not knowingly collect personal data from individuals under 18.",
+          "p2": "If we become aware that a user under 18 has registered, we will immediately suspend their account and permanently delete their personal data. If you have reason to believe a minor has registered on the Platform, please notify us at admin@chamucotravel.com."
+        },
+        "retention": {
+          "title": "8. Data Retention",
+          "p1": "We retain your personal data for as long as your account remains active on the Platform.",
+          "p2": "When you initiate account deletion, a 30-day recovery period begins. During this period you may reactivate your account and all data is preserved. After 30 days, all personal data associated with your account is permanently and irreversibly deleted from our systems.",
+          "p3": "Immutable audit logs generated by platform support administrator actions are retained for the period required by applicable law, even after account deletion, solely to ensure accountability for administrative operations."
+        },
+        "rights": {
+          "title": "9. Rights of the Data Subject",
+          "intro": "Pursuant to Articles 8 and 22 of Law 1581 of 2012, you have the following rights with respect to your personal data at no cost:",
+          "access": "Right of access: obtain confirmation of whether we hold personal data about you and access a copy of that data.",
+          "correction": "Right of rectification: request correction or updating of inaccurate, incomplete, or outdated data.",
+          "deletion": "Right of erasure: request deletion of your data when it is no longer necessary for the purposes for which it was collected, or when there is no legal obligation to retain it.",
+          "revocation": "Right of revocation: withdraw your consent to the processing of your personal data at any time. Withdrawal does not affect the lawfulness of processing carried out before the withdrawal.",
+          "complaint": "Right to lodge a complaint: file a complaint with the Superintendencia de Industria y Comercio (SIC) — Colombia's data protection supervisory authority — at www.sic.gov.co.",
+          "freeAccess": "Right to free and direct access: access your personal data free of charge at any time.",
+          "howTo": "To exercise any of these rights, send your request to admin@chamucotravel.com with sufficient information to identify you and the specific right you wish to exercise."
+        },
+        "security": {
+          "title": "10. Security Measures",
+          "intro": "We implement the following technical and organizational measures to protect your personal data against unauthorized access, alteration, disclosure, or destruction:",
+          "https": "All communications between the client and server are encrypted using HTTPS/TLS.",
+          "auth": "Firebase ID tokens are verified on every API request via Firebase Admin SDK; no session is trusted without cryptographic verification.",
+          "secrets": "Service credentials and secret keys are stored exclusively in GCP Secret Manager and are never committed to source code or configuration files.",
+          "audit": "All write operations performed by support administrators are recorded in immutable, append-only audit logs.",
+          "rbac": "Role-Based Access Control (RBAC) restricts data access to the minimum required for each role.",
+          "sensitive": "Sensitive data (health information, travel documents, emergency contacts) is accessible only to roles with explicit, trip-scoped permissions."
+        },
+        "organizers": {
+          "title": "11. Data Export by Trip Organizers",
+          "p1": "Trip organizers with the 'View Travel Profiles' permission may export participant data — including legal name, travel documents, emergency contacts, and health profile — for logistics purposes such as accommodation check-in, transport manifests, or emergency preparedness for a specific trip.",
+          "p2": "By accepting an invitation or confirming participation in a trip, you consent to the organizer of that trip accessing and potentially exporting your profile data as described in the visibility table in Section 2.",
+          "p3": "Trip organizers who export participant data are solely responsible for handling it in accordance with applicable law. They must not use exported data for any purpose other than the direct logistics of the trip for which it was obtained."
+        },
+        "changes": {
+          "title": "12. Changes to This Policy",
+          "p1": "We may update this Privacy Policy from time to time to reflect changes in our practices, legal requirements, or platform features. When material changes are made, we will notify you at least 10 calendar days in advance via an in-app notification or by email to the address associated with your account.",
+          "p2": "Continued use of the Platform after the updated Policy takes effect constitutes your acceptance of the changes. If you do not agree with any change, you may delete your account before the new Policy takes effect."
+        },
+        "contact": {
+          "title": "13. Contact and Complaints",
+          "p1": "For any questions, requests, or complaints regarding this Privacy Policy or the processing of your personal data, contact us at:",
+          "email": "admin@chamucotravel.com",
+          "p2": "If you believe your data protection rights have been violated and we have not resolved your complaint satisfactorily, you may file a complaint directly with the Superintendencia de Industria y Comercio (SIC) at www.sic.gov.co."
+        }
+      }
+    },
+    "terms": {
+      "title": "Terms and Conditions of Use",
+      "subtitle": "Last updated: April 13, 2026",
+      "preamble": "These Terms and Conditions of Use (\"Terms\") govern your access to and use of Chamuco Travel, operated by Manuel Nuñez Torres, a natural person domiciled in Colombia. By registering or using the Platform, you agree to be bound by these Terms and our Privacy Policy.",
+      "sections": {
+        "acceptance": {
+          "title": "1. Acceptance of Terms",
+          "p1": "By creating an account, accessing, or using Chamuco Travel (\"the Platform\"), you confirm that you have read, understood, and agreed to these Terms and our Privacy Policy, which is incorporated herein by reference.",
+          "p2": "If you do not agree to these Terms in their entirety, you must not register or use the Platform."
+        },
+        "service": {
+          "title": "2. Description of the Service",
+          "p1": "Chamuco Travel is a group travel coordination platform. It enables users to plan trips, manage participants and invitations, track shared expenses (without processing real monetary transactions), communicate through announcements, and build a personal travel history with achievements and statistics.",
+          "p2": "The Platform includes a gamification system — Traveler Score, Level Points, achievements, Chamuco Points, recognitions, and a Discovery Map — designed to celebrate real travel experiences and group history.",
+          "p3": "Chamuco Travel is in active development. Features may be added, modified, or removed over time. We will make reasonable efforts to notify users of significant changes affecting existing functionality."
+        },
+        "eligibility": {
+          "title": "3. Eligibility",
+          "p1": "You must be at least 18 years of age to register and use Chamuco Travel. By creating an account, you represent and warrant that you are 18 years of age or older.",
+          "p2": "If we discover that a user is under 18 years of age, we will immediately suspend their account and permanently delete their personal data."
+        },
+        "account": {
+          "title": "4. Registration and Account",
+          "p1": "Registration requires authentication via Google Sign-In or Facebook Sign-In through Firebase Authentication. During onboarding, you must choose a unique username (3–30 characters; lowercase letters, numbers, underscores, and hyphens only). Your display name is pre-filled from your OAuth provider and may be edited.",
+          "p2": "You are solely responsible for maintaining the confidentiality of your credentials and for all activities that occur under your account. You agree to notify us immediately of any unauthorized access or suspected security breach at admin@chamucotravel.com.",
+          "p3": "You may link both Google and Facebook sign-in methods to the same Chamuco Travel account."
+        },
+        "acceptableUse": {
+          "title": "5. Acceptable Use",
+          "intro": "You agree to use the Platform only for lawful purposes and in accordance with these Terms. You agree not to:",
+          "illegal": "Use the Platform for any activity that violates Colombian law, international law, or the rights of third parties.",
+          "impersonation": "Impersonate another person, create a false identity, or misrepresent your affiliation with any person or entity.",
+          "harmful": "Post, upload, or transmit content that is defamatory, discriminatory, harassing, obscene, or factually false.",
+          "unauthorized": "Attempt to access, modify, or delete another user's account or personal data without explicit authorization.",
+          "spam": "Use the Platform to send spam, unsolicited commercial communications, or bulk messages.",
+          "scraping": "Scrape, crawl, or systematically extract Platform data using automated means without our prior written consent.",
+          "interference": "Interfere with, disrupt, or attempt to gain unauthorized access to the Platform's infrastructure, servers, or networks.",
+          "consequences": "Violation of these use restrictions may result in immediate account suspension or termination, and may give rise to civil or criminal liability under applicable Colombian law."
+        },
+        "expenses": {
+          "title": "6. Expense Module",
+          "p1": "The expense module is a collaborative accounting ledger designed to help groups record costs and calculate suggested settlement amounts among participants.",
+          "p2": "Chamuco Travel does not process, hold, transfer, or intermediate real monetary transactions of any kind. The calculated balances and settlement suggestions are informational and non-binding.",
+          "p3": "Settlement between participants occurs entirely outside the Platform, through whatever means the participants choose. Chamuco Travel is not a party to any such transaction and bears no responsibility for financial disputes, defaults, or disagreements arising from expenses recorded on the Platform."
+        },
+        "ip": {
+          "title": "7. Intellectual Property",
+          "p1": "All intellectual property rights in the Chamuco Travel brand, trademark, logo, user interface design, source code, algorithms, databases, and original platform content belong exclusively to Manuel Nuñez Torres.",
+          "p2": "You retain ownership of content you create and upload to the Platform (trip notes, group descriptions, profile information, etc.). By submitting content to the Platform, you grant Chamuco Travel a non-exclusive, worldwide, royalty-free, sublicensable license to store, display, and distribute that content within the Platform solely for the purpose of providing the service to you and other users.",
+          "p3": "You may not reproduce, distribute, modify, create derivative works of, publicly display, or commercially exploit any Platform content or technology without prior written authorization."
+        },
+        "gamification": {
+          "title": "8. Gamification System",
+          "p1": "Chamuco Points, Traveler Score, Level Points, achievements, recognitions, and rankings have no monetary value, are non-transferable between users, and cannot be exchanged for cash, goods, or any real-world benefit.",
+          "p2": "Chamuco Travel reserves the right to adjust, recalculate, reset, or remove gamification data — including points, scores, levels, and achievements — at any time, without prior notice, in cases of fraudulent activity, data integrity issues, technical corrections, or significant platform changes.",
+          "p3": "Gamification metrics are derived exclusively from completed trips and verified peer interactions on the Platform. No score, level, achievement, or ranking can be obtained through payment or through engagement with the application itself outside of actual travel."
+        },
+        "notifications": {
+          "title": "9. Communications and Notifications",
+          "p1": "By registering and using Chamuco Travel, you consent to receive push notifications and platform communications via Firebase Cloud Messaging (FCM) and other in-app channels. These communications fall into two categories:",
+          "transactionalTitle": "Transactional and service notifications (core service):",
+          "transactional": {
+            "trips": "Trip invitations, join request decisions, status changes, and cancellations.",
+            "feedback": "Post-trip feedback window opened after a trip is completed.",
+            "passport": "Passport expiry alerts (Expiring Soon and Expired).",
+            "gamification": "Level-up notifications, achievement unlocked, and recognition received.",
+            "keyDates": "Key date reminders set by trip organizers.",
+            "announcements": "Broadcast announcements from trip organizers and group administrators."
+          },
+          "platformTitle": "Platform communications:",
+          "platform": {
+            "news": "Updates about new features, improvements, and changes to the Chamuco Travel platform.",
+            "promotional": "Promotional content and announcements related exclusively to Chamuco Travel — not from third-party advertisers."
+          },
+          "p2": "You may manage your notification preferences from the Platform settings. Disabling certain transactional notifications may affect the functionality of the service.",
+          "p3": "Chamuco Travel does not send notifications on behalf of external third parties and does not use push notifications to advertise products or services outside the Platform."
+        },
+        "privacy": {
+          "title": "10. Privacy and Personal Data",
+          "p1": "The collection, use, storage, and protection of your personal data are governed exclusively by our Privacy Policy, available at chamucotravel.com/privacy-policy, which forms an integral part of these Terms.",
+          "p2": "By accepting these Terms, you expressly authorize the processing of your personal data — including sensitive data categories such as health information — in accordance with the Privacy Policy and applicable Colombian data protection law (Law 1581 of 2012 and its implementing decrees)."
+        },
+        "liability": {
+          "title": "11. Limitation of Liability",
+          "intro": "To the maximum extent permitted by applicable Colombian law, Chamuco Travel and its operator shall not be liable for any indirect, incidental, consequential, or punitive damages arising from:",
+          "decisions": "Decisions made by trip organizers, including decisions about participant acceptance, itinerary design, or logistics.",
+          "userContent": "Loss, damage, or harm arising from inaccurate, incomplete, or misleading information entered by users.",
+          "service": "Interruptions, errors, or unavailability of the Platform caused by factors outside our reasonable control, including third-party service outages (Google, Firebase, Meta), network failures, or force majeure events.",
+          "financial": "Financial losses or disputes arising from use of the expense module or from settlements between participants conducted outside the Platform.",
+          "agreements": "Breach of agreements, commitments, or arrangements made between participants outside or beyond the Platform.",
+          "caveat": "Nothing in these Terms excludes or limits liability for fraud, gross negligence, willful misconduct, or any liability that cannot be lawfully excluded under Colombian consumer protection law (Law 1480 of 2011) or other mandatory statutes."
+        },
+        "termination": {
+          "title": "12. Account Suspension and Termination",
+          "p1": "You may delete your account at any time from within the Platform. A 30-day recovery window begins immediately upon deletion. After 30 days, your account and all associated personal data are permanently and irreversibly deleted.",
+          "p2": "Chamuco Travel may suspend or terminate your account without prior notice if you violate these Terms, engage in fraudulent activity, cause harm to other users, or if required by applicable law or regulatory order. Where reasonably practicable, we will attempt to notify you before suspension.",
+          "p3": "Upon termination, your license to access and use the Platform is revoked immediately. Provisions of these Terms that by their nature survive termination — including intellectual property, limitation of liability, governing law, and dispute resolution — remain in full force and effect."
+        },
+        "modifications": {
+          "title": "13. Modifications to the Terms",
+          "p1": "We may update these Terms at any time to reflect changes in our service, applicable law, or business practices. When material changes are made, we will notify you at least 10 calendar days before the new Terms take effect, via in-app notification or by email to the address associated with your account.",
+          "p2": "Continued use of the Platform after the effective date of the updated Terms constitutes your acceptance of the changes. If you do not agree with any modification, you must stop using the Platform and delete your account before the new Terms take effect."
+        },
+        "governingLaw": {
+          "title": "14. Governing Law and Jurisdiction",
+          "p1": "These Terms are governed by and construed in accordance with the laws of the Republic of Colombia, including but not limited to: Law 527 of 1999 (electronic commerce and digital signatures), Law 1480 of 2011 (Consumer Statute), and Law 1581 of 2012 (Personal Data Protection).",
+          "p2": "Any dispute, controversy, or claim arising out of or in connection with these Terms, or the breach, termination, or invalidity thereof, shall be subject to the jurisdiction of the competent courts of Bogotá D.C., Colombia, or to the Superintendencia de Industria y Comercio (SIC) for matters within its administrative jurisdiction.",
+          "p3": "Disputes specifically related to the processing of personal data may be submitted to the SIC's Data Protection Division (Delegatura para la Protección de Datos Personales) at www.sic.gov.co, in accordance with the procedure established in Law 1581 of 2012."
+        },
+        "contact": {
+          "title": "15. Contact",
+          "p1": "For questions, clarifications, or concerns regarding these Terms and Conditions, contact us at:",
+          "email": "admin@chamucotravel.com",
+          "p2": "We aim to respond to all inquiries within 5 business days."
+        }
+      }
+    }
   }
 }

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -17,7 +17,8 @@
       "confirm": "Confirm",
       "loading": "Loading...",
       "viewMore": "View More",
-      "viewLess": "View Less"
+      "viewLess": "View Less",
+      "backToSignIn": "Back to sign in"
     },
     "navigation": {
       "home": "Home",
@@ -161,7 +162,6 @@
     "sessionExpired": "Your session has expired. Please sign in again."
   },
   "legal": {
-    "backToSignIn": "Back to sign in",
     "privacy": {
       "title": "Privacy Policy",
       "subtitle": "Last updated: April 13, 2026",

--- a/apps/web/src/locales/es.json
+++ b/apps/web/src/locales/es.json
@@ -97,6 +97,10 @@
         "placeholder": "¿Cómo debemos llamarte?"
       },
       "submit": "Crear mi cuenta",
+      "terms": {
+        "accept": "Acepto la <privacyLink>Política de Privacidad</privacyLink> y los <termsLink>Términos y Condiciones</termsLink> de Chamuco Travel.",
+        "required": "Debes aceptar los términos para continuar."
+      },
       "error": {
         "failed": "El registro falló. Por favor intenta de nuevo.",
         "usernameTaken": "Ese nombre de usuario ya está en uso. Por favor elige otro."
@@ -155,5 +159,257 @@
     "unauthorized": "No estás autorizado para acceder a este recurso",
     "networkError": "Error de red. Por favor verifica tu conexión.",
     "sessionExpired": "Tu sesión ha expirado. Por favor inicia sesión nuevamente."
+  },
+  "legal": {
+    "backToSignIn": "Volver al inicio de sesión",
+    "privacy": {
+      "title": "Política de Privacidad y Tratamiento de Datos Personales",
+      "subtitle": "Última actualización: 13 de abril de 2026",
+      "preamble": "Manuel Nuñez Torres, persona natural domiciliada en Colombia, opera la plataforma Chamuco Travel accesible en chamucotravel.com (en adelante, \"Chamuco Travel\" o \"la Plataforma\"). Esta Política de Privacidad describe cómo recopilamos, usamos, almacenamos y protegemos sus datos personales de conformidad con la Ley Estatutaria 1581 de 2012 de Protección de Datos Personales y sus decretos reglamentarios.",
+      "sections": {
+        "controller": {
+          "title": "1. Responsable del Tratamiento",
+          "p1": "El Responsable del Tratamiento de sus datos personales es Manuel Nuñez Torres, persona natural domiciliada en Colombia, que opera bajo la marca Chamuco Travel.",
+          "p2": "Para cualquier pregunta, solicitud o queja relacionada con el tratamiento de sus datos personales, contáctenos en: admin@chamucotravel.com. Responderemos dentro del plazo legalmente establecido (15 días hábiles para consultas; 15 días hábiles para reclamaciones, con una prórroga única de 8 días hábiles adicionales de ser necesaria)."
+        },
+        "dataCollected": {
+          "title": "2. Datos Personales que Recopilamos",
+          "intro": "Recopilamos y tratamos las siguientes categorías de datos personales cuando usted se registra y usa la Plataforma:",
+          "account": {
+            "title": "Datos de Cuenta e Identidad",
+            "body": "Nombre completo y foto de perfil (pre-cargados desde su cuenta de Google o Facebook), correo electrónico, nombre de usuario único elegido en el registro, e identificador de autenticación de Firebase."
+          },
+          "profile": {
+            "title": "Datos del Perfil Personal",
+            "body": "Nombre y apellido legal, fecha de nacimiento, país y ciudad de nacimiento, país y ciudad de residencia actual, número de teléfono en formato internacional, y una biografía pública opcional."
+          },
+          "documents": {
+            "title": "Documentos de Viaje",
+            "body": "Nacionalidad o nacionalidades, número de documento de identidad nacional (cédula, DNI, etc.), número de pasaporte, fecha de expedición del pasaporte y fecha de vencimiento del pasaporte."
+          },
+          "health": {
+            "title": "Datos de Salud (Datos Sensibles)",
+            "body": "Preferencias y restricciones dietarias, alergias alimentarias, fobias relacionadas con viajes, limitaciones físicas, condiciones médicas y notas médicas generales opcionales. Estos datos son clasificados como sensibles según el Artículo 5 de la Ley 1581 de 2012. Consulte la Sección 4 para su tratamiento especial."
+          },
+          "emergency": {
+            "title": "Contactos de Emergencia",
+            "body": "Nombre completo, número de teléfono y relación de cada contacto de emergencia designado."
+          },
+          "loyalty": {
+            "title": "Programas de Fidelidad",
+            "body": "Nombres de programas de fidelidad y números de membresía. Esta información es visible únicamente para usted y nunca se comparte con organizadores u otros usuarios."
+          },
+          "activity": {
+            "title": "Datos de Actividad y Uso",
+            "body": "Viajes creados, unidos y completados; membresías en grupos; estadísticas de viaje (países visitados, distancia recorrida, compañeros de viaje únicos, viajes como organizador); logros desbloqueados; reconocimientos recibidos; y saldo de Puntos Chamuco."
+          },
+          "technical": {
+            "title": "Datos Técnicos y de Preferencias",
+            "body": "Zona horaria de residencia, preferencia de idioma, preferencia de moneda, preferencia de tema de interfaz y marca de tiempo de última actividad."
+          }
+        },
+        "purposes": {
+          "title": "3. Finalidades del Tratamiento",
+          "intro": "Tratamos sus datos personales exclusivamente para las siguientes finalidades:",
+          "auth": "Autenticación y verificación de identidad en cada sesión.",
+          "profile": "Gestión de su perfil de usuario, preferencias y configuración de cuenta.",
+          "trips": "Planificación de viajes, gestión de participantes, coordinación de itinerarios y administración de grupos.",
+          "gamification": "Cálculo de estadísticas de viaje, Puntuación de Viajero, logros, Puntos Chamuco y rankings globales.",
+          "notifications": "Envío de notificaciones push mediante Firebase Cloud Messaging (FCM) para eventos de viaje, alertas de vencimiento de pasaporte, logros, anuncios, recordatorios de fechas clave y comunicaciones de plataforma incluyendo actualizaciones de funcionalidades y contenido promocional relacionado exclusivamente con Chamuco Travel.",
+          "sharing": "Compartir datos de su perfil con organizadores de viajes que tengan el permiso explícito de 'Ver Perfiles de Viaje', únicamente para facilitar la logística de un viaje específico.",
+          "export": "Permitir a los organizadores de viajes exportar datos de participantes (nombre, documentos de viaje, contactos de emergencia y perfil de salud) para fines logísticos como check-in de alojamiento, manifiestos de transporte o preparación para emergencias.",
+          "support": "Atención al cliente, resolución de problemas técnicos y mantenimiento de la integridad de la Plataforma.",
+          "legal": "Cumplimiento de obligaciones legales y regulatorias aplicables."
+        },
+        "sensitiveData": {
+          "title": "4. Datos Sensibles",
+          "p1": "Conforme al Artículo 5 de la Ley Estatutaria 1581 de 2012, los datos relacionados con la salud — incluyendo alergias alimentarias, condiciones médicas, limitaciones físicas, fobias relacionadas con viajes y preferencias dietarias — constituyen datos personales sensibles sujetos a protección reforzada.",
+          "p2": "El suministro de datos de salud es completamente voluntario. Puede omitir cualquier campo de salud sin que ello afecte su capacidad de registrarse o usar la Plataforma. Al proporcionar estos datos, usted otorga su consentimiento explícito para su tratamiento con las finalidades descritas en la Sección 3.",
+          "p3": "Los datos de salud se comparten únicamente con el organizador o co-organizador del viaje en el que usted ha confirmado su participación, y solo si dicho organizador cuenta con el permiso de 'Ver Perfiles de Viaje'. No son visibles para otros participantes.",
+          "p4": "Sus notas médicas generales son privadas por defecto. Puede otorgar acceso a las mismas a un organizador específico de un viaje determinado mediante un interruptor voluntario de activación. El organizador no puede solicitar ni exigir este acceso; solo usted puede concederlo."
+        },
+        "thirdParties": {
+          "title": "5. Divulgación a Terceros",
+          "p1": "Compartimos datos personales únicamente con los siguientes proveedores de servicios, estrictamente en la medida necesaria para el funcionamiento de la Plataforma:",
+          "googleTitle": "Google LLC / Firebase / Google Cloud Platform",
+          "googleBody": "Autenticación (Firebase Authentication), notificaciones push (Firebase Cloud Messaging), almacenamiento de archivos (Cloud Storage), alojamiento de base de datos relacional (Cloud SQL en Google Cloud) y alojamiento de la aplicación (Cloud Run). Google actúa como Encargado del Tratamiento bajo sus Términos de Procesamiento y Seguridad de Datos.",
+          "facebookTitle": "Meta Platforms, Inc. (Facebook)",
+          "facebookBody": "Autenticación mediante Facebook Sign-In, disponible como alternativa a Google Sign-In. Solo aplica si usted elige registrarse o iniciar sesión con Facebook.",
+          "noSale": "No vendemos, alquilamos, intercambiamos ni transferimos sus datos personales a terceros con fines comerciales, de mercadeo o publicidad."
+        },
+        "internationalTransfers": {
+          "title": "6. Transferencias Internacionales de Datos",
+          "p1": "Los servidores de Google Cloud Platform y Firebase procesan y almacenan datos principalmente en los Estados Unidos. Estas transferencias constituyen transferencias internacionales de datos personales según el Artículo 26 de la Ley 1581 de 2012.",
+          "p2": "Para garantizar un nivel adecuado de protección, Chamuco Travel se apoya en las Cláusulas Contractuales Tipo de Google y sus Términos de Procesamiento y Seguridad de Datos, que establecen garantías contractuales para la protección de los datos personales transferidos fuera de Colombia.",
+          "p3": "Al registrarse y usar la Plataforma, usted reconoce y consiente la transferencia y el procesamiento de sus datos en los Estados Unidos bajo las salvaguardas de protección de datos descritas anteriormente."
+        },
+        "minors": {
+          "title": "7. Menores de Edad",
+          "p1": "Chamuco Travel está dirigida exclusivamente a usuarios mayores de 18 años. No recopilamos conscientemente datos personales de menores de edad.",
+          "p2": "Si tenemos conocimiento de que un usuario es menor de 18 años, suspenderemos su cuenta de inmediato y eliminaremos permanentemente sus datos personales. Si tiene razones para creer que un menor se ha registrado en la Plataforma, notifíquenos en admin@chamucotravel.com."
+        },
+        "retention": {
+          "title": "8. Conservación de Datos",
+          "p1": "Conservamos sus datos personales durante el tiempo que su cuenta permanezca activa en la Plataforma.",
+          "p2": "Cuando usted inicia la eliminación de su cuenta, comienza un período de recuperación de 30 días. Durante este período puede reactivar su cuenta y todos los datos se preservan. Transcurridos 30 días, todos los datos personales asociados a su cuenta son eliminados de forma permanente e irreversible de nuestros sistemas.",
+          "p3": "Los registros de auditoría inmutables generados por acciones de administradores de soporte de la plataforma se conservan por el período exigido por la ley aplicable, incluso después de la eliminación de la cuenta, exclusivamente para garantizar la rendición de cuentas de las operaciones administrativas."
+        },
+        "rights": {
+          "title": "9. Derechos del Titular",
+          "intro": "De conformidad con los Artículos 8 y 22 de la Ley 1581 de 2012, usted tiene los siguientes derechos sobre sus datos personales de forma gratuita:",
+          "access": "Derecho de acceso: obtener confirmación de si tratamos datos personales suyos y acceder a una copia de dichos datos.",
+          "correction": "Derecho de rectificación: solicitar la corrección o actualización de datos inexactos, incompletos u desactualizados.",
+          "deletion": "Derecho de supresión: solicitar la eliminación de sus datos cuando ya no sean necesarios para las finalidades para las que fueron recopilados, o cuando no exista obligación legal de conservarlos.",
+          "revocation": "Derecho de revocación: revocar en cualquier momento el consentimiento otorgado para el tratamiento de sus datos personales. La revocación no afecta la licitud del tratamiento realizado antes de la misma.",
+          "complaint": "Derecho de queja: presentar una queja ante la Superintendencia de Industria y Comercio (SIC) — autoridad de supervisión de protección de datos de Colombia — en www.sic.gov.co.",
+          "freeAccess": "Derecho de acceso gratuito y directo: acceder a sus datos personales en cualquier momento sin costo alguno.",
+          "howTo": "Para ejercer cualquiera de estos derechos, envíe su solicitud a admin@chamucotravel.com con información suficiente para identificarle y el derecho específico que desea ejercer."
+        },
+        "security": {
+          "title": "10. Medidas de Seguridad",
+          "intro": "Implementamos las siguientes medidas técnicas y organizativas para proteger sus datos personales frente a accesos no autorizados, alteraciones, divulgación o destrucción:",
+          "https": "Todas las comunicaciones entre el cliente y el servidor se cifran mediante HTTPS/TLS.",
+          "auth": "Los tokens de Firebase son verificados en cada solicitud a la API mediante Firebase Admin SDK; ninguna sesión es confiable sin verificación criptográfica.",
+          "secrets": "Las credenciales de servicio y claves secretas se almacenan exclusivamente en GCP Secret Manager y nunca se comprometen en el código fuente ni en archivos de configuración.",
+          "audit": "Todas las operaciones de escritura realizadas por administradores de soporte se registran en registros de auditoría inmutables de solo adición.",
+          "rbac": "El Control de Acceso Basado en Roles (RBAC) restringe el acceso a datos al mínimo requerido para cada rol.",
+          "sensitive": "Los datos sensibles (información de salud, documentos de viaje, contactos de emergencia) son accesibles únicamente para roles con permisos explícitos asignados por viaje."
+        },
+        "organizers": {
+          "title": "11. Exportación de Datos por Organizadores de Viaje",
+          "p1": "Los organizadores de viaje con el permiso de 'Ver Perfiles de Viaje' pueden exportar datos de participantes — incluyendo nombre legal, documentos de viaje, contactos de emergencia y perfil de salud — para fines logísticos como check-in de alojamiento, manifiestos de transporte o preparación para emergencias en un viaje específico.",
+          "p2": "Al aceptar una invitación o confirmar su participación en un viaje, usted consiente que el organizador de ese viaje acceda y potencialmente exporte sus datos de perfil conforme a lo descrito en la tabla de visibilidad de la Sección 2.",
+          "p3": "Los organizadores de viaje que exporten datos de participantes son exclusivamente responsables de tratarlos de conformidad con la ley aplicable. No deben usar los datos exportados para ningún fin distinto a la logística directa del viaje para el que fueron obtenidos."
+        },
+        "changes": {
+          "title": "12. Cambios a Esta Política",
+          "p1": "Podemos actualizar esta Política de Privacidad periódicamente para reflejar cambios en nuestras prácticas, requisitos legales o funcionalidades de la plataforma. Cuando se realicen cambios materiales, le notificaremos con al menos 10 días calendario de anticipación mediante una notificación en la aplicación o por correo electrónico a la dirección asociada a su cuenta.",
+          "p2": "El uso continuado de la Plataforma después de que la Política actualizada entre en vigencia constituye su aceptación de los cambios. Si no está de acuerdo con algún cambio, puede eliminar su cuenta antes de que la nueva Política entre en vigor."
+        },
+        "contact": {
+          "title": "13. Contacto y Reclamaciones",
+          "p1": "Para cualquier pregunta, solicitud o queja relacionada con esta Política de Privacidad o el tratamiento de sus datos personales, contáctenos en:",
+          "email": "admin@chamucotravel.com",
+          "p2": "Si considera que sus derechos de protección de datos han sido vulnerados y no hemos resuelto su queja satisfactoriamente, puede presentar una reclamación directamente ante la Superintendencia de Industria y Comercio (SIC) en www.sic.gov.co."
+        }
+      }
+    },
+    "terms": {
+      "title": "Términos y Condiciones de Uso",
+      "subtitle": "Última actualización: 13 de abril de 2026",
+      "preamble": "Estos Términos y Condiciones de Uso (\"Términos\") rigen el acceso y uso de Chamuco Travel, operado por Manuel Nuñez Torres, persona natural domiciliada en Colombia. Al registrarse o usar la Plataforma, usted acepta quedar vinculado por estos Términos y nuestra Política de Privacidad.",
+      "sections": {
+        "acceptance": {
+          "title": "1. Aceptación de los Términos",
+          "p1": "Al crear una cuenta, acceder o usar Chamuco Travel (\"la Plataforma\"), usted confirma que ha leído, comprendido y aceptado estos Términos y nuestra Política de Privacidad, la cual se incorpora al presente por referencia.",
+          "p2": "Si no está de acuerdo con estos Términos en su totalidad, no debe registrarse ni usar la Plataforma."
+        },
+        "service": {
+          "title": "2. Descripción del Servicio",
+          "p1": "Chamuco Travel es una plataforma de coordinación de viajes grupales. Permite a los usuarios planificar viajes, gestionar participantes e invitaciones, registrar gastos compartidos (sin procesar transacciones monetarias reales), comunicarse mediante anuncios y construir un historial de viajes personal con logros y estadísticas.",
+          "p2": "La Plataforma incluye un sistema de gamificación — Puntuación de Viajero, Puntos de Nivel, logros, Puntos Chamuco, reconocimientos y un Mapa de Descubrimiento — diseñado para celebrar experiencias de viaje reales e historia grupal.",
+          "p3": "Chamuco Travel está en desarrollo activo. Las funcionalidades pueden añadirse, modificarse o eliminarse con el tiempo. Haremos esfuerzos razonables para notificar a los usuarios sobre cambios significativos que afecten funcionalidades existentes."
+        },
+        "eligibility": {
+          "title": "3. Elegibilidad",
+          "p1": "Debe tener al menos 18 años de edad para registrarse y usar Chamuco Travel. Al crear una cuenta, usted declara y garantiza que tiene 18 años de edad o más.",
+          "p2": "Si descubrimos que un usuario es menor de 18 años, suspenderemos su cuenta de inmediato y eliminaremos permanentemente sus datos personales."
+        },
+        "account": {
+          "title": "4. Registro y Cuenta",
+          "p1": "El registro requiere autenticación mediante Google Sign-In o Facebook Sign-In a través de Firebase Authentication. Durante el proceso de incorporación, debe elegir un nombre de usuario único (3–30 caracteres; solo letras minúsculas, números, guiones bajos y guiones). Su nombre para mostrar se pre-carga desde su proveedor OAuth y puede editarse.",
+          "p2": "Usted es el único responsable de mantener la confidencialidad de sus credenciales y de todas las actividades que ocurran bajo su cuenta. Acepta notificarnos de inmediato sobre cualquier acceso no autorizado o sospecha de vulneración de seguridad en admin@chamucotravel.com.",
+          "p3": "Puede vincular tanto el inicio de sesión de Google como el de Facebook a la misma cuenta de Chamuco Travel."
+        },
+        "acceptableUse": {
+          "title": "5. Uso Aceptable",
+          "intro": "Acepta usar la Plataforma únicamente para fines lícitos y de conformidad con estos Términos. Acepta no:",
+          "illegal": "Usar la Plataforma para cualquier actividad que infrinja la legislación colombiana, el derecho internacional o los derechos de terceros.",
+          "impersonation": "Suplantar a otra persona, crear una identidad falsa o tergiversar su afiliación con cualquier persona o entidad.",
+          "harmful": "Publicar, cargar o transmitir contenido difamatorio, discriminatorio, acosador, obsceno o factualmente falso.",
+          "unauthorized": "Intentar acceder, modificar o eliminar la cuenta o los datos personales de otro usuario sin autorización explícita.",
+          "spam": "Usar la Plataforma para enviar spam, comunicaciones comerciales no solicitadas o mensajes masivos.",
+          "scraping": "Extraer, rastrear o recopilar sistemáticamente datos de la Plataforma mediante medios automatizados sin nuestro consentimiento previo por escrito.",
+          "interference": "Interferir, interrumpir o intentar acceder de forma no autorizada a la infraestructura, servidores o redes de la Plataforma.",
+          "consequences": "La violación de estas restricciones de uso puede resultar en la suspensión o terminación inmediata de su cuenta, y puede dar lugar a responsabilidad civil o penal bajo la legislación colombiana aplicable."
+        },
+        "expenses": {
+          "title": "6. Módulo de Gastos",
+          "p1": "El módulo de gastos es un libro contable colaborativo diseñado para ayudar a los grupos a registrar costos y calcular montos sugeridos de liquidación entre participantes.",
+          "p2": "Chamuco Travel no procesa, retiene, transfiere ni intermedia transacciones monetarias reales de ningún tipo. Los saldos calculados y las sugerencias de liquidación son informativos y no vinculantes.",
+          "p3": "La liquidación entre participantes se realiza enteramente fuera de la Plataforma, por los medios que los participantes elijan. Chamuco Travel no es parte de ninguna transacción de este tipo y no asume responsabilidad por disputas financieras, incumplimientos o desacuerdos derivados de gastos registrados en la Plataforma."
+        },
+        "ip": {
+          "title": "7. Propiedad Intelectual",
+          "p1": "Todos los derechos de propiedad intelectual sobre la marca Chamuco Travel, logo, diseño de interfaz de usuario, código fuente, algoritmos, bases de datos y contenido original de la Plataforma pertenecen exclusivamente a Manuel Nuñez Torres.",
+          "p2": "Usted conserva la propiedad del contenido que crea y carga en la Plataforma (notas de viaje, descripciones de grupos, información de perfil, etc.). Al enviar contenido a la Plataforma, otorga a Chamuco Travel una licencia no exclusiva, mundial, libre de regalías y sublicenciable para almacenar, mostrar y distribuir dicho contenido dentro de la Plataforma, exclusivamente con el fin de prestarle el servicio a usted y a otros usuarios.",
+          "p3": "No puede reproducir, distribuir, modificar, crear obras derivadas, exhibir públicamente ni explotar comercialmente ningún contenido o tecnología de la Plataforma sin autorización previa y por escrito."
+        },
+        "gamification": {
+          "title": "8. Sistema de Gamificación",
+          "p1": "Los Puntos Chamuco, la Puntuación de Viajero, los Puntos de Nivel, los logros, los reconocimientos y los rankings no tienen valor monetario, no son transferibles entre usuarios y no pueden canjearse por dinero en efectivo, bienes ni ningún beneficio real.",
+          "p2": "Chamuco Travel se reserva el derecho de ajustar, recalcular, restablecer o eliminar datos de gamificación — incluyendo puntos, puntuaciones, niveles y logros — en cualquier momento y sin previo aviso, en casos de actividad fraudulenta, problemas de integridad de datos, correcciones técnicas o cambios significativos en la plataforma.",
+          "p3": "Las métricas de gamificación se derivan exclusivamente de viajes completados e interacciones verificadas entre pares en la Plataforma. Ninguna puntuación, nivel, logro o ranking puede obtenerse mediante pago ni a través de la interacción con la aplicación misma al margen de viajes reales."
+        },
+        "notifications": {
+          "title": "9. Comunicaciones y Notificaciones",
+          "p1": "Al registrarse y usar Chamuco Travel, usted consiente recibir notificaciones push y comunicaciones de la plataforma mediante Firebase Cloud Messaging (FCM) y otros canales disponibles dentro de la app. Estas comunicaciones se dividen en dos categorías:",
+          "transactionalTitle": "Notificaciones transaccionales y de servicio (servicio básico):",
+          "transactional": {
+            "trips": "Invitaciones a viajes, respuestas a solicitudes de participación, cambios de estado y cancelaciones.",
+            "feedback": "Apertura de ventana de retroalimentación post-viaje al completar un viaje.",
+            "passport": "Alertas de vencimiento de pasaporte (Próximo a Vencer y Vencido).",
+            "gamification": "Notificaciones de subida de nivel, logro desbloqueado y reconocimiento recibido.",
+            "keyDates": "Recordatorios de fechas clave configurados por los organizadores del viaje.",
+            "announcements": "Anuncios de difusión de organizadores de viaje y administradores de grupo."
+          },
+          "platformTitle": "Comunicaciones de plataforma:",
+          "platform": {
+            "news": "Actualizaciones sobre nuevas funcionalidades, mejoras y cambios en la plataforma Chamuco Travel.",
+            "promotional": "Contenido promocional y anuncios relacionados exclusivamente con Chamuco Travel — sin publicidad de terceros externos."
+          },
+          "p2": "Puede gestionar sus preferencias de notificación desde la configuración de la Plataforma. Desactivar ciertas notificaciones transaccionales puede afectar la funcionalidad del servicio.",
+          "p3": "Chamuco Travel no envía notificaciones en nombre de terceros externos y no usa notificaciones push para publicitar productos o servicios ajenos a la Plataforma."
+        },
+        "privacy": {
+          "title": "10. Privacidad y Datos Personales",
+          "p1": "La recopilación, uso, almacenamiento y protección de sus datos personales se rigen exclusivamente por nuestra Política de Privacidad, disponible en chamucotravel.com/privacy-policy, la cual forma parte integral de estos Términos.",
+          "p2": "Al aceptar estos Términos, usted autoriza expresamente el tratamiento de sus datos personales — incluyendo categorías de datos sensibles como información de salud — de conformidad con la Política de Privacidad y la legislación colombiana de protección de datos aplicable (Ley 1581 de 2012 y sus decretos reglamentarios)."
+        },
+        "liability": {
+          "title": "11. Limitación de Responsabilidad",
+          "intro": "En la máxima medida permitida por la legislación colombiana aplicable, Chamuco Travel y su operador no serán responsables por daños indirectos, incidentales, consecuentes o punitivos derivados de:",
+          "decisions": "Decisiones tomadas por organizadores de viajes, incluyendo decisiones sobre aceptación de participantes, diseño de itinerarios o logística.",
+          "userContent": "Pérdidas, daños o perjuicios derivados de información inexacta, incompleta o engañosa introducida por los usuarios.",
+          "service": "Interrupciones, errores o indisponibilidad de la Plataforma causados por factores fuera de nuestro control razonable, incluyendo interrupciones de servicios de terceros (Google, Firebase, Meta), fallas de red o eventos de fuerza mayor.",
+          "financial": "Pérdidas financieras o disputas derivadas del uso del módulo de gastos o de liquidaciones entre participantes realizadas fuera de la Plataforma.",
+          "agreements": "Incumplimiento de acuerdos, compromisos o arreglos realizados entre participantes fuera o más allá de la Plataforma.",
+          "caveat": "Nada de lo contenido en estos Términos excluye ni limita la responsabilidad por fraude, negligencia grave, dolo o cualquier responsabilidad que no pueda ser excluida lícitamente bajo la Ley 1480 de 2011 (Estatuto del Consumidor) u otras normas imperativas colombianas."
+        },
+        "termination": {
+          "title": "12. Suspensión y Terminación de Cuenta",
+          "p1": "Puede eliminar su cuenta en cualquier momento desde dentro de la Plataforma. Inmediatamente después de la eliminación comienza un período de recuperación de 30 días. Transcurridos 30 días, su cuenta y todos los datos personales asociados son eliminados de forma permanente e irreversible.",
+          "p2": "Chamuco Travel puede suspender o terminar su cuenta sin previo aviso si usted viola estos Términos, realiza actividades fraudulentas, causa daños a otros usuarios o si así lo requiere la ley o una orden regulatoria aplicable. En la medida en que sea razonablemente posible, intentaremos notificarle antes de la suspensión.",
+          "p3": "Tras la terminación, su licencia para acceder y usar la Plataforma queda revocada de inmediato. Las disposiciones de estos Términos que por su naturaleza deban sobrevivir a la terminación — incluyendo propiedad intelectual, limitación de responsabilidad, ley aplicable y resolución de disputas — permanecerán en plena vigencia y efecto."
+        },
+        "modifications": {
+          "title": "13. Modificaciones a los Términos",
+          "p1": "Podemos actualizar estos Términos en cualquier momento para reflejar cambios en nuestro servicio, la legislación aplicable o nuestras prácticas comerciales. Cuando se realicen cambios materiales, le notificaremos con al menos 10 días calendario antes de que los nuevos Términos entren en vigencia, mediante notificación en la aplicación o por correo electrónico a la dirección asociada a su cuenta.",
+          "p2": "El uso continuado de la Plataforma después de la fecha de vigencia de los Términos actualizados constituye su aceptación de los cambios. Si no está de acuerdo con alguna modificación, debe dejar de usar la Plataforma y eliminar su cuenta antes de que los nuevos Términos entren en vigor."
+        },
+        "governingLaw": {
+          "title": "14. Ley Aplicable y Jurisdicción",
+          "p1": "Estos Términos se rigen e interpretan de conformidad con las leyes de la República de Colombia, incluyendo pero no limitado a: la Ley 527 de 1999 (comercio electrónico y firmas digitales), la Ley 1480 de 2011 (Estatuto del Consumidor) y la Ley 1581 de 2012 (Protección de Datos Personales).",
+          "p2": "Cualquier disputa, controversia o reclamación que surja de o en relación con estos Términos, o su incumplimiento, terminación o nulidad, estará sujeta a la jurisdicción de los jueces competentes de Bogotá D.C., Colombia, o ante la Superintendencia de Industria y Comercio (SIC) para los asuntos de su competencia administrativa.",
+          "p3": "Las disputas relacionadas específicamente con el tratamiento de datos personales pueden someterse ante la Delegatura para la Protección de Datos Personales de la SIC en www.sic.gov.co, de conformidad con el procedimiento establecido en la Ley 1581 de 2012."
+        },
+        "contact": {
+          "title": "15. Contacto",
+          "p1": "Para preguntas, aclaraciones o inquietudes sobre estos Términos y Condiciones, contáctenos en:",
+          "email": "admin@chamucotravel.com",
+          "p2": "Nuestro objetivo es responder a todas las consultas dentro de los 5 días hábiles siguientes."
+        }
+      }
+    }
   }
 }

--- a/apps/web/src/locales/es.json
+++ b/apps/web/src/locales/es.json
@@ -17,7 +17,8 @@
       "confirm": "Confirmar",
       "loading": "Cargando...",
       "viewMore": "Ver Más",
-      "viewLess": "Ver Menos"
+      "viewLess": "Ver Menos",
+      "backToSignIn": "Volver al inicio de sesión"
     },
     "navigation": {
       "home": "Inicio",
@@ -161,7 +162,6 @@
     "sessionExpired": "Tu sesión ha expirado. Por favor inicia sesión nuevamente."
   },
   "legal": {
-    "backToSignIn": "Volver al inicio de sesión",
     "privacy": {
       "title": "Política de Privacidad y Tratamiento de Datos Personales",
       "subtitle": "Última actualización: 13 de abril de 2026",

--- a/apps/web/src/middleware.test.ts
+++ b/apps/web/src/middleware.test.ts
@@ -156,6 +156,34 @@ describe('middleware', () => {
     });
   });
 
+  describe.each(['/privacy-policy', '/terms-of-service'])('%s — public legal page', (route) => {
+    it('calls NextResponse.next() when unauthenticated (no cookies)', () => {
+      const request = makeRequest(`https://app.chamucotravel.com${route}`);
+      middleware(request);
+      expect(mockNext).toHaveBeenCalledOnce();
+      expect(mockRedirect).not.toHaveBeenCalled();
+    });
+
+    it('calls NextResponse.next() when authenticated but not registered', () => {
+      const request = makeRequest(`https://app.chamucotravel.com${route}`, {
+        'chamuco-auth': '1',
+      });
+      middleware(request);
+      expect(mockNext).toHaveBeenCalledOnce();
+      expect(mockRedirect).not.toHaveBeenCalled();
+    });
+
+    it('calls NextResponse.next() when fully authenticated', () => {
+      const request = makeRequest(`https://app.chamucotravel.com${route}`, {
+        'chamuco-auth': '1',
+        'chamuco-registered': '1',
+      });
+      middleware(request);
+      expect(mockNext).toHaveBeenCalledOnce();
+      expect(mockRedirect).not.toHaveBeenCalled();
+    });
+  });
+
   describe('protected routes (e.g. /, /trips, /profile/settings)', () => {
     it('redirects unauthenticated request to /sign-in', () => {
       const request = makeRequest('https://app.chamucotravel.com/');

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -33,6 +33,11 @@ export function middleware(request: NextRequest): NextResponse {
     return NextResponse.redirect(new URL('/', request.url));
   }
 
+  // Public legal pages — always accessible regardless of auth state
+  if (pathname === '/privacy-policy' || pathname === '/terms-of-service') {
+    return NextResponse.next();
+  }
+
   if (pathname === '/onboarding') {
     if (!isAuthenticated) return NextResponse.redirect(new URL('/sign-in', request.url));
     if (isRegistered) return NextResponse.redirect(new URL('/', request.url));

--- a/documentation/legal/legal-pages.md
+++ b/documentation/legal/legal-pages.md
@@ -1,0 +1,156 @@
+# Legal Pages — Privacy Policy & Terms of Service
+
+**Status:** Implemented (MVP)
+**Last Updated:** 2026-04-13
+**Applicable Law:** Ley 1581 de 2012 · Decreto 1074 de 2015 (Título 2, Cap. 25) · Ley 527 de 1999 · Ley 1480 de 2011
+
+---
+
+## Overview
+
+Chamuco Travel is operated by a Colombian data controller and is therefore subject to Colombian data protection law (Habeas Data — Ley 1581 de 2012). Two public legal pages have been implemented:
+
+| Page                 | URL                 | Accessible without auth |
+| -------------------- | ------------------- | ----------------------- |
+| Privacy Policy       | `/privacy-policy`   | Yes                     |
+| Terms and Conditions | `/terms-of-service` | Yes                     |
+
+Both pages are bilingual (Spanish / English), switch with the app language toggle, and render without nav chrome (logo + language/theme toggles only).
+
+---
+
+## Data Controller
+
+| Field   | Value                                                       |
+| ------- | ----------------------------------------------------------- |
+| Name    | Manuel Nuñez Torres                                         |
+| Type    | Persona natural domiciliada en Colombia                     |
+| NIT     | Pending — must be updated to legal entity NIT before launch |
+| Contact | admin@chamucotravel.com                                     |
+| Brand   | Chamuco Travel                                              |
+| Domain  | chamucotravel.com                                           |
+
+---
+
+## Privacy Policy — Section Summary
+
+| Section                    | Key Obligation                                                                                                      |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| 1. Data Controller         | Identity + contact (Art. 17, Ley 1581)                                                                              |
+| 2. Data Collected          | 8 categories: account, profile, documents, **health (sensitive)**, emergency contacts, loyalty, activity, technical |
+| 3. Purposes                | Listed exhaustively — principle of purpose limitation (Art. 4)                                                      |
+| 4. Sensitive Data          | Explicit consent, voluntary, shared only with authorized organizers (Art. 5–6)                                      |
+| 5. Third Parties           | Google/GCP + Meta/Facebook. No sale of data                                                                         |
+| 6. International Transfers | Google SCCs — US servers (Art. 26)                                                                                  |
+| 7. Minors                  | 18+ only. Account deletion if underage discovered                                                                   |
+| 8. Retention               | Active account + 30-day grace on deletion, then permanent erasure                                                   |
+| 9. Rights of Data Subject  | Access · Rectification · Erasure · Revocation · SIC complaint · Free access (Art. 8 + 22)                           |
+| 10. Security               | HTTPS · Firebase token verification · GCP Secret Manager · RBAC · Immutable audit logs                              |
+| 11. Organizer Export       | Consent given at trip join; organizer responsible for exported data                                                 |
+| 12. Policy Changes         | 10-day notice before material changes                                                                               |
+| 13. Contact & Complaints   | admin@chamucotravel.com · www.sic.gov.co                                                                            |
+
+---
+
+## Terms of Service — Section Summary
+
+| Section                           | Key Clause                                                                             |
+| --------------------------------- | -------------------------------------------------------------------------------------- |
+| 1. Acceptance                     | Binding on registration                                                                |
+| 2. Service                        | Group travel coordination, no real money processed                                     |
+| 3. Eligibility                    | 18+ only                                                                               |
+| 4. Account                        | Google / Facebook OAuth; username rules; credential responsibility                     |
+| 5. Acceptable Use                 | 7 prohibited categories + consequence clause                                           |
+| 6. Expense Module                 | Collaborative ledger only — no financial intermediation                                |
+| 7. Intellectual Property          | Operator retains platform IP; user retains content ownership                           |
+| 8. Gamification                   | No monetary value; no transfer; operator may adjust                                    |
+| 9. Communications & Notifications | Consent to transactional + platform/promotional push notifications; no third-party ads |
+| 10. Privacy                       | Reference to Privacy Policy; explicit consent for sensitive data                       |
+| 11. Liability                     | Limited — 5 excluded categories + Colombian law caveat                                 |
+| 12. Termination                   | 30-day recovery window; operator suspension rights                                     |
+| 13. Modifications                 | 10-day notice before material changes                                                  |
+| 14. Governing Law                 | Republic of Colombia; Bogotá D.C. courts; SIC jurisdiction                             |
+| 15. Contact                       | admin@chamucotravel.com                                                                |
+
+---
+
+## Consent at Registration
+
+The user must actively accept both documents before completing onboarding. This is implemented as a **mandatory checkbox** on the onboarding page (`/onboarding`) that links to both legal pages (opens in new tab). The submit button is disabled until the checkbox is checked.
+
+**Implementation:** `apps/web/src/app/onboarding/page.tsx` — `termsAccepted` boolean state gates the submit button.
+
+---
+
+## Where Legal Links Should Appear
+
+The following locations should display links to the Privacy Policy and/or Terms of Service. Items marked ✅ are already implemented; items marked ⬜ are pending.
+
+### ✅ Implemented
+
+| Location                         | Link(s) shown          | Notes                             |
+| -------------------------------- | ---------------------- | --------------------------------- |
+| Onboarding — acceptance checkbox | Privacy Policy + Terms | Required to complete registration |
+| Privacy Policy page footer       | Terms and Conditions   | Cross-link                        |
+| Terms of Service page footer     | Privacy Policy         | Cross-link                        |
+
+### ⬜ Pending
+
+| Location                               | Link(s) to add                             | Priority                                                              |
+| -------------------------------------- | ------------------------------------------ | --------------------------------------------------------------------- |
+| Sign-in page footer                    | Privacy Policy + Terms                     | High — many regulatory frameworks require links before authentication |
+| App footer / settings screen           | Privacy Policy + Terms                     | High — must be findable from within the app at all times              |
+| Account deletion confirmation dialog   | Privacy Policy (data retention clause)     | Medium — user should know their data will be deleted per the policy   |
+| Email notifications footer             | Privacy Policy + Terms                     | Medium — standard requirement for transactional and marketing emails  |
+| Push notification opt-in prompt        | Privacy Policy                             | Medium — FCM consent notice                                           |
+| App Store / Google Play listing        | Privacy Policy URL                         | High — required by both Apple App Store and Google Play policies      |
+| Onboarding — health data fields        | Privacy Policy (Section 4, sensitive data) | Medium — contextual notice when collecting sensitive data             |
+| Organizer "Export participants" action | Privacy Policy (Section 11)                | Medium — remind organizer of their responsibilities at export time    |
+
+---
+
+## Regulatory Compliance Checklist
+
+### Before Launch (Mandatory)
+
+- [ ] **Update Data Controller identity** — replace "persona natural" with the registered legal entity name and NIT once the company is constituted.
+- [ ] **Register databases with SIC (RNBD)** — _Registro Nacional de Bases de Datos_ is mandatory for companies with more than 5 employees. Register at [www.sic.gov.co](https://www.sic.gov.co) before scaling.
+- [ ] **Add legal links to sign-in page** — required to be accessible before authentication.
+- [ ] **Add legal links to app footer / settings** — must be reachable from within the authenticated app at all times (Art. 15, Ley 1581).
+- [ ] **Add Privacy Policy URL to App Store and Google Play listings** — both stores require it for apps that collect personal data.
+
+### Before Adding New Data Categories
+
+- [ ] Update Section 2 of the Privacy Policy for any new data category collected.
+- [ ] If the new data is sensitive (health, biometric, financial), update Section 4 and add explicit consent UI.
+- [ ] Re-evaluate international transfer obligations if new third-party processors are added.
+
+### Periodic Reviews
+
+- [ ] **Annual review** of the Privacy Policy and Terms of Service for changes in Colombian regulations.
+- [ ] **After any significant feature launch** that involves new data processing (messaging, payments, etc.).
+
+---
+
+## Response Time Obligations (Ley 1581, Art. 22)
+
+| Request type                                          | Legal deadline                                   |
+| ----------------------------------------------------- | ------------------------------------------------ |
+| Consulta (data access query)                          | 10 business days (extendable 5 more with notice) |
+| Reclamación (claim: correction, deletion, revocation) | 15 business days (extendable 8 more with notice) |
+
+All incoming requests to admin@chamucotravel.com related to personal data must be logged with receipt date to track these deadlines.
+
+---
+
+## Implementation Files
+
+| File                                               | Purpose                          |
+| -------------------------------------------------- | -------------------------------- |
+| `apps/web/src/app/privacy-policy/page.tsx`         | Privacy Policy page component    |
+| `apps/web/src/app/terms-of-service/page.tsx`       | Terms of Service page component  |
+| `apps/web/src/app/onboarding/page.tsx`             | Checkbox consent at registration |
+| `apps/web/src/locales/en.json` → `legal` namespace | English legal text               |
+| `apps/web/src/locales/es.json` → `legal` namespace | Spanish legal text               |
+| `apps/web/src/middleware.ts`                       | Public access for legal routes   |
+| `apps/web/src/components/layout/AppShell.tsx`      | No nav chrome on legal pages     |

--- a/scripts/validate-i18n-keys.mjs
+++ b/scripts/validate-i18n-keys.mjs
@@ -18,7 +18,7 @@ const WEB_DIR = 'apps/web';
 const SRC_DIR = join(WEB_DIR, 'src');
 const LOCALES_DIR = join(WEB_DIR, 'src', 'locales');
 
-const KNOWN_NAMESPACES = ['auth', 'trips', 'groups', 'profile', 'errors', 'common', 'explore', 'legal'];
+const KNOWN_NAMESPACES = ['auth', 'trips', 'groups', 'profile', 'errors', 'common', 'explore'];
 const EXPLICIT_NS_PATTERN = new RegExp(`^(${KNOWN_NAMESPACES.join('|')})\\\.`);
 
 console.log(`${BLUE}🔍 Validating i18n keys...${NC}\n`);

--- a/scripts/validate-i18n-keys.mjs
+++ b/scripts/validate-i18n-keys.mjs
@@ -18,7 +18,7 @@ const WEB_DIR = 'apps/web';
 const SRC_DIR = join(WEB_DIR, 'src');
 const LOCALES_DIR = join(WEB_DIR, 'src', 'locales');
 
-const KNOWN_NAMESPACES = ['auth', 'trips', 'groups', 'profile', 'errors', 'common', 'explore'];
+const KNOWN_NAMESPACES = ['auth', 'trips', 'groups', 'profile', 'errors', 'common', 'explore', 'legal'];
 const EXPLICIT_NS_PATTERN = new RegExp(`^(${KNOWN_NAMESPACES.join('|')})\\\.`);
 
 console.log(`${BLUE}🔍 Validating i18n keys...${NC}\n`);
@@ -44,14 +44,24 @@ for (const file of sourceFiles) {
     .filter((line) => !line.includes('eslint-disable'))
     .join('\n');
 
-  // Detect namespace from useTranslation('namespace') — first match wins
-  const nsMatch = content.match(/useTranslation\(['"]([a-zA-Z0-9_-]+)['"]\)/);
-  const namespace = nsMatch ? nsMatch[1] : 'common';
+  // Detect namespace from useTranslation('namespace') or useTranslation(['ns1', 'ns2'])
+  // For the array form, the first element is the default namespace.
+  let namespace = 'common';
+  const singleNsMatch = content.match(/useTranslation\(['"]([a-zA-Z0-9_-]+)['"]\)/);
+  if (singleNsMatch) {
+    namespace = singleNsMatch[1];
+  } else {
+    const arrayNsMatch = content.match(/useTranslation\(\s*\[\s*['"]([a-zA-Z0-9_-]+)['"]/);
+    if (arrayNsMatch) namespace = arrayNsMatch[1];
+  }
 
-  // Extract all t('key') calls
-  for (const match of filteredContent.matchAll(/t\(['"]([a-zA-Z0-9._-]+)['"]\)/g)) {
+  // Extract all t('key') calls, including explicit namespace prefix (e.g. 'common:actions.save')
+  for (const match of filteredContent.matchAll(/t\(['"]([a-zA-Z0-9._:-]+)['"]\)/g)) {
     const key = match[1];
-    if (EXPLICIT_NS_PATTERN.test(key)) {
+    if (key.includes(':')) {
+      // Explicit namespace prefix — normalise colon to dot: common:actions.save → common.actions.save
+      usedKeys.add(key.replace(':', '.'));
+    } else if (EXPLICIT_NS_PATTERN.test(key)) {
       usedKeys.add(key);
     } else if (key.includes('.')) {
       usedKeys.add(`${namespace}.${key}`);


### PR DESCRIPTION
## Summary

Adds public Privacy Policy (`/privacy-policy`) and Terms of Service (`/terms-of-service`) pages required by Colombian Ley 1581 de 2012 (Habeas Data). The app collects sensitive personal data (health information, passport details, emergency contacts), so publicly accessible legal pages and explicit registration consent are mandatory before collecting any data.

## Changes

**New legal pages**
- `/privacy-policy` — 13-section policy covering data controller identity, 8 data categories (including sensitive health data), third parties (Google/GCP + Meta/Facebook), international transfers via Google SCCs, Habeas Data rights, and organizer export consent
- `/terms-of-service` — 15-section ToS including a dedicated Communications & Notifications clause (transactional + platform-only promotional; no third-party ads), expense ledger disclaimer, gamification no-monetary-value clause, and governing law (República de Colombia / Bogotá D.C. courts)
- Both pages are bilingual (ES/EN), language-toggle aware, render without nav chrome, and are publicly accessible without authentication

**Onboarding consent gate**
- Mandatory acceptance checkbox using `Trans` component with links to both legal pages (open in new tab)
- "Create my account" button remains disabled until checkbox is checked
- `termsAccepted` state added to `OnboardingPage`

**Infrastructure**
- `middleware.ts`: bypass legal routes regardless of auth state
- `AppShell.tsx`: legal pages added to `AUTH_PATHS` (no nav chrome)
- `locales/en.json` + `locales/es.json`: new `legal` namespace with full bilingual content for both documents

**Documentation**
- `documentation/legal/legal-pages.md`: compliance checklist, data controller info, pending link placements (sign-in footer, in-app settings, app stores), response time obligations (Art. 22 Ley 1581), implementation file index

## Testing

- All 391 existing tests pass; 4 new tests added to `onboarding/page.test.tsx`:
  - Terms checkbox renders unchecked by default
  - Submit button disabled when terms not accepted (even with valid username + display name)
  - Checking the checkbox enables the submit button when all other fields are valid
  - `Trans` mock added to the `react-i18next` mock factory
- Updated `renderFormWithAvailableUsername` helper to check the terms checkbox, and updated the "cancel button disabled while isSubmitting" test to check terms before submitting

## Notes

- NIT field in the Privacy Policy is marked as "Pending" — must be updated to the registered legal entity NIT before launch (tracked in the compliance checklist)
- Several link placements are still pending (sign-in footer, app settings, app stores) — documented as ⬜ items in `documentation/legal/legal-pages.md`

Closes #121