### PR TITLE
feat(db): add user_nationalities Drizzle schema and migration

### DIFF
--- a/apps/api/src/database/migrations/0004_short_sage.sql
+++ b/apps/api/src/database/migrations/0004_short_sage.sql
@@ -28,3 +28,5 @@ CREATE INDEX "user_nationalities_user_id_idx" ON "user_nationalities" USING btre
 CREATE TRIGGER user_nationalities_set_updated_at
   BEFORE UPDATE ON "user_nationalities"
   FOR EACH ROW EXECUTE PROCEDURE set_updated_at();
+--> statement-breakpoint
+CREATE UNIQUE INDEX "user_nationalities_one_primary_per_user" ON "user_nationalities" USING btree ("user_id") WHERE "user_nationalities"."is_primary" = true;

--- a/apps/api/src/database/migrations/0004_short_sage.sql
+++ b/apps/api/src/database/migrations/0004_short_sage.sql
@@ -1,0 +1,30 @@
+CREATE TYPE "public"."passport_status" AS ENUM('OMITTED', 'ACTIVE', 'EXPIRING_SOON', 'EXPIRED');--> statement-breakpoint
+CREATE TABLE "user_nationalities" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"country_code" char(2) NOT NULL,
+	"is_primary" boolean NOT NULL,
+	"national_id_number" text,
+	"passport_number" text,
+	"passport_issue_date" date,
+	"passport_expiry_date" date,
+	"passport_status" "passport_status" NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "user_nationalities_user_id_country_code_unique" UNIQUE("user_id","country_code"),
+	CONSTRAINT "passport_data_consistency" CHECK (("user_nationalities"."passport_status" = 'OMITTED'
+        AND "user_nationalities"."passport_number" IS NULL
+        AND "user_nationalities"."passport_issue_date" IS NULL
+        AND "user_nationalities"."passport_expiry_date" IS NULL)
+      OR
+      ("user_nationalities"."passport_status" <> 'OMITTED'
+        AND "user_nationalities"."passport_number" IS NOT NULL
+        AND "user_nationalities"."passport_issue_date" IS NOT NULL
+        AND "user_nationalities"."passport_expiry_date" IS NOT NULL))
+);
+--> statement-breakpoint
+ALTER TABLE "user_nationalities" ADD CONSTRAINT "user_nationalities_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "user_nationalities_user_id_idx" ON "user_nationalities" USING btree ("user_id");
+--> statement-breakpoint
+CREATE TRIGGER user_nationalities_set_updated_at
+  BEFORE UPDATE ON "user_nationalities"
+  FOR EACH ROW EXECUTE PROCEDURE set_updated_at();

--- a/apps/api/src/database/migrations/meta/0004_snapshot.json
+++ b/apps/api/src/database/migrations/meta/0004_snapshot.json
@@ -419,6 +419,22 @@
           "concurrently": false,
           "method": "btree",
           "with": {}
+        },
+        "user_nationalities_one_primary_per_user": {
+          "name": "user_nationalities_one_primary_per_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"user_nationalities\".\"is_primary\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
         }
       },
       "foreignKeys": {

--- a/apps/api/src/database/migrations/meta/0004_snapshot.json
+++ b/apps/api/src/database/migrations/meta/0004_snapshot.json
@@ -1,0 +1,679 @@
+{
+  "id": "3b07df81-3c62-401b-b83b-a855db987edf",
+  "prevId": "6d77e6e2-098e-46e3-8831-2c47169db9c9",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_provider": {
+          "name": "auth_provider",
+          "type": "auth_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "firebase_uid": {
+          "name": "firebase_uid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "platform_role": {
+          "name": "platform_role",
+          "type": "platform_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'USER'"
+        },
+        "agency_id": {
+          "name": "agency_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        },
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": ["username"]
+        },
+        "users_firebase_uid_unique": {
+          "name": "users_firebase_uid_unique",
+          "nullsNotDistinct": false,
+          "columns": ["firebase_uid"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "users_username_format": {
+          "name": "users_username_format",
+          "value": "\"users\".\"username\" ~ '^[a-z0-9_-]{3,30}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_preferences": {
+      "name": "user_preferences",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "app_language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ES'"
+        },
+        "currency": {
+          "name": "currency",
+          "type": "app_currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'COP'"
+        },
+        "theme": {
+          "name": "theme",
+          "type": "app_theme",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'SYSTEM'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_preferences_user_id_users_id_fk": {
+          "name": "user_preferences_user_id_users_id_fk",
+          "tableFrom": "user_preferences",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_profiles": {
+      "name": "user_profiles",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_of_birth": {
+          "name": "date_of_birth",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "birth_country": {
+          "name": "birth_country",
+          "type": "char(2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "birth_city": {
+          "name": "birth_city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "home_country": {
+          "name": "home_country",
+          "type": "char(2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "home_city": {
+          "name": "home_city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dietary_preference": {
+          "name": "dietary_preference",
+          "type": "dietary_preference",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'OMNIVORE'"
+        },
+        "dietary_notes": {
+          "name": "dietary_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "general_medical_notes": {
+          "name": "general_medical_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "food_allergies": {
+          "name": "food_allergies",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "phobias": {
+          "name": "phobias",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "physical_limitations": {
+          "name": "physical_limitations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "medical_conditions": {
+          "name": "medical_conditions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "emergency_contacts": {
+          "name": "emergency_contacts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "loyalty_programs": {
+          "name": "loyalty_programs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_profiles_user_id_users_id_fk": {
+          "name": "user_profiles_user_id_users_id_fk",
+          "tableFrom": "user_profiles",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_nationalities": {
+      "name": "user_nationalities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country_code": {
+          "name": "country_code",
+          "type": "char(2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "national_id_number": {
+          "name": "national_id_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "passport_number": {
+          "name": "passport_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "passport_issue_date": {
+          "name": "passport_issue_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "passport_expiry_date": {
+          "name": "passport_expiry_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "passport_status": {
+          "name": "passport_status",
+          "type": "passport_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_nationalities_user_id_idx": {
+          "name": "user_nationalities_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_nationalities_user_id_users_id_fk": {
+          "name": "user_nationalities_user_id_users_id_fk",
+          "tableFrom": "user_nationalities",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_nationalities_user_id_country_code_unique": {
+          "name": "user_nationalities_user_id_country_code_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id", "country_code"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "passport_data_consistency": {
+          "name": "passport_data_consistency",
+          "value": "(\"user_nationalities\".\"passport_status\" = 'OMITTED'\n        AND \"user_nationalities\".\"passport_number\" IS NULL\n        AND \"user_nationalities\".\"passport_issue_date\" IS NULL\n        AND \"user_nationalities\".\"passport_expiry_date\" IS NULL)\n      OR\n      (\"user_nationalities\".\"passport_status\" <> 'OMITTED'\n        AND \"user_nationalities\".\"passport_number\" IS NOT NULL\n        AND \"user_nationalities\".\"passport_issue_date\" IS NOT NULL\n        AND \"user_nationalities\".\"passport_expiry_date\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.support_admin_audit_log": {
+      "name": "support_admin_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "admin_user_id": {
+          "name": "admin_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_table": {
+          "name": "target_table",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "before_state": {
+          "name": "before_state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "after_state": {
+          "name": "after_state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "performed_at": {
+          "name": "performed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "support_admin_audit_log_admin_user_id_idx": {
+          "name": "support_admin_audit_log_admin_user_id_idx",
+          "columns": [
+            {
+              "expression": "admin_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "support_admin_audit_log_performed_at_idx": {
+          "name": "support_admin_audit_log_performed_at_idx",
+          "columns": [
+            {
+              "expression": "performed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "support_admin_audit_log_admin_user_id_users_id_fk": {
+          "name": "support_admin_audit_log_admin_user_id_users_id_fk",
+          "tableFrom": "support_admin_audit_log",
+          "tableTo": "users",
+          "columnsFrom": ["admin_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.auth_provider": {
+      "name": "auth_provider",
+      "schema": "public",
+      "values": ["GOOGLE", "FACEBOOK"]
+    },
+    "public.platform_role": {
+      "name": "platform_role",
+      "schema": "public",
+      "values": ["USER", "SUPPORT_ADMIN"]
+    },
+    "public.app_currency": {
+      "name": "app_currency",
+      "schema": "public",
+      "values": ["COP", "USD"]
+    },
+    "public.app_language": {
+      "name": "app_language",
+      "schema": "public",
+      "values": ["ES", "EN"]
+    },
+    "public.app_theme": {
+      "name": "app_theme",
+      "schema": "public",
+      "values": ["LIGHT", "DARK", "SYSTEM"]
+    },
+    "public.dietary_preference": {
+      "name": "dietary_preference",
+      "schema": "public",
+      "values": ["OMNIVORE", "VEGETARIAN", "VEGAN", "PESCATARIAN", "GLUTEN_FREE", "OTHER"]
+    },
+    "public.food_allergen": {
+      "name": "food_allergen",
+      "schema": "public",
+      "values": [
+        "GLUTEN",
+        "CRUSTACEANS",
+        "EGGS",
+        "FISH",
+        "PEANUTS",
+        "SOYBEANS",
+        "MILK",
+        "TREE_NUTS",
+        "CELERY",
+        "MUSTARD",
+        "SESAME",
+        "SULPHITES",
+        "LUPIN",
+        "MOLLUSCS",
+        "OTHER"
+      ]
+    },
+    "public.medical_condition_type": {
+      "name": "medical_condition_type",
+      "schema": "public",
+      "values": [
+        "DIABETES",
+        "EPILEPSY",
+        "SEVERE_ALLERGY_EPIPEN",
+        "ASTHMA",
+        "HEART_CONDITION",
+        "HYPERTENSION",
+        "BLOOD_CLOTTING_DISORDER",
+        "IMMUNODEFICIENCY",
+        "MENTAL_HEALTH_CONDITION",
+        "OTHER"
+      ]
+    },
+    "public.phobia_type": {
+      "name": "phobia_type",
+      "schema": "public",
+      "values": [
+        "HEIGHTS",
+        "ENCLOSED_SPACES",
+        "FLYING",
+        "DEEP_WATER",
+        "OPEN_WATER",
+        "ANIMALS",
+        "INSECTS",
+        "SNAKES",
+        "SPIDERS",
+        "DARKNESS",
+        "CROWDS",
+        "MOTION_SICKNESS",
+        "OTHER"
+      ]
+    },
+    "public.physical_limitation_type": {
+      "name": "physical_limitation_type",
+      "schema": "public",
+      "values": [
+        "WHEELCHAIR_USER",
+        "REDUCED_MOBILITY",
+        "CANNOT_USE_STAIRS",
+        "HEARING_IMPAIRMENT",
+        "VISUAL_IMPAIRMENT",
+        "REQUIRES_OXYGEN",
+        "REQUIRES_CPAP",
+        "CHRONIC_PAIN",
+        "JOINT_CONDITION",
+        "CARDIAC_CONDITION",
+        "RESPIRATORY_CONDITION",
+        "PREGNANCY",
+        "OTHER"
+      ]
+    },
+    "public.passport_status": {
+      "name": "passport_status",
+      "schema": "public",
+      "values": ["OMITTED", "ACTIVE", "EXPIRING_SOON", "EXPIRED"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/src/database/migrations/meta/_journal.json
+++ b/apps/api/src/database/migrations/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1776440330027,
       "tag": "0003_flat_energizer",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1776448136514,
+      "tag": "0004_short_sage",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/database/schema/index.ts
+++ b/apps/api/src/database/schema/index.ts
@@ -12,4 +12,5 @@
 export * from '@/modules/users/schema/users.schema';
 export * from '@/modules/users/schema/user-preferences.schema';
 export * from '@/modules/users/schema/user-profiles.schema';
+export * from '@/modules/users/schema/user-nationalities.schema';
 export * from '@/modules/users/schema/support-admin-audit-log.schema';

--- a/apps/api/src/modules/users/schema/user-nationalities.schema.ts
+++ b/apps/api/src/modules/users/schema/user-nationalities.schema.ts
@@ -1,0 +1,58 @@
+import { PassportStatus } from '@chamuco/shared-types';
+import { sql } from 'drizzle-orm';
+import {
+  boolean,
+  char,
+  check,
+  date,
+  index,
+  pgEnum,
+  pgTable,
+  text,
+  timestamp,
+  unique,
+  uuid,
+} from 'drizzle-orm/pg-core';
+
+import { users } from './users.schema';
+
+export const passportStatusEnum = pgEnum('passport_status', [
+  PassportStatus.OMITTED,
+  PassportStatus.ACTIVE,
+  PassportStatus.EXPIRING_SOON,
+  PassportStatus.EXPIRED,
+]);
+
+export const userNationalities = pgTable(
+  'user_nationalities',
+  {
+    id: uuid('id').primaryKey().notNull().defaultRandom(),
+    userId: uuid('user_id')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+    countryCode: char('country_code', { length: 2 }).notNull(),
+    isPrimary: boolean('is_primary').notNull(),
+    nationalIdNumber: text('national_id_number'),
+    passportNumber: text('passport_number'),
+    passportIssueDate: date('passport_issue_date'),
+    passportExpiryDate: date('passport_expiry_date'),
+    passportStatus: passportStatusEnum('passport_status').notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    unique('user_nationalities_user_id_country_code_unique').on(table.userId, table.countryCode),
+    index('user_nationalities_user_id_idx').on(table.userId),
+    check(
+      'passport_data_consistency',
+      sql`(${table.passportStatus} = 'OMITTED'
+        AND ${table.passportNumber} IS NULL
+        AND ${table.passportIssueDate} IS NULL
+        AND ${table.passportExpiryDate} IS NULL)
+      OR
+      (${table.passportStatus} <> 'OMITTED'
+        AND ${table.passportNumber} IS NOT NULL
+        AND ${table.passportIssueDate} IS NOT NULL
+        AND ${table.passportExpiryDate} IS NOT NULL)`,
+    ),
+  ],
+);

--- a/apps/api/src/modules/users/schema/user-nationalities.schema.ts
+++ b/apps/api/src/modules/users/schema/user-nationalities.schema.ts
@@ -11,6 +11,7 @@ import {
   text,
   timestamp,
   unique,
+  uniqueIndex,
   uuid,
 } from 'drizzle-orm/pg-core';
 
@@ -42,6 +43,9 @@ export const userNationalities = pgTable(
   (table) => [
     unique('user_nationalities_user_id_country_code_unique').on(table.userId, table.countryCode),
     index('user_nationalities_user_id_idx').on(table.userId),
+    uniqueIndex('user_nationalities_one_primary_per_user')
+      .on(table.userId)
+      .where(sql`${table.isPrimary} = true`),
     check(
       'passport_data_consistency',
       sql`(${table.passportStatus} = 'OMITTED'

--- a/packages/shared-types/src/enums/index.ts
+++ b/packages/shared-types/src/enums/index.ts
@@ -6,5 +6,6 @@ export * from './dietary-preference.enum';
 export * from './food-allergen.enum';
 export * from './medical-condition-type.enum';
 export * from './phobia-type.enum';
+export * from './passport-status.enum';
 export * from './physical-limitation-type.enum';
 export * from './platform-role.enum';

--- a/packages/shared-types/src/enums/index.ts
+++ b/packages/shared-types/src/enums/index.ts
@@ -5,7 +5,7 @@ export * from './app-theme.enum';
 export * from './dietary-preference.enum';
 export * from './food-allergen.enum';
 export * from './medical-condition-type.enum';
-export * from './phobia-type.enum';
 export * from './passport-status.enum';
+export * from './phobia-type.enum';
 export * from './physical-limitation-type.enum';
 export * from './platform-role.enum';

--- a/packages/shared-types/src/enums/passport-status.enum.ts
+++ b/packages/shared-types/src/enums/passport-status.enum.ts
@@ -1,0 +1,6 @@
+export enum PassportStatus {
+  OMITTED = 'OMITTED',
+  ACTIVE = 'ACTIVE',
+  EXPIRING_SOON = 'EXPIRING_SOON',
+  EXPIRED = 'EXPIRED',
+}


### PR DESCRIPTION
## Summary

Implements the `user_nationalities` table as documented in `features/users.md`. This is a 1:many extension of `users` that stores each nationality/citizenship a user holds, along with the associated travel document (national ID + passport). Designed to support dual/triple citizenship and passport expiry tracking — a requirement for trip validation and pre-trip checklists.

## Changes

**`@chamuco/shared-types` — 1 new enum**
- `PassportStatus` (OMITTED, ACTIVE, EXPIRING_SOON, EXPIRED) — pre-computed status flag to avoid recomputing expiry dates at query time

**`apps/api` — Drizzle schema + migration**
- `user-nationalities.schema.ts`: table definition with `passportStatusEnum`, unique index on `(user_id, country_code)`, and a `CHECK` constraint (`passport_data_consistency`) enforced directly in the Drizzle schema via `check()` + `sql` template
- `0004_short_sage.sql`: generated migration with `CREATE TYPE`, `CREATE TABLE` (CHECK inline), FK with `ON DELETE CASCADE`, btree index on `user_id`, and manual `set_updated_at` trigger
- `schema/index.ts`: barrel updated

## Testing

- `pnpm validate` passes: format ✅ lint ✅ security audit ✅ typecheck ✅
- API test suite: 156/156 tests pass
- API coverage: 99.4% stmts / 97.19% branch / 96.55% funcs / 99.35% lines (all above 90% threshold)
- Migration SQL reviewed manually: CHECK constraint correctly enforces the OMITTED/non-OMITTED passport field consistency rule

## Notes

- `passport_issue_date` and `passport_expiry_date` are `date` (not `timestamp`) — date-only precision is correct for document fields
- The `set_updated_at` trigger is added manually to the migration (drizzle-kit does not generate triggers); follows the same pattern as `users`, `user_preferences`, and `user_profiles`
- `passport_status` is a pre-computed cache column — the daily job that transitions ACTIVE → EXPIRING_SOON → EXPIRED is a separate concern (scheduled task, not part of this schema issue)

Closes #103