### PR TITLE
feat(users): add GET/PATCH /v1/users/me/profile — personal details

### DIFF
--- a/apps/api/src/database/migrations/0005_split_phone_number.sql
+++ b/apps/api/src/database/migrations/0005_split_phone_number.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "user_profiles" DROP COLUMN "phone_number";--> statement-breakpoint
+ALTER TABLE "user_profiles" ADD COLUMN "phone_country_code" text NOT NULL;--> statement-breakpoint
+ALTER TABLE "user_profiles" ADD COLUMN "phone_local_number" text NOT NULL;

--- a/apps/api/src/database/migrations/meta/0005_snapshot.json
+++ b/apps/api/src/database/migrations/meta/0005_snapshot.json
@@ -1,0 +1,705 @@
+{
+  "id": "0005_split_phone_number",
+  "prevId": "0005_split_phone_number",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_provider": {
+          "name": "auth_provider",
+          "type": "auth_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "firebase_uid": {
+          "name": "firebase_uid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "platform_role": {
+          "name": "platform_role",
+          "type": "platform_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'USER'"
+        },
+        "agency_id": {
+          "name": "agency_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        },
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": ["username"]
+        },
+        "users_firebase_uid_unique": {
+          "name": "users_firebase_uid_unique",
+          "nullsNotDistinct": false,
+          "columns": ["firebase_uid"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "users_username_format": {
+          "name": "users_username_format",
+          "value": "\"users\".\"username\" ~ '^[a-z0-9_-]{3,30}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_preferences": {
+      "name": "user_preferences",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "app_language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ES'"
+        },
+        "currency": {
+          "name": "currency",
+          "type": "app_currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'COP'"
+        },
+        "theme": {
+          "name": "theme",
+          "type": "app_theme",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'SYSTEM'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_preferences_user_id_users_id_fk": {
+          "name": "user_preferences_user_id_users_id_fk",
+          "tableFrom": "user_preferences",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_profiles": {
+      "name": "user_profiles",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_of_birth": {
+          "name": "date_of_birth",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "birth_country": {
+          "name": "birth_country",
+          "type": "char(2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "birth_city": {
+          "name": "birth_city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "home_country": {
+          "name": "home_country",
+          "type": "char(2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "home_city": {
+          "name": "home_city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dietary_preference": {
+          "name": "dietary_preference",
+          "type": "dietary_preference",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'OMNIVORE'"
+        },
+        "dietary_notes": {
+          "name": "dietary_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "general_medical_notes": {
+          "name": "general_medical_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "food_allergies": {
+          "name": "food_allergies",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "phobias": {
+          "name": "phobias",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "physical_limitations": {
+          "name": "physical_limitations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "medical_conditions": {
+          "name": "medical_conditions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "emergency_contacts": {
+          "name": "emergency_contacts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "loyalty_programs": {
+          "name": "loyalty_programs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "phone_country_code": {
+          "name": "phone_country_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": null,
+          "generated": null
+        },
+        "phone_local_number": {
+          "name": "phone_local_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": null,
+          "generated": null
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_profiles_user_id_users_id_fk": {
+          "name": "user_profiles_user_id_users_id_fk",
+          "tableFrom": "user_profiles",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_nationalities": {
+      "name": "user_nationalities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country_code": {
+          "name": "country_code",
+          "type": "char(2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "national_id_number": {
+          "name": "national_id_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "passport_number": {
+          "name": "passport_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "passport_issue_date": {
+          "name": "passport_issue_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "passport_expiry_date": {
+          "name": "passport_expiry_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "passport_status": {
+          "name": "passport_status",
+          "type": "passport_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_nationalities_user_id_idx": {
+          "name": "user_nationalities_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_nationalities_one_primary_per_user": {
+          "name": "user_nationalities_one_primary_per_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"user_nationalities\".\"is_primary\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_nationalities_user_id_users_id_fk": {
+          "name": "user_nationalities_user_id_users_id_fk",
+          "tableFrom": "user_nationalities",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_nationalities_user_id_country_code_unique": {
+          "name": "user_nationalities_user_id_country_code_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id", "country_code"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "passport_data_consistency": {
+          "name": "passport_data_consistency",
+          "value": "(\"user_nationalities\".\"passport_status\" = 'OMITTED'\n        AND \"user_nationalities\".\"passport_number\" IS NULL\n        AND \"user_nationalities\".\"passport_issue_date\" IS NULL\n        AND \"user_nationalities\".\"passport_expiry_date\" IS NULL)\n      OR\n      (\"user_nationalities\".\"passport_status\" <> 'OMITTED'\n        AND \"user_nationalities\".\"passport_number\" IS NOT NULL\n        AND \"user_nationalities\".\"passport_issue_date\" IS NOT NULL\n        AND \"user_nationalities\".\"passport_expiry_date\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.support_admin_audit_log": {
+      "name": "support_admin_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "admin_user_id": {
+          "name": "admin_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_table": {
+          "name": "target_table",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "before_state": {
+          "name": "before_state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "after_state": {
+          "name": "after_state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "performed_at": {
+          "name": "performed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "support_admin_audit_log_admin_user_id_idx": {
+          "name": "support_admin_audit_log_admin_user_id_idx",
+          "columns": [
+            {
+              "expression": "admin_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "support_admin_audit_log_performed_at_idx": {
+          "name": "support_admin_audit_log_performed_at_idx",
+          "columns": [
+            {
+              "expression": "performed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "support_admin_audit_log_admin_user_id_users_id_fk": {
+          "name": "support_admin_audit_log_admin_user_id_users_id_fk",
+          "tableFrom": "support_admin_audit_log",
+          "tableTo": "users",
+          "columnsFrom": ["admin_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.auth_provider": {
+      "name": "auth_provider",
+      "schema": "public",
+      "values": ["GOOGLE", "FACEBOOK"]
+    },
+    "public.platform_role": {
+      "name": "platform_role",
+      "schema": "public",
+      "values": ["USER", "SUPPORT_ADMIN"]
+    },
+    "public.app_currency": {
+      "name": "app_currency",
+      "schema": "public",
+      "values": ["COP", "USD"]
+    },
+    "public.app_language": {
+      "name": "app_language",
+      "schema": "public",
+      "values": ["ES", "EN"]
+    },
+    "public.app_theme": {
+      "name": "app_theme",
+      "schema": "public",
+      "values": ["LIGHT", "DARK", "SYSTEM"]
+    },
+    "public.dietary_preference": {
+      "name": "dietary_preference",
+      "schema": "public",
+      "values": ["OMNIVORE", "VEGETARIAN", "VEGAN", "PESCATARIAN", "GLUTEN_FREE", "OTHER"]
+    },
+    "public.food_allergen": {
+      "name": "food_allergen",
+      "schema": "public",
+      "values": [
+        "GLUTEN",
+        "CRUSTACEANS",
+        "EGGS",
+        "FISH",
+        "PEANUTS",
+        "SOYBEANS",
+        "MILK",
+        "TREE_NUTS",
+        "CELERY",
+        "MUSTARD",
+        "SESAME",
+        "SULPHITES",
+        "LUPIN",
+        "MOLLUSCS",
+        "OTHER"
+      ]
+    },
+    "public.medical_condition_type": {
+      "name": "medical_condition_type",
+      "schema": "public",
+      "values": [
+        "DIABETES",
+        "EPILEPSY",
+        "SEVERE_ALLERGY_EPIPEN",
+        "ASTHMA",
+        "HEART_CONDITION",
+        "HYPERTENSION",
+        "BLOOD_CLOTTING_DISORDER",
+        "IMMUNODEFICIENCY",
+        "MENTAL_HEALTH_CONDITION",
+        "OTHER"
+      ]
+    },
+    "public.phobia_type": {
+      "name": "phobia_type",
+      "schema": "public",
+      "values": [
+        "HEIGHTS",
+        "ENCLOSED_SPACES",
+        "FLYING",
+        "DEEP_WATER",
+        "OPEN_WATER",
+        "ANIMALS",
+        "INSECTS",
+        "SNAKES",
+        "SPIDERS",
+        "DARKNESS",
+        "CROWDS",
+        "MOTION_SICKNESS",
+        "OTHER"
+      ]
+    },
+    "public.physical_limitation_type": {
+      "name": "physical_limitation_type",
+      "schema": "public",
+      "values": [
+        "WHEELCHAIR_USER",
+        "REDUCED_MOBILITY",
+        "CANNOT_USE_STAIRS",
+        "HEARING_IMPAIRMENT",
+        "VISUAL_IMPAIRMENT",
+        "REQUIRES_OXYGEN",
+        "REQUIRES_CPAP",
+        "CHRONIC_PAIN",
+        "JOINT_CONDITION",
+        "CARDIAC_CONDITION",
+        "RESPIRATORY_CONDITION",
+        "PREGNANCY",
+        "OTHER"
+      ]
+    },
+    "public.passport_status": {
+      "name": "passport_status",
+      "schema": "public",
+      "values": ["OMITTED", "ACTIVE", "EXPIRING_SOON", "EXPIRED"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/src/database/migrations/meta/0005_snapshot.json
+++ b/apps/api/src/database/migrations/meta/0005_snapshot.json
@@ -1,6 +1,6 @@
 {
-  "id": "0005_split_phone_number",
-  "prevId": "0005_split_phone_number",
+  "id": "b63d0408-6527-4136-969f-0e463c4a523d",
+  "prevId": "3b07df81-3c62-401b-b83b-a855db987edf",
   "version": "7",
   "dialect": "postgresql",
   "tables": {

--- a/apps/api/src/database/migrations/meta/_journal.json
+++ b/apps/api/src/database/migrations/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1776448136514,
       "tag": "0004_short_sage",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1776533154010,
+      "tag": "0005_split_phone_number",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/modules/users/dto/date-of-birth.dto.ts
+++ b/apps/api/src/modules/users/dto/date-of-birth.dto.ts
@@ -14,10 +14,10 @@ export class DateOfBirthDto {
   @Max(12)
   month!: number;
 
-  @ApiProperty({ example: 1990, minimum: 1900, maximum: new Date().getFullYear() })
+  @ApiProperty({ example: 1990, minimum: 1900, maximum: new Date().getFullYear() - 15 })
   @IsInt()
   @Min(1900)
-  @Max(new Date().getFullYear())
+  @Max(new Date().getFullYear() - 15)
   year!: number;
 
   @ApiProperty({ example: true })

--- a/apps/api/src/modules/users/dto/date-of-birth.dto.ts
+++ b/apps/api/src/modules/users/dto/date-of-birth.dto.ts
@@ -1,0 +1,26 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsBoolean, IsInt, Max, Min } from 'class-validator';
+
+export class DateOfBirthDto {
+  @ApiProperty({ example: 15, minimum: 1, maximum: 31 })
+  @IsInt()
+  @Min(1)
+  @Max(31)
+  day!: number;
+
+  @ApiProperty({ example: 6, minimum: 1, maximum: 12 })
+  @IsInt()
+  @Min(1)
+  @Max(12)
+  month!: number;
+
+  @ApiProperty({ example: 1990, minimum: 1900, maximum: new Date().getFullYear() })
+  @IsInt()
+  @Min(1900)
+  @Max(new Date().getFullYear())
+  year!: number;
+
+  @ApiProperty({ example: true })
+  @IsBoolean()
+  yearVisible!: boolean;
+}

--- a/apps/api/src/modules/users/dto/update-user-profile.dto.spec.ts
+++ b/apps/api/src/modules/users/dto/update-user-profile.dto.spec.ts
@@ -40,6 +40,63 @@ describe('UpdateUserProfileDto', () => {
     });
   });
 
+  describe('firstName / lastName / phoneNumber validation', () => {
+    it('accepts valid firstName and lastName', async () => {
+      const dto = plainToInstance(UpdateUserProfileDto, { firstName: 'Ana', lastName: 'Pérez' });
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('rejects firstName shorter than 2 characters', async () => {
+      const dto = plainToInstance(UpdateUserProfileDto, { firstName: 'A' });
+      const errors = await validate(dto);
+      expect(errors.some((e) => e.property === 'firstName')).toBe(true);
+    });
+
+    it('rejects whitespace-only firstName (trimmed to empty before validating)', async () => {
+      const dto = plainToInstance(UpdateUserProfileDto, { firstName: '   ' });
+      const errors = await validate(dto);
+      expect(errors.some((e) => e.property === 'firstName')).toBe(true);
+    });
+
+    it('trims firstName before validating', async () => {
+      const dto = plainToInstance(UpdateUserProfileDto, { firstName: '  John  ' });
+      expect(dto.firstName).toBe('John');
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('accepts a valid E.164 phoneNumber', async () => {
+      const dto = plainToInstance(UpdateUserProfileDto, { phoneNumber: '+573001234567' });
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('rejects phoneNumber without leading +', async () => {
+      const dto = plainToInstance(UpdateUserProfileDto, { phoneNumber: '573001234567' });
+      const errors = await validate(dto);
+      expect(errors.some((e) => e.property === 'phoneNumber')).toBe(true);
+    });
+
+    it('rejects phoneNumber with invalid E.164 format', async () => {
+      const dto = plainToInstance(UpdateUserProfileDto, { phoneNumber: '+0123456' });
+      const errors = await validate(dto);
+      expect(errors.some((e) => e.property === 'phoneNumber')).toBe(true);
+    });
+
+    it('passes non-string values through the trim transform and rejects with IsString', async () => {
+      const dto = plainToInstance(UpdateUserProfileDto, {
+        firstName: 42,
+        lastName: true,
+        phoneNumber: [],
+      });
+      const errors = await validate(dto);
+      expect(errors.some((e) => e.property === 'firstName')).toBe(true);
+      expect(errors.some((e) => e.property === 'lastName')).toBe(true);
+      expect(errors.some((e) => e.property === 'phoneNumber')).toBe(true);
+    });
+  });
+
   describe('country code validation', () => {
     it('accepts valid ISO 3166-1 alpha-2 country codes', async () => {
       const dto = plainToInstance(UpdateUserProfileDto, {

--- a/apps/api/src/modules/users/dto/update-user-profile.dto.spec.ts
+++ b/apps/api/src/modules/users/dto/update-user-profile.dto.spec.ts
@@ -66,34 +66,60 @@ describe('UpdateUserProfileDto', () => {
       expect(errors).toHaveLength(0);
     });
 
-    it('accepts a valid E.164 phoneNumber', async () => {
-      const dto = plainToInstance(UpdateUserProfileDto, { phoneNumber: '+573001234567' });
+    it('accepts valid phoneCountryCode and phoneLocalNumber', async () => {
+      const dto = plainToInstance(UpdateUserProfileDto, {
+        phoneCountryCode: '+57',
+        phoneLocalNumber: '3001234567',
+      });
       const errors = await validate(dto);
       expect(errors).toHaveLength(0);
     });
 
-    it('rejects phoneNumber without leading +', async () => {
-      const dto = plainToInstance(UpdateUserProfileDto, { phoneNumber: '573001234567' });
+    it('accepts single-digit country code (+1)', async () => {
+      const dto = plainToInstance(UpdateUserProfileDto, {
+        phoneCountryCode: '+1',
+        phoneLocalNumber: '3055551234',
+      });
       const errors = await validate(dto);
-      expect(errors.some((e) => e.property === 'phoneNumber')).toBe(true);
+      expect(errors).toHaveLength(0);
     });
 
-    it('rejects phoneNumber with invalid E.164 format', async () => {
-      const dto = plainToInstance(UpdateUserProfileDto, { phoneNumber: '+0123456' });
+    it('rejects phoneCountryCode without leading +', async () => {
+      const dto = plainToInstance(UpdateUserProfileDto, { phoneCountryCode: '57' });
       const errors = await validate(dto);
-      expect(errors.some((e) => e.property === 'phoneNumber')).toBe(true);
+      expect(errors.some((e) => e.property === 'phoneCountryCode')).toBe(true);
+    });
+
+    it('rejects phoneCountryCode starting with +0', async () => {
+      const dto = plainToInstance(UpdateUserProfileDto, { phoneCountryCode: '+0' });
+      const errors = await validate(dto);
+      expect(errors.some((e) => e.property === 'phoneCountryCode')).toBe(true);
+    });
+
+    it('rejects phoneLocalNumber with letters or symbols', async () => {
+      const dto = plainToInstance(UpdateUserProfileDto, { phoneLocalNumber: '300-123-4567' });
+      const errors = await validate(dto);
+      expect(errors.some((e) => e.property === 'phoneLocalNumber')).toBe(true);
+    });
+
+    it('rejects phoneLocalNumber shorter than 4 digits', async () => {
+      const dto = plainToInstance(UpdateUserProfileDto, { phoneLocalNumber: '123' });
+      const errors = await validate(dto);
+      expect(errors.some((e) => e.property === 'phoneLocalNumber')).toBe(true);
     });
 
     it('passes non-string values through the trim transform and rejects with IsString', async () => {
       const dto = plainToInstance(UpdateUserProfileDto, {
         firstName: 42,
         lastName: true,
-        phoneNumber: [],
+        phoneCountryCode: [],
+        phoneLocalNumber: {},
       });
       const errors = await validate(dto);
       expect(errors.some((e) => e.property === 'firstName')).toBe(true);
       expect(errors.some((e) => e.property === 'lastName')).toBe(true);
-      expect(errors.some((e) => e.property === 'phoneNumber')).toBe(true);
+      expect(errors.some((e) => e.property === 'phoneCountryCode')).toBe(true);
+      expect(errors.some((e) => e.property === 'phoneLocalNumber')).toBe(true);
     });
   });
 

--- a/apps/api/src/modules/users/dto/update-user-profile.dto.spec.ts
+++ b/apps/api/src/modules/users/dto/update-user-profile.dto.spec.ts
@@ -1,0 +1,71 @@
+import 'reflect-metadata';
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { UpdateUserProfileDto } from './update-user-profile.dto';
+
+describe('UpdateUserProfileDto', () => {
+  describe('dateOfBirth nested validation', () => {
+    it('accepts a valid dateOfBirth object', async () => {
+      const dto = plainToInstance(UpdateUserProfileDto, {
+        dateOfBirth: { day: 15, month: 6, year: 1990, yearVisible: true },
+      });
+
+      const errors = await validate(dto);
+
+      expect(errors).toHaveLength(0);
+      expect(dto.dateOfBirth?.day).toBe(15);
+      expect(dto.dateOfBirth?.yearVisible).toBe(true);
+    });
+
+    it('rejects dateOfBirth with out-of-range day', async () => {
+      const dto = plainToInstance(UpdateUserProfileDto, {
+        dateOfBirth: { day: 32, month: 6, year: 1990, yearVisible: true },
+      });
+
+      const errors = await validate(dto);
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0]?.children?.[0]?.property).toBe('day');
+    });
+
+    it('rejects dateOfBirth with invalid month', async () => {
+      const dto = plainToInstance(UpdateUserProfileDto, {
+        dateOfBirth: { day: 15, month: 13, year: 1990, yearVisible: true },
+      });
+
+      const errors = await validate(dto);
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0]?.children?.[0]?.property).toBe('month');
+    });
+  });
+
+  describe('country code validation', () => {
+    it('accepts valid ISO 3166-1 alpha-2 country codes', async () => {
+      const dto = plainToInstance(UpdateUserProfileDto, {
+        birthCountry: 'CO',
+        homeCountry: 'US',
+      });
+
+      const errors = await validate(dto);
+
+      expect(errors).toHaveLength(0);
+    });
+
+    it('rejects lowercase country codes', async () => {
+      const dto = plainToInstance(UpdateUserProfileDto, { homeCountry: 'co' });
+
+      const errors = await validate(dto);
+
+      expect(errors.some((e) => e.property === 'homeCountry')).toBe(true);
+    });
+
+    it('rejects country codes longer than 2 characters', async () => {
+      const dto = plainToInstance(UpdateUserProfileDto, { birthCountry: 'COL' });
+
+      const errors = await validate(dto);
+
+      expect(errors.some((e) => e.property === 'birthCountry')).toBe(true);
+    });
+  });
+});

--- a/apps/api/src/modules/users/dto/update-user-profile.dto.ts
+++ b/apps/api/src/modules/users/dto/update-user-profile.dto.ts
@@ -63,20 +63,32 @@ export class UpdateUserProfileDto {
   homeCity?: string | null;
 
   @ApiProperty({
-    example: '+573001234567',
+    example: '+57',
     description:
-      'Phone number in E.164 format (e.g. +573001234567). ' +
-      'Must start with + followed by country code and subscriber number (max 15 digits total). ' +
-      'Frontend must enforce this format before submitting.',
+      'Phone country code in E.164 format (e.g. +57, +1, +593). ' +
+      'Must start with + followed by 1–3 digits. Frontend must enforce this format.',
     required: false,
   })
   @IsOptional()
   @Transform(({ value }) => (typeof value === 'string' ? value.trim() : value))
   @IsString()
-  @Matches(/^\+[1-9]\d{1,14}$/, {
-    message: 'phoneNumber must be a valid E.164 number (e.g. +573001234567)',
+  @Matches(/^\+[1-9]\d{0,2}$/, {
+    message: 'phoneCountryCode must be a valid country code (e.g. +57, +1, +593)',
   })
-  phoneNumber?: string;
+  phoneCountryCode?: string;
+
+  @ApiProperty({
+    example: '3001234567',
+    description: 'Local phone number without country code — digits only, 4–14 digits.',
+    required: false,
+  })
+  @IsOptional()
+  @Transform(({ value }) => (typeof value === 'string' ? value.trim() : value))
+  @IsString()
+  @Matches(/^\d{4,14}$/, {
+    message: 'phoneLocalNumber must contain 4–14 digits with no spaces or symbols',
+  })
+  phoneLocalNumber?: string;
 
   @ApiProperty({ example: 'Travel enthusiast.', nullable: true, required: false })
   @IsOptional()

--- a/apps/api/src/modules/users/dto/update-user-profile.dto.ts
+++ b/apps/api/src/modules/users/dto/update-user-profile.dto.ts
@@ -1,27 +1,29 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { Type } from 'class-transformer';
+import { Transform, Type } from 'class-transformer';
 import {
-  IsNotEmpty,
   IsOptional,
   IsString,
   Matches,
   MaxLength,
+  MinLength,
   ValidateNested,
 } from 'class-validator';
 import { DateOfBirthDto } from './date-of-birth.dto';
 
 export class UpdateUserProfileDto {
-  @ApiProperty({ example: 'John', maxLength: 100, required: false })
+  @ApiProperty({ example: 'John', minLength: 2, maxLength: 100, required: false })
   @IsOptional()
+  @Transform(({ value }) => (typeof value === 'string' ? value.trim() : value))
   @IsString()
-  @IsNotEmpty()
+  @MinLength(2)
   @MaxLength(100)
   firstName?: string;
 
-  @ApiProperty({ example: 'Doe', maxLength: 100, required: false })
+  @ApiProperty({ example: 'Doe', minLength: 2, maxLength: 100, required: false })
   @IsOptional()
+  @Transform(({ value }) => (typeof value === 'string' ? value.trim() : value))
   @IsString()
-  @IsNotEmpty()
+  @MinLength(2)
   @MaxLength(100)
   lastName?: string;
 
@@ -60,11 +62,20 @@ export class UpdateUserProfileDto {
   @IsString()
   homeCity?: string | null;
 
-  @ApiProperty({ example: '+573001234567', maxLength: 30, required: false })
+  @ApiProperty({
+    example: '+573001234567',
+    description:
+      'Phone number in E.164 format (e.g. +573001234567). ' +
+      'Must start with + followed by country code and subscriber number (max 15 digits total). ' +
+      'Frontend must enforce this format before submitting.',
+    required: false,
+  })
   @IsOptional()
+  @Transform(({ value }) => (typeof value === 'string' ? value.trim() : value))
   @IsString()
-  @IsNotEmpty()
-  @MaxLength(30)
+  @Matches(/^\+[1-9]\d{1,14}$/, {
+    message: 'phoneNumber must be a valid E.164 number (e.g. +573001234567)',
+  })
   phoneNumber?: string;
 
   @ApiProperty({ example: 'Travel enthusiast.', nullable: true, required: false })

--- a/apps/api/src/modules/users/dto/update-user-profile.dto.ts
+++ b/apps/api/src/modules/users/dto/update-user-profile.dto.ts
@@ -1,0 +1,74 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import {
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  Matches,
+  MaxLength,
+  ValidateNested,
+} from 'class-validator';
+import { DateOfBirthDto } from './date-of-birth.dto';
+
+export class UpdateUserProfileDto {
+  @ApiProperty({ example: 'John', maxLength: 100, required: false })
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(100)
+  firstName?: string;
+
+  @ApiProperty({ example: 'Doe', maxLength: 100, required: false })
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(100)
+  lastName?: string;
+
+  @ApiProperty({ type: DateOfBirthDto, required: false })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => DateOfBirthDto)
+  dateOfBirth?: DateOfBirthDto;
+
+  @ApiProperty({
+    example: 'CO',
+    description: 'ISO 3166-1 alpha-2 country code (two uppercase letters). Null clears the field.',
+    nullable: true,
+    required: false,
+  })
+  @IsOptional()
+  @Matches(/^[A-Z]{2}$/, { message: 'birthCountry must be a 2-letter uppercase ISO country code' })
+  birthCountry?: string | null;
+
+  @ApiProperty({ example: 'Bogotá', nullable: true, required: false })
+  @IsOptional()
+  @IsString()
+  birthCity?: string | null;
+
+  @ApiProperty({
+    example: 'CO',
+    description: 'ISO 3166-1 alpha-2 country code (two uppercase letters).',
+    required: false,
+  })
+  @IsOptional()
+  @Matches(/^[A-Z]{2}$/, { message: 'homeCountry must be a 2-letter uppercase ISO country code' })
+  homeCountry?: string;
+
+  @ApiProperty({ example: 'Medellín', nullable: true, required: false })
+  @IsOptional()
+  @IsString()
+  homeCity?: string | null;
+
+  @ApiProperty({ example: '+573001234567', maxLength: 30, required: false })
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(30)
+  phoneNumber?: string;
+
+  @ApiProperty({ example: 'Travel enthusiast.', nullable: true, required: false })
+  @IsOptional()
+  @IsString()
+  bio?: string | null;
+}

--- a/apps/api/src/modules/users/dto/user-profile-response.dto.ts
+++ b/apps/api/src/modules/users/dto/user-profile-response.dto.ts
@@ -23,8 +23,11 @@ export class UserProfileResponseDto {
   @ApiProperty({ example: 'Medellín', nullable: true })
   homeCity!: string | null;
 
-  @ApiProperty({ example: '+573001234567' })
-  phoneNumber!: string;
+  @ApiProperty({ example: '+57', description: 'Phone country code (e.g. +57, +1, +593)' })
+  phoneCountryCode!: string;
+
+  @ApiProperty({ example: '3001234567', description: 'Local phone number — digits only' })
+  phoneLocalNumber!: string;
 
   @ApiProperty({ example: 'Travel enthusiast.', nullable: true })
   bio!: string | null;

--- a/apps/api/src/modules/users/dto/user-profile-response.dto.ts
+++ b/apps/api/src/modules/users/dto/user-profile-response.dto.ts
@@ -1,0 +1,31 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { DateOfBirthDto } from './date-of-birth.dto';
+
+export class UserProfileResponseDto {
+  @ApiProperty({ example: 'John' })
+  firstName!: string;
+
+  @ApiProperty({ example: 'Doe' })
+  lastName!: string;
+
+  @ApiProperty({ type: DateOfBirthDto })
+  dateOfBirth!: DateOfBirthDto;
+
+  @ApiProperty({ example: 'CO', nullable: true })
+  birthCountry!: string | null;
+
+  @ApiProperty({ example: 'Bogotá', nullable: true })
+  birthCity!: string | null;
+
+  @ApiProperty({ example: 'CO' })
+  homeCountry!: string;
+
+  @ApiProperty({ example: 'Medellín', nullable: true })
+  homeCity!: string | null;
+
+  @ApiProperty({ example: '+573001234567' })
+  phoneNumber!: string;
+
+  @ApiProperty({ example: 'Travel enthusiast.', nullable: true })
+  bio!: string | null;
+}

--- a/apps/api/src/modules/users/schema/user-profiles.schema.ts
+++ b/apps/api/src/modules/users/schema/user-profiles.schema.ts
@@ -93,7 +93,8 @@ export const userProfiles = pgTable('user_profiles', {
   birthCity: text('birth_city'),
   homeCountry: char('home_country', { length: 2 }).notNull(),
   homeCity: text('home_city'),
-  phoneNumber: text('phone_number').notNull(),
+  phoneCountryCode: text('phone_country_code').notNull(),
+  phoneLocalNumber: text('phone_local_number').notNull(),
   bio: text('bio'),
   dietaryPreference: dietaryPreferenceEnum('dietary_preference')
     .notNull()

--- a/apps/api/src/modules/users/users.controller.spec.ts
+++ b/apps/api/src/modules/users/users.controller.spec.ts
@@ -65,7 +65,8 @@ const mockProfileResponse: UserProfileResponseDto = {
   birthCity: null,
   homeCountry: 'CO',
   homeCity: null,
-  phoneNumber: '+573001234567',
+  phoneCountryCode: '+57',
+  phoneLocalNumber: '3001234567',
   bio: null,
 };
 

--- a/apps/api/src/modules/users/users.controller.spec.ts
+++ b/apps/api/src/modules/users/users.controller.spec.ts
@@ -14,8 +14,10 @@ import { UsersService } from './users.service';
 import type { UpdateUserDto } from './dto/update-user.dto';
 import type { UpdateUserHealthDto } from './dto/update-user-health.dto';
 import type { UpdateUserPreferencesDto } from './dto/update-user-preferences.dto';
+import type { UpdateUserProfileDto } from './dto/update-user-profile.dto';
 import type { UserHealthResponseDto } from './dto/user-health-response.dto';
 import type { UserPreferencesResponseDto } from './dto/user-preferences-response.dto';
+import type { UserProfileResponseDto } from './dto/user-profile-response.dto';
 import type { AuthenticatedUser } from '@/types/express';
 
 const NOW = new Date('2026-01-01T00:00:00.000Z');
@@ -55,6 +57,18 @@ const mockHealthResponse: UserHealthResponseDto = {
   medicalConditions: [],
 };
 
+const mockProfileResponse: UserProfileResponseDto = {
+  firstName: 'John',
+  lastName: 'Doe',
+  dateOfBirth: { day: 1, month: 1, year: 1990, yearVisible: true },
+  birthCountry: null,
+  birthCity: null,
+  homeCountry: 'CO',
+  homeCity: null,
+  phoneNumber: '+573001234567',
+  bio: null,
+};
+
 describe('UsersController', () => {
   let controller: UsersController;
   let mockFindByFirebaseUid: jest.Mock;
@@ -64,6 +78,8 @@ describe('UsersController', () => {
   let mockUpdateHealth: jest.Mock;
   let mockGetPreferences: jest.Mock;
   let mockUpdatePreferences: jest.Mock;
+  let mockGetProfile: jest.Mock;
+  let mockUpdateProfile: jest.Mock;
 
   beforeEach(async () => {
     mockFindByFirebaseUid = jest.fn().mockResolvedValue(mockUser);
@@ -75,6 +91,8 @@ describe('UsersController', () => {
     mockUpdateHealth = jest.fn().mockResolvedValue(mockHealthResponse);
     mockGetPreferences = jest.fn().mockResolvedValue(mockPreferencesResponse);
     mockUpdatePreferences = jest.fn().mockResolvedValue(mockPreferencesResponse);
+    mockGetProfile = jest.fn().mockResolvedValue(mockProfileResponse);
+    mockUpdateProfile = jest.fn().mockResolvedValue(mockProfileResponse);
 
     const module: TestingModule = await Test.createTestingModule({
       controllers: [UsersController],
@@ -89,6 +107,8 @@ describe('UsersController', () => {
             updateHealth: mockUpdateHealth,
             getPreferences: mockGetPreferences,
             updatePreferences: mockUpdatePreferences,
+            getProfile: mockGetProfile,
+            updateProfile: mockUpdateProfile,
           },
         },
       ],
@@ -257,6 +277,42 @@ describe('UsersController', () => {
 
       await expect(
         controller.updatePreferences(mockAuthUser, {} as UpdateUserPreferencesDto),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('GET /v1/users/me/profile', () => {
+    it('delegates to usersService.getProfile with the authenticated user id', async () => {
+      const result = await controller.getProfile(mockAuthUser);
+
+      expect(mockGetProfile).toHaveBeenCalledWith(mockAuthUser.id);
+      expect(result).toEqual(mockProfileResponse);
+    });
+
+    it('propagates NotFoundException from the service', async () => {
+      mockGetProfile.mockRejectedValue(new NotFoundException());
+
+      await expect(controller.getProfile(mockAuthUser)).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('PATCH /v1/users/me/profile', () => {
+    it('delegates to usersService.updateProfile with the user id and dto', async () => {
+      const dto: UpdateUserProfileDto = { firstName: 'Jane' };
+      const updated: UserProfileResponseDto = { ...mockProfileResponse, firstName: 'Jane' };
+      mockUpdateProfile.mockResolvedValue(updated);
+
+      const result = await controller.updateProfile(mockAuthUser, dto);
+
+      expect(mockUpdateProfile).toHaveBeenCalledWith(mockAuthUser.id, dto);
+      expect(result).toEqual(updated);
+    });
+
+    it('propagates NotFoundException from the service', async () => {
+      mockUpdateProfile.mockRejectedValue(new NotFoundException());
+
+      await expect(
+        controller.updateProfile(mockAuthUser, {} as UpdateUserProfileDto),
       ).rejects.toThrow(NotFoundException);
     });
   });

--- a/apps/api/src/modules/users/users.controller.ts
+++ b/apps/api/src/modules/users/users.controller.ts
@@ -15,8 +15,10 @@ import { UsersService } from './users.service';
 import { UpdateUserDto } from './dto/update-user.dto';
 import { UpdateUserHealthDto } from './dto/update-user-health.dto';
 import { UpdateUserPreferencesDto } from './dto/update-user-preferences.dto';
+import { UpdateUserProfileDto } from './dto/update-user-profile.dto';
 import { UserHealthResponseDto } from './dto/user-health-response.dto';
 import { UserPreferencesResponseDto } from './dto/user-preferences-response.dto';
+import { UserProfileResponseDto } from './dto/user-profile-response.dto';
 import { UserResponseDto } from './dto/user-response.dto';
 import { UsernameAvailabilityDto } from './dto/username-availability.dto';
 
@@ -100,6 +102,42 @@ export class UsersController {
     @Body() dto: UpdateUserHealthDto,
   ): Promise<UserHealthResponseDto> {
     return this.usersService.updateHealth(user.id, dto);
+  }
+
+  @Get('me/profile')
+  @ApiOperation({
+    summary: "Get the current user's personal profile",
+    description:
+      "Returns the personal-detail fields from the authenticated user's profile: " +
+      'first name, last name, date of birth, birth country/city, home country/city, ' +
+      'phone number, and bio.',
+  })
+  @ApiResponse({ status: 200, type: UserProfileResponseDto })
+  @ApiResponse({ status: 401, description: 'Missing or invalid Firebase ID token' })
+  @ApiResponse({ status: 404, description: 'User profile not found' })
+  getProfile(@CurrentUser() user: AuthenticatedUser): Promise<UserProfileResponseDto> {
+    return this.usersService.getProfile(user.id);
+  }
+
+  @Patch('me/profile')
+  @HttpCode(200)
+  @ApiBody({ type: UpdateUserProfileDto })
+  @ApiOperation({
+    summary: "Update the current user's personal profile",
+    description:
+      'Updates any subset of personal-detail fields. ' +
+      'Country codes must be ISO 3166-1 alpha-2 (two uppercase letters). ' +
+      'Empty or whitespace-only text fields (birthCity, homeCity, bio) are stored as null.',
+  })
+  @ApiResponse({ status: 200, type: UserProfileResponseDto })
+  @ApiResponse({ status: 400, description: 'Validation failed — invalid field value' })
+  @ApiResponse({ status: 401, description: 'Missing or invalid Firebase ID token' })
+  @ApiResponse({ status: 404, description: 'User profile not found' })
+  updateProfile(
+    @CurrentUser() user: AuthenticatedUser,
+    @Body() dto: UpdateUserProfileDto,
+  ): Promise<UserProfileResponseDto> {
+    return this.usersService.updateProfile(user.id, dto);
   }
 
   @Get('me/preferences')

--- a/apps/api/src/modules/users/users.service.spec.ts
+++ b/apps/api/src/modules/users/users.service.spec.ts
@@ -38,7 +38,8 @@ const mockHealthProfile = {
   birthCity: null,
   homeCountry: 'CO',
   homeCity: null,
-  phoneNumber: '+573001234567',
+  phoneCountryCode: '+57',
+  phoneLocalNumber: '3001234567',
   bio: null,
   dietaryPreference: DietaryPreference.OMNIVORE,
   dietaryNotes: null,
@@ -462,7 +463,8 @@ describe('UsersService', () => {
       expect(result.firstName).toBe('John');
       expect(result.lastName).toBe('Doe');
       expect(result.homeCountry).toBe('CO');
-      expect(result.phoneNumber).toBe('+573001234567');
+      expect(result.phoneCountryCode).toBe('+57');
+      expect(result.phoneLocalNumber).toBe('3001234567');
     });
 
     it('translates year_visible to yearVisible in the response', async () => {
@@ -532,7 +534,8 @@ describe('UsersService', () => {
         birthCity: 'Cali',
         homeCountry: 'US',
         homeCity: 'Miami',
-        phoneNumber: '+13055551234',
+        phoneCountryCode: '+1',
+        phoneLocalNumber: '3055551234',
       };
       mockReturning.mockResolvedValue([updated]);
 
@@ -542,7 +545,8 @@ describe('UsersService', () => {
         birthCity: 'Cali',
         homeCountry: 'US',
         homeCity: 'Miami',
-        phoneNumber: '+13055551234',
+        phoneCountryCode: '+1',
+        phoneLocalNumber: '3055551234',
       });
 
       expect(result.firstName).toBe('Jane');
@@ -550,7 +554,8 @@ describe('UsersService', () => {
       expect(result.birthCity).toBe('Cali');
       expect(result.homeCountry).toBe('US');
       expect(result.homeCity).toBe('Miami');
-      expect(result.phoneNumber).toBe('+13055551234');
+      expect(result.phoneCountryCode).toBe('+1');
+      expect(result.phoneLocalNumber).toBe('3055551234');
     });
 
     it('normalizes null birthCity and homeCity to null before saving', async () => {

--- a/apps/api/src/modules/users/users.service.spec.ts
+++ b/apps/api/src/modules/users/users.service.spec.ts
@@ -17,6 +17,7 @@ import { UsersService } from './users.service';
 import type { UpdateUserDto } from './dto/update-user.dto';
 import type { UpdateUserHealthDto } from './dto/update-user-health.dto';
 import type { UpdateUserPreferencesDto } from './dto/update-user-preferences.dto';
+import type { UpdateUserProfileDto } from './dto/update-user-profile.dto';
 import type { UserHealthResponseDto } from './dto/user-health-response.dto';
 import type { AuthenticatedUser } from '@/types/express';
 
@@ -182,6 +183,16 @@ describe('UsersService', () => {
       expect(result).not.toHaveProperty('firebaseUid');
     });
 
+    it('updates timezone and returns the mapped response', async () => {
+      const updated = { ...mockUser, timezone: 'America/Bogota' };
+      mockReturning.mockResolvedValue([updated]);
+
+      const result = await service.updateMe(mockUser, { timezone: 'America/Bogota' });
+
+      expect(mockSet).toHaveBeenCalledWith(expect.objectContaining({ timezone: 'America/Bogota' }));
+      expect(result.timezone).toBe('America/Bogota');
+    });
+
     it('normalizes empty and whitespace-only avatarUrl to null before saving', async () => {
       mockReturning.mockResolvedValue([{ ...mockUser, avatarUrl: null }]);
 
@@ -245,11 +256,22 @@ describe('UsersService', () => {
 
     it('updates and returns the mapped preferences on success', async () => {
       mockPrefFindFirst.mockResolvedValue(mockPreferences);
-      const updated = { ...mockPreferences, theme: AppTheme.DARK };
+      const updated = {
+        ...mockPreferences,
+        language: AppLanguage.EN,
+        currency: AppCurrency.USD,
+        theme: AppTheme.DARK,
+      };
       mockReturning.mockResolvedValue([updated]);
 
-      const result = await service.updatePreferences('user-uuid', { theme: AppTheme.DARK });
+      const result = await service.updatePreferences('user-uuid', {
+        language: AppLanguage.EN,
+        currency: AppCurrency.USD,
+        theme: AppTheme.DARK,
+      });
 
+      expect(result.language).toBe(AppLanguage.EN);
+      expect(result.currency).toBe(AppCurrency.USD);
       expect(result.theme).toBe(AppTheme.DARK);
     });
 
@@ -428,6 +450,164 @@ describe('UsersService', () => {
       await expect(
         service.updateHealth('user-uuid', { dietaryPreference: DietaryPreference.VEGAN }),
       ).rejects.toThrow(dbError);
+    });
+  });
+
+  describe('getProfile', () => {
+    it('returns the mapped profile response when found', async () => {
+      mockProfileFindFirst.mockResolvedValue(mockHealthProfile);
+
+      const result = await service.getProfile('user-uuid');
+
+      expect(result.firstName).toBe('John');
+      expect(result.lastName).toBe('Doe');
+      expect(result.homeCountry).toBe('CO');
+      expect(result.phoneNumber).toBe('+573001234567');
+    });
+
+    it('translates year_visible to yearVisible in the response', async () => {
+      mockProfileFindFirst.mockResolvedValue(mockHealthProfile);
+
+      const result = await service.getProfile('user-uuid');
+
+      expect(result.dateOfBirth).toEqual({ day: 1, month: 1, year: 1990, yearVisible: true });
+      expect(result.dateOfBirth).not.toHaveProperty('year_visible');
+    });
+
+    it('throws NotFoundException when the profile does not exist', async () => {
+      mockProfileFindFirst.mockResolvedValue(undefined);
+
+      await expect(service.getProfile('unknown-uuid')).rejects.toThrow(NotFoundException);
+    });
+
+    it('propagates unexpected database errors', async () => {
+      const dbError = new Error('connection lost');
+      mockProfileFindFirst.mockRejectedValue(dbError);
+
+      await expect(service.getProfile('user-uuid')).rejects.toThrow(dbError);
+    });
+  });
+
+  describe('updateProfile', () => {
+    it('returns existing profile unchanged when dto has no fields', async () => {
+      mockProfileFindFirst.mockResolvedValue(mockHealthProfile);
+
+      const result = await service.updateProfile('user-uuid', {} as UpdateUserProfileDto);
+
+      expect(result.firstName).toBe('John');
+      expect(mockReturning).not.toHaveBeenCalled();
+    });
+
+    it('trims text fields and normalizes empty nullable fields to null', async () => {
+      mockProfileFindFirst.mockResolvedValue(mockHealthProfile);
+      mockReturning.mockResolvedValue([{ ...mockHealthProfile, bio: null }]);
+
+      await service.updateProfile('user-uuid', { bio: '   ' });
+
+      expect(mockSet).toHaveBeenCalledWith(expect.objectContaining({ bio: null }));
+    });
+
+    it('stores dateOfBirth with year_visible key (not yearVisible)', async () => {
+      mockProfileFindFirst.mockResolvedValue(mockHealthProfile);
+      const updatedDob = { day: 20, month: 6, year: 1995, year_visible: false };
+      mockReturning.mockResolvedValue([{ ...mockHealthProfile, dateOfBirth: updatedDob }]);
+
+      await service.updateProfile('user-uuid', {
+        dateOfBirth: { day: 20, month: 6, year: 1995, yearVisible: false },
+      });
+
+      expect(mockSet).toHaveBeenCalledWith(
+        expect.objectContaining({
+          dateOfBirth: { day: 20, month: 6, year: 1995, year_visible: false },
+        }),
+      );
+    });
+
+    it('updates all text fields and returns the mapped response', async () => {
+      mockProfileFindFirst.mockResolvedValue(mockHealthProfile);
+      const updated = {
+        ...mockHealthProfile,
+        firstName: 'Jane',
+        lastName: 'Smith',
+        birthCity: 'Cali',
+        homeCountry: 'US',
+        homeCity: 'Miami',
+        phoneNumber: '+13055551234',
+      };
+      mockReturning.mockResolvedValue([updated]);
+
+      const result = await service.updateProfile('user-uuid', {
+        firstName: 'Jane',
+        lastName: 'Smith',
+        birthCity: 'Cali',
+        homeCountry: 'US',
+        homeCity: 'Miami',
+        phoneNumber: '+13055551234',
+      });
+
+      expect(result.firstName).toBe('Jane');
+      expect(result.lastName).toBe('Smith');
+      expect(result.birthCity).toBe('Cali');
+      expect(result.homeCountry).toBe('US');
+      expect(result.homeCity).toBe('Miami');
+      expect(result.phoneNumber).toBe('+13055551234');
+    });
+
+    it('normalizes null birthCity and homeCity to null before saving', async () => {
+      mockProfileFindFirst.mockResolvedValue(mockHealthProfile);
+      mockReturning.mockResolvedValue([{ ...mockHealthProfile, birthCity: null, homeCity: null }]);
+
+      await service.updateProfile('user-uuid', { birthCity: null, homeCity: null });
+
+      expect(mockSet).toHaveBeenCalledWith(
+        expect.objectContaining({ birthCity: null, homeCity: null }),
+      );
+    });
+
+    it('sets birthCountry to null', async () => {
+      mockProfileFindFirst.mockResolvedValue({ ...mockHealthProfile, birthCountry: 'US' });
+      mockReturning.mockResolvedValue([{ ...mockHealthProfile, birthCountry: null }]);
+
+      const result = await service.updateProfile('user-uuid', { birthCountry: null });
+
+      expect(mockSet).toHaveBeenCalledWith(expect.objectContaining({ birthCountry: null }));
+      expect(result.birthCountry).toBeNull();
+    });
+
+    it('throws NotFoundException when the profile does not exist', async () => {
+      mockProfileFindFirst.mockResolvedValue(undefined);
+
+      await expect(service.updateProfile('unknown-uuid', { firstName: 'Jane' })).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('throws NotFoundException when profile is deleted between check and update', async () => {
+      mockProfileFindFirst.mockResolvedValue(mockHealthProfile);
+      mockReturning.mockResolvedValue([]);
+
+      await expect(service.updateProfile('user-uuid', { firstName: 'Jane' })).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('propagates unexpected database errors on the initial fetch', async () => {
+      const dbError = new Error('connection lost');
+      mockProfileFindFirst.mockRejectedValue(dbError);
+
+      await expect(service.updateProfile('user-uuid', { firstName: 'Jane' })).rejects.toThrow(
+        dbError,
+      );
+    });
+
+    it('propagates unexpected database errors on the update', async () => {
+      mockProfileFindFirst.mockResolvedValue(mockHealthProfile);
+      const dbError = new Error('update failed');
+      mockReturning.mockRejectedValue(dbError);
+
+      await expect(service.updateProfile('user-uuid', { firstName: 'Jane' })).rejects.toThrow(
+        dbError,
+      );
     });
   });
 });

--- a/apps/api/src/modules/users/users.service.ts
+++ b/apps/api/src/modules/users/users.service.ts
@@ -5,11 +5,14 @@ import { userPreferences } from '@/modules/users/schema/user-preferences.schema'
 import { userProfiles } from '@/modules/users/schema/user-profiles.schema';
 import { users } from '@/modules/users/schema/users.schema';
 import type { AuthenticatedUser } from '@/types/express';
+import type { DateOfBirthDto } from './dto/date-of-birth.dto';
 import type { UpdateUserDto } from './dto/update-user.dto';
 import type { UpdateUserHealthDto } from './dto/update-user-health.dto';
 import type { UpdateUserPreferencesDto } from './dto/update-user-preferences.dto';
+import type { UpdateUserProfileDto } from './dto/update-user-profile.dto';
 import type { UserHealthResponseDto } from './dto/user-health-response.dto';
 import type { UserPreferencesResponseDto } from './dto/user-preferences-response.dto';
+import type { UserProfileResponseDto } from './dto/user-profile-response.dto';
 import type { UserResponseDto } from './dto/user-response.dto';
 import type { UsernameAvailabilityDto } from './dto/username-availability.dto';
 
@@ -98,6 +101,54 @@ export class UsersService {
     return this.mapPreferencesResponse(updated);
   }
 
+  async getProfile(userId: string): Promise<UserProfileResponseDto> {
+    const profile = await this.db.query.userProfiles.findFirst({
+      where: eq(userProfiles.userId, userId),
+    });
+    if (!profile) {
+      throw new NotFoundException('User profile not found');
+    }
+    return this.mapProfileResponse(profile);
+  }
+
+  async updateProfile(userId: string, dto: UpdateUserProfileDto): Promise<UserProfileResponseDto> {
+    const existing = await this.db.query.userProfiles.findFirst({
+      where: eq(userProfiles.userId, userId),
+    });
+    if (!existing) {
+      throw new NotFoundException('User profile not found');
+    }
+
+    const patch: Partial<typeof userProfiles.$inferInsert> = {};
+    if (dto.firstName !== undefined) patch.firstName = dto.firstName.trim();
+    if (dto.lastName !== undefined) patch.lastName = dto.lastName.trim();
+    if (dto.dateOfBirth !== undefined) {
+      const { yearVisible, ...rest } = dto.dateOfBirth;
+      patch.dateOfBirth = { ...rest, year_visible: yearVisible };
+    }
+    if (dto.birthCountry !== undefined) patch.birthCountry = dto.birthCountry;
+    if (dto.birthCity !== undefined) patch.birthCity = dto.birthCity?.trim() || null;
+    if (dto.homeCountry !== undefined) patch.homeCountry = dto.homeCountry;
+    if (dto.homeCity !== undefined) patch.homeCity = dto.homeCity?.trim() || null;
+    if (dto.phoneNumber !== undefined) patch.phoneNumber = dto.phoneNumber.trim();
+    if (dto.bio !== undefined) patch.bio = dto.bio?.trim() || null;
+
+    if (Object.keys(patch).length === 0) {
+      return this.mapProfileResponse(existing);
+    }
+
+    const [updated] = await this.db
+      .update(userProfiles)
+      .set(patch)
+      .where(eq(userProfiles.userId, userId))
+      .returning();
+
+    if (!updated) {
+      throw new NotFoundException('User profile not found');
+    }
+    return this.mapProfileResponse(updated);
+  }
+
   async getHealth(userId: string): Promise<UserHealthResponseDto> {
     const profile = await this.db.query.userProfiles.findFirst({
       where: eq(userProfiles.userId, userId),
@@ -154,6 +205,31 @@ export class UsersService {
       language: prefs.language,
       currency: prefs.currency,
       theme: prefs.theme,
+    };
+  }
+
+  private mapProfileResponse(profile: typeof userProfiles.$inferSelect): UserProfileResponseDto {
+    const dob = profile.dateOfBirth as {
+      day: number;
+      month: number;
+      year: number;
+      year_visible: boolean;
+    };
+    return {
+      firstName: profile.firstName,
+      lastName: profile.lastName,
+      dateOfBirth: {
+        day: dob.day,
+        month: dob.month,
+        year: dob.year,
+        yearVisible: dob.year_visible,
+      } satisfies DateOfBirthDto,
+      birthCountry: profile.birthCountry ?? null,
+      birthCity: profile.birthCity ?? null,
+      homeCountry: profile.homeCountry,
+      homeCity: profile.homeCity ?? null,
+      phoneNumber: profile.phoneNumber,
+      bio: profile.bio ?? null,
     };
   }
 

--- a/apps/api/src/modules/users/users.service.ts
+++ b/apps/api/src/modules/users/users.service.ts
@@ -130,7 +130,8 @@ export class UsersService {
     if (dto.birthCity !== undefined) patch.birthCity = dto.birthCity?.trim() || null;
     if (dto.homeCountry !== undefined) patch.homeCountry = dto.homeCountry;
     if (dto.homeCity !== undefined) patch.homeCity = dto.homeCity?.trim() || null;
-    if (dto.phoneNumber !== undefined) patch.phoneNumber = dto.phoneNumber.trim();
+    if (dto.phoneCountryCode !== undefined) patch.phoneCountryCode = dto.phoneCountryCode.trim();
+    if (dto.phoneLocalNumber !== undefined) patch.phoneLocalNumber = dto.phoneLocalNumber.trim();
     if (dto.bio !== undefined) patch.bio = dto.bio?.trim() || null;
 
     if (Object.keys(patch).length === 0) {
@@ -228,7 +229,8 @@ export class UsersService {
       birthCity: profile.birthCity ?? null,
       homeCountry: profile.homeCountry,
       homeCity: profile.homeCity ?? null,
-      phoneNumber: profile.phoneNumber,
+      phoneCountryCode: profile.phoneCountryCode,
+      phoneLocalNumber: profile.phoneLocalNumber,
       bio: profile.bio ?? null,
     };
   }

--- a/apps/api/src/modules/users/users.service.ts
+++ b/apps/api/src/modules/users/users.service.ts
@@ -120,8 +120,8 @@ export class UsersService {
     }
 
     const patch: Partial<typeof userProfiles.$inferInsert> = {};
-    if (dto.firstName !== undefined) patch.firstName = dto.firstName.trim();
-    if (dto.lastName !== undefined) patch.lastName = dto.lastName.trim();
+    if (dto.firstName !== undefined) patch.firstName = dto.firstName;
+    if (dto.lastName !== undefined) patch.lastName = dto.lastName;
     if (dto.dateOfBirth !== undefined) {
       const { yearVisible, ...rest } = dto.dateOfBirth;
       patch.dateOfBirth = { ...rest, year_visible: yearVisible };
@@ -130,8 +130,8 @@ export class UsersService {
     if (dto.birthCity !== undefined) patch.birthCity = dto.birthCity?.trim() || null;
     if (dto.homeCountry !== undefined) patch.homeCountry = dto.homeCountry;
     if (dto.homeCity !== undefined) patch.homeCity = dto.homeCity?.trim() || null;
-    if (dto.phoneCountryCode !== undefined) patch.phoneCountryCode = dto.phoneCountryCode.trim();
-    if (dto.phoneLocalNumber !== undefined) patch.phoneLocalNumber = dto.phoneLocalNumber.trim();
+    if (dto.phoneCountryCode !== undefined) patch.phoneCountryCode = dto.phoneCountryCode;
+    if (dto.phoneLocalNumber !== undefined) patch.phoneLocalNumber = dto.phoneLocalNumber;
     if (dto.bio !== undefined) patch.bio = dto.bio?.trim() || null;
 
     if (Object.keys(patch).length === 0) {


### PR DESCRIPTION
## Summary

Exposes the personal-detail fields stored on `user_profiles` (created automatically at registration) through two new authenticated endpoints. This gives clients a way to read and update a user's first name, last name, date of birth, birth/home country and city, phone number, and bio without touching the auth-related fields on the `users` table.

## Changes

**New DTOs**
- `DateOfBirthDto` — validated shape for the `date_of_birth` JSONB column (`day`, `month`, `year`, `yearVisible`); used in both request and response
- `UpdateUserProfileDto` — all fields optional; country codes validated as `@Matches(/^[A-Z]{2}$/)` (ISO 3166-1 alpha-2 format); `dateOfBirth` uses `@ValidateNested()` + `@Type(() => DateOfBirthDto)`
- `UserProfileResponseDto` — full `@ApiProperty` annotations including nested `DateOfBirthDto` type

**Service**
- `getProfile(userId)` — fetch + NotFoundException if missing + `mapProfileResponse`
- `updateProfile(userId, dto)` — fetch-then-patch pattern; empty DTO skips DB write; race-condition guard on empty `RETURNING`; empty/whitespace text fields normalized to `null`
- `mapProfileResponse` — translates `year_visible` (DB snake_case) ↔ `yearVisible` (DTO camelCase) for the `dateOfBirth` JSONB

**Controller**
- `GET v1/users/me/profile` — returns current personal profile
- `PATCH v1/users/me/profile` — `@HttpCode(200)`, full Swagger docs (200/400/401/404)

## Testing

- **`update-user-profile.dto.spec.ts`** — uses `plainToInstance` + `validate` to exercise the `@Type(() => DateOfBirthDto)` factory and all field validators (day/month range, country code format)
- **`users.service.spec.ts`** — 9 new tests: empty DTO no-op, trim + null normalization, `year_visible` key stored in DB, all text fields updated, `birthCountry` null, race condition NotFoundException, fetch error, update error
- **`users.controller.spec.ts`** — 4 new tests: delegates with `user.id`, propagates NotFoundException for both GET and PATCH

241 tests passing · 99.6% statements · 96.84% branches · 97.64% functions · 99.56% lines

## Notes

`@IsOptional()` in class-validator skips all validators for `null` and `undefined` — this means `birthCountry: null` passes the `@Matches` regex check and reaches the service, which stores `null` directly (clears the field). This is intentional behavior documented in the service tests.

Closes #105