### PR TITLE
feat(users): add PATCH /users/me and GET+PATCH /users/me/preferences

### DIFF
--- a/apps/api/src/modules/users/dto/update-user-preferences.dto.ts
+++ b/apps/api/src/modules/users/dto/update-user-preferences.dto.ts
@@ -1,0 +1,20 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { AppCurrency, AppLanguage, AppTheme } from '@chamuco/shared-types';
+import { IsEnum, IsOptional } from 'class-validator';
+
+export class UpdateUserPreferencesDto {
+  @ApiProperty({ enum: AppLanguage, example: AppLanguage.ES, required: false })
+  @IsOptional()
+  @IsEnum(AppLanguage)
+  language?: AppLanguage;
+
+  @ApiProperty({ enum: AppCurrency, example: AppCurrency.COP, required: false })
+  @IsOptional()
+  @IsEnum(AppCurrency)
+  currency?: AppCurrency;
+
+  @ApiProperty({ enum: AppTheme, example: AppTheme.SYSTEM, required: false })
+  @IsOptional()
+  @IsEnum(AppTheme)
+  theme?: AppTheme;
+}

--- a/apps/api/src/modules/users/dto/update-user.dto.ts
+++ b/apps/api/src/modules/users/dto/update-user.dto.ts
@@ -1,0 +1,32 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsOptional, IsString, IsTimeZone, MaxLength } from 'class-validator';
+
+export class UpdateUserDto {
+  @ApiProperty({
+    example: 'John Doe',
+    maxLength: 100,
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(100)
+  displayName?: string;
+
+  @ApiProperty({
+    example: 'https://example.com/avatar.jpg',
+    nullable: true,
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  avatarUrl?: string | null;
+
+  @ApiProperty({
+    example: 'America/Bogota',
+    required: false,
+  })
+  @IsOptional()
+  @IsTimeZone()
+  timezone?: string;
+}

--- a/apps/api/src/modules/users/dto/user-preferences-response.dto.ts
+++ b/apps/api/src/modules/users/dto/user-preferences-response.dto.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { AppCurrency, AppLanguage, AppTheme } from '@chamuco/shared-types';
+
+export class UserPreferencesResponseDto {
+  @ApiProperty({ enum: AppLanguage, example: AppLanguage.ES })
+  language!: AppLanguage;
+
+  @ApiProperty({ enum: AppCurrency, example: AppCurrency.COP })
+  currency!: AppCurrency;
+
+  @ApiProperty({ enum: AppTheme, example: AppTheme.SYSTEM })
+  theme!: AppTheme;
+}

--- a/apps/api/src/modules/users/users.controller.spec.ts
+++ b/apps/api/src/modules/users/users.controller.spec.ts
@@ -1,10 +1,21 @@
 import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import { AuthProvider, DietaryPreference, FoodAllergen, PlatformRole } from '@chamuco/shared-types';
+import {
+  AppCurrency,
+  AppLanguage,
+  AppTheme,
+  AuthProvider,
+  DietaryPreference,
+  FoodAllergen,
+  PlatformRole,
+} from '@chamuco/shared-types';
 import { UsersController } from './users.controller';
 import { UsersService } from './users.service';
+import type { UpdateUserDto } from './dto/update-user.dto';
 import type { UpdateUserHealthDto } from './dto/update-user-health.dto';
+import type { UpdateUserPreferencesDto } from './dto/update-user-preferences.dto';
 import type { UserHealthResponseDto } from './dto/user-health-response.dto';
+import type { UserPreferencesResponseDto } from './dto/user-preferences-response.dto';
 import type { AuthenticatedUser } from '@/types/express';
 
 const NOW = new Date('2026-01-01T00:00:00.000Z');
@@ -28,6 +39,12 @@ const mockAuthUser: AuthenticatedUser = {
 // mockUser is the expected shape after getMe strips firebaseUid
 const { firebaseUid: _, ...mockUser } = mockAuthUser;
 
+const mockPreferencesResponse: UserPreferencesResponseDto = {
+  language: AppLanguage.ES,
+  currency: AppCurrency.COP,
+  theme: AppTheme.SYSTEM,
+};
+
 const mockHealthResponse: UserHealthResponseDto = {
   dietaryPreference: DietaryPreference.OMNIVORE,
   dietaryNotes: null,
@@ -42,16 +59,22 @@ describe('UsersController', () => {
   let controller: UsersController;
   let mockFindByFirebaseUid: jest.Mock;
   let mockCheckUsernameAvailability: jest.Mock;
+  let mockUpdateMe: jest.Mock;
   let mockGetHealth: jest.Mock;
   let mockUpdateHealth: jest.Mock;
+  let mockGetPreferences: jest.Mock;
+  let mockUpdatePreferences: jest.Mock;
 
   beforeEach(async () => {
     mockFindByFirebaseUid = jest.fn().mockResolvedValue(mockUser);
     mockCheckUsernameAvailability = jest
       .fn()
       .mockResolvedValue({ available: true, username: 'john_doe' });
+    mockUpdateMe = jest.fn().mockResolvedValue(mockUser);
     mockGetHealth = jest.fn().mockResolvedValue(mockHealthResponse);
     mockUpdateHealth = jest.fn().mockResolvedValue(mockHealthResponse);
+    mockGetPreferences = jest.fn().mockResolvedValue(mockPreferencesResponse);
+    mockUpdatePreferences = jest.fn().mockResolvedValue(mockPreferencesResponse);
 
     const module: TestingModule = await Test.createTestingModule({
       controllers: [UsersController],
@@ -61,8 +84,11 @@ describe('UsersController', () => {
           useValue: {
             findByFirebaseUid: mockFindByFirebaseUid,
             checkUsernameAvailability: mockCheckUsernameAvailability,
+            updateMe: mockUpdateMe,
             getHealth: mockGetHealth,
             updateHealth: mockUpdateHealth,
+            getPreferences: mockGetPreferences,
+            updatePreferences: mockUpdatePreferences,
           },
         },
       ],
@@ -147,6 +173,27 @@ describe('UsersController', () => {
     });
   });
 
+  describe('PATCH /v1/users/me', () => {
+    it('delegates to usersService.updateMe with the authenticated user and dto', async () => {
+      const dto: UpdateUserDto = { displayName: 'Jane Doe' };
+      const updated = { ...mockUser, displayName: 'Jane Doe' };
+      mockUpdateMe.mockResolvedValue(updated);
+
+      const result = await controller.updateMe(mockAuthUser, dto);
+
+      expect(mockUpdateMe).toHaveBeenCalledWith(mockAuthUser, dto);
+      expect(result).toEqual(updated);
+    });
+
+    it('propagates NotFoundException from the service', async () => {
+      mockUpdateMe.mockRejectedValue(new NotFoundException());
+
+      await expect(controller.updateMe(mockAuthUser, {} as UpdateUserDto)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
   describe('PATCH /v1/users/me/health', () => {
     it('delegates to usersService.updateHealth with the user id and dto', async () => {
       const dto: UpdateUserHealthDto = {
@@ -171,6 +218,45 @@ describe('UsersController', () => {
 
       await expect(
         controller.updateHealthProfile(mockAuthUser, {} as UpdateUserHealthDto),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('GET /v1/users/me/preferences', () => {
+    it('delegates to usersService.getPreferences with the authenticated user id', async () => {
+      const result = await controller.getPreferences(mockAuthUser);
+
+      expect(mockGetPreferences).toHaveBeenCalledWith(mockAuthUser.id);
+      expect(result).toEqual(mockPreferencesResponse);
+    });
+
+    it('propagates NotFoundException from the service', async () => {
+      mockGetPreferences.mockRejectedValue(new NotFoundException());
+
+      await expect(controller.getPreferences(mockAuthUser)).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('PATCH /v1/users/me/preferences', () => {
+    it('delegates to usersService.updatePreferences with the user id and dto', async () => {
+      const dto: UpdateUserPreferencesDto = { theme: AppTheme.DARK };
+      const updated: UserPreferencesResponseDto = {
+        ...mockPreferencesResponse,
+        theme: AppTheme.DARK,
+      };
+      mockUpdatePreferences.mockResolvedValue(updated);
+
+      const result = await controller.updatePreferences(mockAuthUser, dto);
+
+      expect(mockUpdatePreferences).toHaveBeenCalledWith(mockAuthUser.id, dto);
+      expect(result).toEqual(updated);
+    });
+
+    it('propagates NotFoundException from the service', async () => {
+      mockUpdatePreferences.mockRejectedValue(new NotFoundException());
+
+      await expect(
+        controller.updatePreferences(mockAuthUser, {} as UpdateUserPreferencesDto),
       ).rejects.toThrow(NotFoundException);
     });
   });

--- a/apps/api/src/modules/users/users.controller.ts
+++ b/apps/api/src/modules/users/users.controller.ts
@@ -12,8 +12,11 @@ import { CurrentUser } from '@/common/decorators/current-user.decorator';
 import { Public } from '@/common/decorators/public.decorator';
 import type { AuthenticatedUser } from '@/types/express';
 import { UsersService } from './users.service';
+import { UpdateUserDto } from './dto/update-user.dto';
 import { UpdateUserHealthDto } from './dto/update-user-health.dto';
+import { UpdateUserPreferencesDto } from './dto/update-user-preferences.dto';
 import { UserHealthResponseDto } from './dto/user-health-response.dto';
+import { UserPreferencesResponseDto } from './dto/user-preferences-response.dto';
 import { UserResponseDto } from './dto/user-response.dto';
 import { UsernameAvailabilityDto } from './dto/username-availability.dto';
 
@@ -40,6 +43,24 @@ export class UsersController {
     // the serialized response.
     const { firebaseUid: _, ...dto } = user;
     return dto;
+  }
+
+  @Patch('me')
+  @HttpCode(200)
+  @ApiBody({ type: UpdateUserDto })
+  @ApiOperation({
+    summary: 'Update the current authenticated user',
+    description: 'Updates any subset of editable user fields: displayName, avatarUrl, timezone.',
+  })
+  @ApiResponse({ status: 200, type: UserResponseDto })
+  @ApiResponse({ status: 400, description: 'Validation failed — invalid field value' })
+  @ApiResponse({ status: 401, description: 'Missing or invalid Firebase ID token' })
+  @ApiResponse({ status: 404, description: 'User not found' })
+  async updateMe(
+    @CurrentUser() user: AuthenticatedUser,
+    @Body() dto: UpdateUserDto,
+  ): Promise<UserResponseDto> {
+    return this.usersService.updateMe(user, dto);
   }
 
   @Get('me/health')
@@ -79,6 +100,36 @@ export class UsersController {
     @Body() dto: UpdateUserHealthDto,
   ): Promise<UserHealthResponseDto> {
     return this.usersService.updateHealth(user.id, dto);
+  }
+
+  @Get('me/preferences')
+  @ApiOperation({
+    summary: "Get the current user's preferences",
+    description: "Returns the authenticated user's preferences: language, currency, theme.",
+  })
+  @ApiResponse({ status: 200, type: UserPreferencesResponseDto })
+  @ApiResponse({ status: 401, description: 'Missing or invalid Firebase ID token' })
+  @ApiResponse({ status: 404, description: 'User preferences not found' })
+  getPreferences(@CurrentUser() user: AuthenticatedUser): Promise<UserPreferencesResponseDto> {
+    return this.usersService.getPreferences(user.id);
+  }
+
+  @Patch('me/preferences')
+  @HttpCode(200)
+  @ApiBody({ type: UpdateUserPreferencesDto })
+  @ApiOperation({
+    summary: "Update the current user's preferences",
+    description: 'Updates any subset of preference fields: language, currency, theme.',
+  })
+  @ApiResponse({ status: 200, type: UserPreferencesResponseDto })
+  @ApiResponse({ status: 400, description: 'Validation failed — invalid enum value' })
+  @ApiResponse({ status: 401, description: 'Missing or invalid Firebase ID token' })
+  @ApiResponse({ status: 404, description: 'User preferences not found' })
+  updatePreferences(
+    @CurrentUser() user: AuthenticatedUser,
+    @Body() dto: UpdateUserPreferencesDto,
+  ): Promise<UserPreferencesResponseDto> {
+    return this.usersService.updatePreferences(user.id, dto);
   }
 
   @Get('username-available')

--- a/apps/api/src/modules/users/users.service.spec.ts
+++ b/apps/api/src/modules/users/users.service.spec.ts
@@ -1,6 +1,9 @@
 import { NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import {
+  AppCurrency,
+  AppLanguage,
+  AppTheme,
   AuthProvider,
   DietaryPreference,
   FoodAllergen,
@@ -11,9 +14,19 @@ import {
 } from '@chamuco/shared-types';
 import { DRIZZLE_CLIENT } from '@/database/drizzle.provider';
 import { UsersService } from './users.service';
+import type { UpdateUserDto } from './dto/update-user.dto';
 import type { UpdateUserHealthDto } from './dto/update-user-health.dto';
+import type { UpdateUserPreferencesDto } from './dto/update-user-preferences.dto';
 import type { UserHealthResponseDto } from './dto/user-health-response.dto';
 import type { AuthenticatedUser } from '@/types/express';
+
+const mockPreferences = {
+  userId: 'user-uuid',
+  language: AppLanguage.ES,
+  currency: AppCurrency.COP,
+  theme: AppTheme.SYSTEM,
+  updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+};
 
 const mockHealthProfile = {
   userId: 'user-uuid',
@@ -58,12 +71,14 @@ describe('UsersService', () => {
   let service: UsersService;
   let mockFindFirst: jest.Mock;
   let mockProfileFindFirst: jest.Mock;
+  let mockPrefFindFirst: jest.Mock;
   let mockReturning: jest.Mock;
   let mockSet: jest.Mock;
 
   beforeEach(async () => {
     mockFindFirst = jest.fn();
     mockProfileFindFirst = jest.fn();
+    mockPrefFindFirst = jest.fn();
     mockReturning = jest.fn();
 
     const mockWhere = jest.fn().mockReturnValue({ returning: mockReturning });
@@ -79,6 +94,7 @@ describe('UsersService', () => {
             query: {
               users: { findFirst: mockFindFirst },
               userProfiles: { findFirst: mockProfileFindFirst },
+              userPreferences: { findFirst: mockPrefFindFirst },
             },
             update: mockUpdate,
           },
@@ -135,6 +151,134 @@ describe('UsersService', () => {
       mockFindFirst.mockRejectedValue(dbError);
 
       await expect(service.checkUsernameAvailability('some_user')).rejects.toThrow(dbError);
+    });
+  });
+
+  describe('updateMe', () => {
+    it('returns existing user unchanged when dto has no fields', async () => {
+      const result = await service.updateMe(mockUser, {} as UpdateUserDto);
+
+      expect(result.displayName).toBe('John Doe');
+      expect(result).not.toHaveProperty('firebaseUid');
+      expect(mockReturning).not.toHaveBeenCalled();
+    });
+
+    it('updates and returns the mapped response on success', async () => {
+      const updated = {
+        ...mockUser,
+        displayName: 'Jane Doe',
+        avatarUrl: 'https://example.com/a.jpg',
+      };
+      mockReturning.mockResolvedValue([updated]);
+
+      const dto: UpdateUserDto = {
+        displayName: 'Jane Doe',
+        avatarUrl: 'https://example.com/a.jpg',
+      };
+      const result = await service.updateMe(mockUser, dto);
+
+      expect(result.displayName).toBe('Jane Doe');
+      expect(result.avatarUrl).toBe('https://example.com/a.jpg');
+      expect(result).not.toHaveProperty('firebaseUid');
+    });
+
+    it('throws NotFoundException when user is deleted between check and update', async () => {
+      mockReturning.mockResolvedValue([]);
+
+      await expect(service.updateMe(mockUser, { displayName: 'Jane' })).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('propagates unexpected database errors', async () => {
+      const dbError = new Error('update failed');
+      mockReturning.mockRejectedValue(dbError);
+
+      await expect(service.updateMe(mockUser, { displayName: 'Jane' })).rejects.toThrow(dbError);
+    });
+  });
+
+  describe('getPreferences', () => {
+    it('returns the mapped preferences when found', async () => {
+      mockPrefFindFirst.mockResolvedValue(mockPreferences);
+
+      const result = await service.getPreferences('user-uuid');
+
+      expect(result).toEqual({
+        language: AppLanguage.ES,
+        currency: AppCurrency.COP,
+        theme: AppTheme.SYSTEM,
+      });
+    });
+
+    it('throws NotFoundException when preferences do not exist', async () => {
+      mockPrefFindFirst.mockResolvedValue(undefined);
+
+      await expect(service.getPreferences('unknown-uuid')).rejects.toThrow(NotFoundException);
+    });
+
+    it('propagates unexpected database errors', async () => {
+      const dbError = new Error('connection lost');
+      mockPrefFindFirst.mockRejectedValue(dbError);
+
+      await expect(service.getPreferences('user-uuid')).rejects.toThrow(dbError);
+    });
+  });
+
+  describe('updatePreferences', () => {
+    it('returns existing preferences unchanged when dto has no fields', async () => {
+      mockPrefFindFirst.mockResolvedValue(mockPreferences);
+
+      const result = await service.updatePreferences('user-uuid', {} as UpdateUserPreferencesDto);
+
+      expect(result.language).toBe(AppLanguage.ES);
+      expect(mockReturning).not.toHaveBeenCalled();
+    });
+
+    it('updates and returns the mapped preferences on success', async () => {
+      mockPrefFindFirst.mockResolvedValue(mockPreferences);
+      const updated = { ...mockPreferences, theme: AppTheme.DARK };
+      mockReturning.mockResolvedValue([updated]);
+
+      const result = await service.updatePreferences('user-uuid', { theme: AppTheme.DARK });
+
+      expect(result.theme).toBe(AppTheme.DARK);
+    });
+
+    it('throws NotFoundException when preferences do not exist', async () => {
+      mockPrefFindFirst.mockResolvedValue(undefined);
+
+      await expect(
+        service.updatePreferences('unknown-uuid', { theme: AppTheme.DARK }),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('throws NotFoundException when preferences deleted between check and update', async () => {
+      mockPrefFindFirst.mockResolvedValue(mockPreferences);
+      mockReturning.mockResolvedValue([]);
+
+      await expect(
+        service.updatePreferences('user-uuid', { theme: AppTheme.DARK }),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('propagates unexpected database errors on the initial fetch', async () => {
+      const dbError = new Error('connection lost');
+      mockPrefFindFirst.mockRejectedValue(dbError);
+
+      await expect(
+        service.updatePreferences('user-uuid', { theme: AppTheme.DARK }),
+      ).rejects.toThrow(dbError);
+    });
+
+    it('propagates unexpected database errors on the update', async () => {
+      mockPrefFindFirst.mockResolvedValue(mockPreferences);
+      const dbError = new Error('update failed');
+      mockReturning.mockRejectedValue(dbError);
+
+      await expect(
+        service.updatePreferences('user-uuid', { theme: AppTheme.DARK }),
+      ).rejects.toThrow(dbError);
     });
   });
 

--- a/apps/api/src/modules/users/users.service.spec.ts
+++ b/apps/api/src/modules/users/users.service.spec.ts
@@ -182,6 +182,14 @@ describe('UsersService', () => {
       expect(result).not.toHaveProperty('firebaseUid');
     });
 
+    it('normalizes empty and whitespace-only avatarUrl to null before saving', async () => {
+      mockReturning.mockResolvedValue([{ ...mockUser, avatarUrl: null }]);
+
+      await service.updateMe(mockUser, { avatarUrl: '' });
+
+      expect(mockSet).toHaveBeenCalledWith(expect.objectContaining({ avatarUrl: null }));
+    });
+
     it('throws NotFoundException when user is deleted between check and update', async () => {
       mockReturning.mockResolvedValue([]);
 

--- a/apps/api/src/modules/users/users.service.ts
+++ b/apps/api/src/modules/users/users.service.ts
@@ -1,11 +1,16 @@
 import { Inject, Injectable, NotFoundException } from '@nestjs/common';
 import { eq } from 'drizzle-orm';
 import { DRIZZLE_CLIENT, DrizzleClient } from '@/database/drizzle.provider';
+import { userPreferences } from '@/modules/users/schema/user-preferences.schema';
 import { userProfiles } from '@/modules/users/schema/user-profiles.schema';
 import { users } from '@/modules/users/schema/users.schema';
 import type { AuthenticatedUser } from '@/types/express';
+import type { UpdateUserDto } from './dto/update-user.dto';
 import type { UpdateUserHealthDto } from './dto/update-user-health.dto';
+import type { UpdateUserPreferencesDto } from './dto/update-user-preferences.dto';
 import type { UserHealthResponseDto } from './dto/user-health-response.dto';
+import type { UserPreferencesResponseDto } from './dto/user-preferences-response.dto';
+import type { UserResponseDto } from './dto/user-response.dto';
 import type { UsernameAvailabilityDto } from './dto/username-availability.dto';
 
 @Injectable()
@@ -27,6 +32,70 @@ export class UsersService {
       where: eq(users.username, username),
     });
     return { available: !existing, username };
+  }
+
+  async updateMe(existingUser: AuthenticatedUser, dto: UpdateUserDto): Promise<UserResponseDto> {
+    const patch: Partial<typeof users.$inferInsert> = {};
+    if (dto.displayName !== undefined) patch.displayName = dto.displayName.trim();
+    if (dto.avatarUrl !== undefined) patch.avatarUrl = dto.avatarUrl;
+    if (dto.timezone !== undefined) patch.timezone = dto.timezone;
+
+    if (Object.keys(patch).length === 0) {
+      return this.mapUserResponse(existingUser);
+    }
+
+    const [updated] = await this.db
+      .update(users)
+      .set(patch)
+      .where(eq(users.id, existingUser.id))
+      .returning();
+
+    if (!updated) {
+      throw new NotFoundException('User not found');
+    }
+    return this.mapUserResponse(updated);
+  }
+
+  async getPreferences(userId: string): Promise<UserPreferencesResponseDto> {
+    const prefs = await this.db.query.userPreferences.findFirst({
+      where: eq(userPreferences.userId, userId),
+    });
+    if (!prefs) {
+      throw new NotFoundException('User preferences not found');
+    }
+    return this.mapPreferencesResponse(prefs);
+  }
+
+  async updatePreferences(
+    userId: string,
+    dto: UpdateUserPreferencesDto,
+  ): Promise<UserPreferencesResponseDto> {
+    const existing = await this.db.query.userPreferences.findFirst({
+      where: eq(userPreferences.userId, userId),
+    });
+    if (!existing) {
+      throw new NotFoundException('User preferences not found');
+    }
+
+    const patch: Partial<typeof userPreferences.$inferInsert> = {};
+    if (dto.language !== undefined) patch.language = dto.language;
+    if (dto.currency !== undefined) patch.currency = dto.currency;
+    if (dto.theme !== undefined) patch.theme = dto.theme;
+
+    if (Object.keys(patch).length === 0) {
+      return this.mapPreferencesResponse(existing);
+    }
+
+    const [updated] = await this.db
+      .update(userPreferences)
+      .set(patch)
+      .where(eq(userPreferences.userId, userId))
+      .returning();
+
+    if (!updated) {
+      throw new NotFoundException('User preferences not found');
+    }
+    return this.mapPreferencesResponse(updated);
   }
 
   async getHealth(userId: string): Promise<UserHealthResponseDto> {
@@ -71,6 +140,21 @@ export class UsersService {
       throw new NotFoundException('User profile not found');
     }
     return this.mapHealthResponse(updated);
+  }
+
+  private mapUserResponse(user: typeof users.$inferSelect): UserResponseDto {
+    const { firebaseUid: _, ...dto } = user;
+    return dto;
+  }
+
+  private mapPreferencesResponse(
+    prefs: typeof userPreferences.$inferSelect,
+  ): UserPreferencesResponseDto {
+    return {
+      language: prefs.language,
+      currency: prefs.currency,
+      theme: prefs.theme,
+    };
   }
 
   private mapHealthResponse(profile: typeof userProfiles.$inferSelect): UserHealthResponseDto {

--- a/apps/api/src/modules/users/users.service.ts
+++ b/apps/api/src/modules/users/users.service.ts
@@ -37,7 +37,7 @@ export class UsersService {
   async updateMe(existingUser: AuthenticatedUser, dto: UpdateUserDto): Promise<UserResponseDto> {
     const patch: Partial<typeof users.$inferInsert> = {};
     if (dto.displayName !== undefined) patch.displayName = dto.displayName.trim();
-    if (dto.avatarUrl !== undefined) patch.avatarUrl = dto.avatarUrl;
+    if (dto.avatarUrl !== undefined) patch.avatarUrl = dto.avatarUrl?.trim() || null;
     if (dto.timezone !== undefined) patch.timezone = dto.timezone;
 
     if (Object.keys(patch).length === 0) {


### PR DESCRIPTION
## Summary

Adds the three remaining user endpoints requested in issue #104. `GET /users/me` already existed — this PR wires up `PATCH /users/me` (displayName, avatarUrl, timezone), `GET /users/me/preferences`, and `PATCH /users/me/preferences` (language, currency, theme). All four endpoints require `FirebaseAuthGuard` and are fully documented with OpenAPI decorators.

## Changes

**New DTOs**
- `UpdateUserDto` — optional fields `displayName` (string, trimmed, max 100), `avatarUrl` (string | null), `timezone` (IANA timezone string)
- `UserPreferencesResponseDto` — `language`, `currency`, `theme` enums
- `UpdateUserPreferencesDto` — optional subset of preference fields

**Service methods (`UsersService`)**
- `updateMe` — partial-patch pattern: builds patch only from defined DTO fields, skips DB write when patch is empty, race-condition guard via `RETURNING` clause
- `getPreferences` — fetches `user_preferences` row, throws `NotFoundException` if missing
- `updatePreferences` — same two-step fetch-then-update pattern as `updateHealth`
- Private helpers: `mapUserResponse` (strips `firebaseUid`), `mapPreferencesResponse`

**Controller (`UsersController`)**
- `PATCH v1/users/me` — `@HttpCode(200)`, full Swagger
- `GET v1/users/me/preferences` — full Swagger
- `PATCH v1/users/me/preferences` — `@HttpCode(200)`, full Swagger

## Testing

- 215 unit tests, all passing; overall coverage remains ≥ 98% statements / ≥ 94% branches
- `updateMe`: empty DTO (no DB write), successful update, race-condition (empty RETURNING), DB error propagation
- `getPreferences`: found, not found, DB error
- `updatePreferences`: empty DTO, successful update, not found on fetch, not found between fetch and update, DB errors on both steps
- Controller delegates verified for all three new routes; `NotFoundException` propagation tested on each

Closes #104