### PR TITLE
ci: restore pnpm audit security check

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -69,12 +69,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      # TODO: Restore when pnpm 11 is stable (Node 22 already satisfied).
-      #       pnpm 10.x uses retired npm audit endpoints (HTTP 410).
-      #       Tracked: https://github.com/pnpm/pnpm/issues/11265
-      #       Vulnerability scanning handled by Dependabot (.github/dependabot.yml).
-      # - name: Audit dependencies for vulnerabilities
-      #   run: pnpm audit --audit-level high
+      - name: Audit dependencies for vulnerabilities
+        run: pnpm audit --audit-level high
 
       - name: Build workspace packages
         run: pnpm --filter @chamuco/shared-types --filter @chamuco/shared-utils build

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -54,12 +54,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      # TODO: Restore when pnpm 11 is stable (Node 22 already satisfied).
-      #       pnpm 10.x uses retired npm audit endpoints (HTTP 410).
-      #       Tracked: https://github.com/pnpm/pnpm/issues/11265
-      #       Vulnerability scanning handled by Dependabot (.github/dependabot.yml).
-      # - name: Audit dependencies for vulnerabilities
-      #   run: pnpm audit --audit-level high
+      - name: Audit dependencies for vulnerabilities
+        run: pnpm audit --audit-level high
 
       - name: Build workspace packages
         run: pnpm --filter @chamuco/shared-types --filter @chamuco/shared-utils build

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -9,18 +9,13 @@ if [ $? -ne 0 ]; then
 fi
 
 # 2. Dependency security audit
-# TODO: Restore when pnpm 11 is stable (project already satisfies Node >=22).
-#       pnpm 10.x uses retired npm audit endpoints that return HTTP 410.
-#       Tracked: https://github.com/pnpm/pnpm/issues/11265
-#       Vulnerability scanning is handled by Dependabot (.github/dependabot.yml).
-#
-# echo "🔒 Auditing dependencies for security vulnerabilities..."
-# pnpm audit --audit-level=high
-# if [ $? -ne 0 ]; then
-#   echo "❌ High or critical security vulnerabilities found"
-#   echo "💡 Run 'pnpm audit' to see details and 'pnpm audit --fix' to auto-fix"
-#   exit 1
-# fi
+echo "🔒 Auditing dependencies for security vulnerabilities..."
+pnpm audit --audit-level=high
+if [ $? -ne 0 ]; then
+  echo "❌ High or critical security vulnerabilities found"
+  echo "💡 Run 'pnpm audit' to see details and 'pnpm audit --fix' to auto-fix"
+  exit 1
+fi
 
 # 3. Type checking (only affected packages)
 echo "🔧 Type checking affected packages..."

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test:coverage": "turbo run test:coverage",
     "format": "prettier --write \"**/*.{ts,tsx,js,jsx,json,md,yaml,yml}\"",
     "format:check": "prettier --check \"**/*.{ts,tsx,js,jsx,json,md,yaml,yml}\"",
-    "validate": "pnpm format:check && pnpm lint && pnpm typecheck && pnpm test && pnpm test:coverage",
+    "validate": "pnpm format:check && pnpm lint && pnpm audit --audit-level=high && pnpm typecheck && pnpm test && pnpm test:coverage",
     "prepare": "husky",
     "clean": "turbo run clean && rm -rf node_modules .turbo",
     "db:start": "./scripts/db/start.sh",


### PR DESCRIPTION
## Summary

`pnpm audit` was disabled in early 2025 because pnpm 10.x was hitting retired npm audit endpoints that returned HTTP 410 (tracked in pnpm/pnpm#11265). That issue is now resolved — `pnpm audit --audit-level=high` exits 0 and returns clean results. This PR re-enables the audit gate across all enforcement points.

## Changes

- **Pre-commit hook** — uncommented the `pnpm audit --audit-level=high` step and removed the TODO comment referencing pnpm/pnpm#11265
- **CI/CD pipelines** — restored the `Audit dependencies for vulnerabilities` step in both `api.yml` and `web.yml`; removed the TODO comment blocks
- **`validate` script** — added `pnpm audit --audit-level=high` back into `package.json`'s `validate` script, which is used for full pre-push validation

## Testing

- Verified `pnpm audit --audit-level=high` exits 0 locally (`No known vulnerabilities found`)
- Pre-commit hook ran the audit step successfully on the commit in this branch

Closes #145