### PR TITLE
feat(users): add /users/me/emergency-contacts sub-resource CRUD

### DIFF
--- a/apps/api/src/modules/users/dto/emergency-contact.dto.spec.ts
+++ b/apps/api/src/modules/users/dto/emergency-contact.dto.spec.ts
@@ -1,0 +1,159 @@
+import 'reflect-metadata';
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { EmergencyContactDto, UpdateEmergencyContactDto } from './emergency-contact.dto';
+
+const VALID_ID = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
+
+const validContact = {
+  id: VALID_ID,
+  fullName: 'María López',
+  phoneCountryCode: '+57',
+  phoneLocalNumber: '3001234567',
+  relationship: 'mother',
+  isPrimary: true,
+};
+
+describe('EmergencyContactDto', () => {
+  it('accepts a valid contact', async () => {
+    const dto = plainToInstance(EmergencyContactDto, validContact);
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(0);
+  });
+
+  it('rejects a non-UUID id', async () => {
+    const dto = plainToInstance(EmergencyContactDto, { ...validContact, id: 'not-a-uuid' });
+    const errors = await validate(dto);
+    expect(errors.some((e) => e.property === 'id')).toBe(true);
+  });
+
+  it('rejects fullName shorter than 2 characters', async () => {
+    const dto = plainToInstance(EmergencyContactDto, { ...validContact, fullName: 'A' });
+    const errors = await validate(dto);
+    expect(errors.some((e) => e.property === 'fullName')).toBe(true);
+  });
+
+  it('rejects whitespace-only fullName (trimmed to empty before validating)', async () => {
+    const dto = plainToInstance(EmergencyContactDto, { ...validContact, fullName: '   ' });
+    const errors = await validate(dto);
+    expect(errors.some((e) => e.property === 'fullName')).toBe(true);
+  });
+
+  it('trims fullName before validating', async () => {
+    const dto = plainToInstance(EmergencyContactDto, { ...validContact, fullName: '  Ana  ' });
+    expect(dto.fullName).toBe('Ana');
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(0);
+  });
+
+  it('accepts single-digit country code (+1)', async () => {
+    const dto = plainToInstance(EmergencyContactDto, {
+      ...validContact,
+      phoneCountryCode: '+1',
+      phoneLocalNumber: '3055551234',
+    });
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(0);
+  });
+
+  it('rejects phoneCountryCode without leading +', async () => {
+    const dto = plainToInstance(EmergencyContactDto, { ...validContact, phoneCountryCode: '57' });
+    const errors = await validate(dto);
+    expect(errors.some((e) => e.property === 'phoneCountryCode')).toBe(true);
+  });
+
+  it('rejects phoneCountryCode starting with +0', async () => {
+    const dto = plainToInstance(EmergencyContactDto, { ...validContact, phoneCountryCode: '+0' });
+    const errors = await validate(dto);
+    expect(errors.some((e) => e.property === 'phoneCountryCode')).toBe(true);
+  });
+
+  it('rejects phoneLocalNumber with letters or symbols', async () => {
+    const dto = plainToInstance(EmergencyContactDto, {
+      ...validContact,
+      phoneLocalNumber: '300-123-4567',
+    });
+    const errors = await validate(dto);
+    expect(errors.some((e) => e.property === 'phoneLocalNumber')).toBe(true);
+  });
+
+  it('rejects phoneLocalNumber shorter than 4 digits', async () => {
+    const dto = plainToInstance(EmergencyContactDto, { ...validContact, phoneLocalNumber: '123' });
+    const errors = await validate(dto);
+    expect(errors.some((e) => e.property === 'phoneLocalNumber')).toBe(true);
+  });
+
+  it('passes non-string values through the trim transform and rejects with IsString', async () => {
+    const dto = plainToInstance(EmergencyContactDto, {
+      ...validContact,
+      fullName: 42,
+      phoneCountryCode: [],
+      phoneLocalNumber: {},
+      relationship: true,
+    });
+    const errors = await validate(dto);
+    expect(errors.some((e) => e.property === 'fullName')).toBe(true);
+    expect(errors.some((e) => e.property === 'phoneCountryCode')).toBe(true);
+    expect(errors.some((e) => e.property === 'phoneLocalNumber')).toBe(true);
+    expect(errors.some((e) => e.property === 'relationship')).toBe(true);
+  });
+
+  it('rejects missing required fields', async () => {
+    const dto = plainToInstance(EmergencyContactDto, {});
+    const errors = await validate(dto);
+    const properties = errors.map((e) => e.property);
+    expect(properties).toContain('id');
+    expect(properties).toContain('fullName');
+    expect(properties).toContain('phoneCountryCode');
+    expect(properties).toContain('phoneLocalNumber');
+    expect(properties).toContain('relationship');
+    expect(properties).toContain('isPrimary');
+  });
+});
+
+describe('UpdateEmergencyContactDto', () => {
+  it('accepts an empty object (all fields optional)', async () => {
+    const dto = plainToInstance(UpdateEmergencyContactDto, {});
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(0);
+  });
+
+  it('accepts a partial update with only isPrimary', async () => {
+    const dto = plainToInstance(UpdateEmergencyContactDto, { isPrimary: false });
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(0);
+  });
+
+  it('accepts a partial update with all optional string fields and trims them', async () => {
+    const dto = plainToInstance(UpdateEmergencyContactDto, {
+      fullName: '  Ana López  ',
+      phoneCountryCode: '+1',
+      phoneLocalNumber: '3055551234',
+      relationship: '  sister  ',
+    });
+    expect(dto.fullName).toBe('Ana López');
+    expect(dto.relationship).toBe('sister');
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(0);
+  });
+
+  it('rejects invalid phoneCountryCode when provided', async () => {
+    const dto = plainToInstance(UpdateEmergencyContactDto, { phoneCountryCode: '57' });
+    const errors = await validate(dto);
+    expect(errors.some((e) => e.property === 'phoneCountryCode')).toBe(true);
+  });
+
+  it('passes non-string values through the trim transform and rejects with IsString', async () => {
+    const dto = plainToInstance(UpdateEmergencyContactDto, {
+      fullName: 42,
+      phoneCountryCode: [],
+      phoneLocalNumber: {},
+      relationship: true,
+    });
+    const errors = await validate(dto);
+    expect(errors.some((e) => e.property === 'fullName')).toBe(true);
+    expect(errors.some((e) => e.property === 'phoneCountryCode')).toBe(true);
+    expect(errors.some((e) => e.property === 'phoneLocalNumber')).toBe(true);
+    expect(errors.some((e) => e.property === 'relationship')).toBe(true);
+  });
+});

--- a/apps/api/src/modules/users/dto/emergency-contact.dto.ts
+++ b/apps/api/src/modules/users/dto/emergency-contact.dto.ts
@@ -1,0 +1,118 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Transform } from 'class-transformer';
+import {
+  IsBoolean,
+  IsOptional,
+  IsString,
+  IsUUID,
+  Matches,
+  MaxLength,
+  MinLength,
+} from 'class-validator';
+
+export class EmergencyContactDto {
+  @ApiProperty({
+    example: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+    description: 'Client-generated UUID',
+  })
+  @IsUUID()
+  id!: string;
+
+  @ApiProperty({ example: 'María López', minLength: 2, maxLength: 100 })
+  @Transform(({ value }) => (typeof value === 'string' ? value.trim() : value))
+  @IsString()
+  @MinLength(2)
+  @MaxLength(100)
+  fullName!: string;
+
+  @ApiProperty({
+    example: '+57',
+    description:
+      'Phone country code in E.164 format (e.g. +57, +1, +593). ' +
+      'Must start with + followed by 1–3 digits. Frontend must enforce this format.',
+  })
+  @Transform(({ value }) => (typeof value === 'string' ? value.trim() : value))
+  @IsString()
+  @Matches(/^\+[1-9]\d{0,2}$/, {
+    message: 'phoneCountryCode must be a valid country code (e.g. +57, +1, +593)',
+  })
+  phoneCountryCode!: string;
+
+  @ApiProperty({
+    example: '3001234567',
+    description: 'Local phone number without country code — digits only, 4–14 digits.',
+  })
+  @Transform(({ value }) => (typeof value === 'string' ? value.trim() : value))
+  @IsString()
+  @Matches(/^\d{4,14}$/, {
+    message: 'phoneLocalNumber must contain 4–14 digits with no spaces or symbols',
+  })
+  phoneLocalNumber!: string;
+
+  @ApiProperty({
+    example: 'mother',
+    description: 'Relationship to the user',
+    minLength: 1,
+    maxLength: 100,
+  })
+  @Transform(({ value }) => (typeof value === 'string' ? value.trim() : value))
+  @IsString()
+  @MinLength(1)
+  @MaxLength(100)
+  relationship!: string;
+
+  @ApiProperty({ example: true, description: 'Exactly one contact must be primary' })
+  @IsBoolean()
+  isPrimary!: boolean;
+}
+
+export class UpdateEmergencyContactDto {
+  @ApiProperty({ example: 'María López', minLength: 2, maxLength: 100, required: false })
+  @IsOptional()
+  @Transform(({ value }) => (typeof value === 'string' ? value.trim() : value))
+  @IsString()
+  @MinLength(2)
+  @MaxLength(100)
+  fullName?: string;
+
+  @ApiProperty({
+    example: '+57',
+    description:
+      'Phone country code in E.164 format (e.g. +57, +1, +593). ' +
+      'Must start with + followed by 1–3 digits. Frontend must enforce this format.',
+    required: false,
+  })
+  @IsOptional()
+  @Transform(({ value }) => (typeof value === 'string' ? value.trim() : value))
+  @IsString()
+  @Matches(/^\+[1-9]\d{0,2}$/, {
+    message: 'phoneCountryCode must be a valid country code (e.g. +57, +1, +593)',
+  })
+  phoneCountryCode?: string;
+
+  @ApiProperty({
+    example: '3001234567',
+    description: 'Local phone number without country code — digits only, 4–14 digits.',
+    required: false,
+  })
+  @IsOptional()
+  @Transform(({ value }) => (typeof value === 'string' ? value.trim() : value))
+  @IsString()
+  @Matches(/^\d{4,14}$/, {
+    message: 'phoneLocalNumber must contain 4–14 digits with no spaces or symbols',
+  })
+  phoneLocalNumber?: string;
+
+  @ApiProperty({ example: 'mother', minLength: 1, maxLength: 100, required: false })
+  @IsOptional()
+  @Transform(({ value }) => (typeof value === 'string' ? value.trim() : value))
+  @IsString()
+  @MinLength(1)
+  @MaxLength(100)
+  relationship?: string;
+
+  @ApiProperty({ example: true, required: false })
+  @IsOptional()
+  @IsBoolean()
+  isPrimary?: boolean;
+}

--- a/apps/api/src/modules/users/dto/emergency-contact.dto.ts
+++ b/apps/api/src/modules/users/dto/emergency-contact.dto.ts
@@ -1,14 +1,6 @@
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, OmitType, PartialType } from '@nestjs/swagger';
 import { Transform } from 'class-transformer';
-import {
-  IsBoolean,
-  IsOptional,
-  IsString,
-  IsUUID,
-  Matches,
-  MaxLength,
-  MinLength,
-} from 'class-validator';
+import { IsBoolean, IsString, IsUUID, Matches, MaxLength, MinLength } from 'class-validator';
 
 export class EmergencyContactDto {
   @ApiProperty({
@@ -66,53 +58,6 @@ export class EmergencyContactDto {
   isPrimary!: boolean;
 }
 
-export class UpdateEmergencyContactDto {
-  @ApiProperty({ example: 'María López', minLength: 2, maxLength: 100, required: false })
-  @IsOptional()
-  @Transform(({ value }) => (typeof value === 'string' ? value.trim() : value))
-  @IsString()
-  @MinLength(2)
-  @MaxLength(100)
-  fullName?: string;
-
-  @ApiProperty({
-    example: '+57',
-    description:
-      'Phone country code in E.164 format (e.g. +57, +1, +593). ' +
-      'Must start with + followed by 1–3 digits. Frontend must enforce this format.',
-    required: false,
-  })
-  @IsOptional()
-  @Transform(({ value }) => (typeof value === 'string' ? value.trim() : value))
-  @IsString()
-  @Matches(/^\+[1-9]\d{0,2}$/, {
-    message: 'phoneCountryCode must be a valid country code (e.g. +57, +1, +593)',
-  })
-  phoneCountryCode?: string;
-
-  @ApiProperty({
-    example: '3001234567',
-    description: 'Local phone number without country code — digits only, 4–14 digits.',
-    required: false,
-  })
-  @IsOptional()
-  @Transform(({ value }) => (typeof value === 'string' ? value.trim() : value))
-  @IsString()
-  @Matches(/^\d{4,14}$/, {
-    message: 'phoneLocalNumber must contain 4–14 digits with no spaces or symbols',
-  })
-  phoneLocalNumber?: string;
-
-  @ApiProperty({ example: 'mother', minLength: 1, maxLength: 100, required: false })
-  @IsOptional()
-  @Transform(({ value }) => (typeof value === 'string' ? value.trim() : value))
-  @IsString()
-  @MinLength(1)
-  @MaxLength(100)
-  relationship?: string;
-
-  @ApiProperty({ example: true, required: false })
-  @IsOptional()
-  @IsBoolean()
-  isPrimary?: boolean;
-}
+export class UpdateEmergencyContactDto extends PartialType(
+  OmitType(EmergencyContactDto, ['id'] as const),
+) {}

--- a/apps/api/src/modules/users/users.controller.spec.ts
+++ b/apps/api/src/modules/users/users.controller.spec.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { BadRequestException, ConflictException, NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import {
   AppCurrency,
@@ -12,6 +12,7 @@ import {
 import { UsersController } from './users.controller';
 import { UsersService } from './users.service';
 import type { UpdateUserDto } from './dto/update-user.dto';
+import type { EmergencyContactDto, UpdateEmergencyContactDto } from './dto/emergency-contact.dto';
 import type { UpdateUserHealthDto } from './dto/update-user-health.dto';
 import type { UpdateUserPreferencesDto } from './dto/update-user-preferences.dto';
 import type { UpdateUserProfileDto } from './dto/update-user-profile.dto';
@@ -81,6 +82,19 @@ describe('UsersController', () => {
   let mockUpdatePreferences: jest.Mock;
   let mockGetProfile: jest.Mock;
   let mockUpdateProfile: jest.Mock;
+  let mockGetEmergencyContacts: jest.Mock;
+  let mockAddEmergencyContact: jest.Mock;
+  let mockUpdateEmergencyContact: jest.Mock;
+  let mockDeleteEmergencyContact: jest.Mock;
+
+  const mockContactResponse: EmergencyContactDto = {
+    id: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+    fullName: 'María López',
+    phoneCountryCode: '+57',
+    phoneLocalNumber: '3001234567',
+    relationship: 'mother',
+    isPrimary: true,
+  };
 
   beforeEach(async () => {
     mockFindByFirebaseUid = jest.fn().mockResolvedValue(mockUser);
@@ -94,6 +108,10 @@ describe('UsersController', () => {
     mockUpdatePreferences = jest.fn().mockResolvedValue(mockPreferencesResponse);
     mockGetProfile = jest.fn().mockResolvedValue(mockProfileResponse);
     mockUpdateProfile = jest.fn().mockResolvedValue(mockProfileResponse);
+    mockGetEmergencyContacts = jest.fn().mockResolvedValue([mockContactResponse]);
+    mockAddEmergencyContact = jest.fn().mockResolvedValue(mockContactResponse);
+    mockUpdateEmergencyContact = jest.fn().mockResolvedValue(mockContactResponse);
+    mockDeleteEmergencyContact = jest.fn().mockResolvedValue(undefined);
 
     const module: TestingModule = await Test.createTestingModule({
       controllers: [UsersController],
@@ -110,6 +128,10 @@ describe('UsersController', () => {
             updatePreferences: mockUpdatePreferences,
             getProfile: mockGetProfile,
             updateProfile: mockUpdateProfile,
+            getEmergencyContacts: mockGetEmergencyContacts,
+            addEmergencyContact: mockAddEmergencyContact,
+            updateEmergencyContact: mockUpdateEmergencyContact,
+            deleteEmergencyContact: mockDeleteEmergencyContact,
           },
         },
       ],
@@ -315,6 +337,88 @@ describe('UsersController', () => {
       await expect(
         controller.updateProfile(mockAuthUser, {} as UpdateUserProfileDto),
       ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('GET /v1/users/me/emergency-contacts', () => {
+    it('delegates to usersService.getEmergencyContacts with the authenticated user id', async () => {
+      const result = await controller.getEmergencyContacts(mockAuthUser);
+
+      expect(mockGetEmergencyContacts).toHaveBeenCalledWith(mockAuthUser.id);
+      expect(result).toEqual([mockContactResponse]);
+    });
+
+    it('propagates NotFoundException from the service', async () => {
+      mockGetEmergencyContacts.mockRejectedValue(new NotFoundException());
+
+      await expect(controller.getEmergencyContacts(mockAuthUser)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe('POST /v1/users/me/emergency-contacts', () => {
+    it('delegates to usersService.addEmergencyContact with the user id and dto', async () => {
+      const result = await controller.addEmergencyContact(mockAuthUser, mockContactResponse);
+
+      expect(mockAddEmergencyContact).toHaveBeenCalledWith(mockAuthUser.id, mockContactResponse);
+      expect(result).toEqual(mockContactResponse);
+    });
+
+    it('propagates ConflictException from the service', async () => {
+      mockAddEmergencyContact.mockRejectedValue(new ConflictException());
+
+      await expect(
+        controller.addEmergencyContact(mockAuthUser, mockContactResponse),
+      ).rejects.toThrow(ConflictException);
+    });
+  });
+
+  describe('PATCH /v1/users/me/emergency-contacts/:id', () => {
+    it('delegates to usersService.updateEmergencyContact with the user id, contact id, and dto', async () => {
+      const dto: UpdateEmergencyContactDto = { fullName: 'Ana López' };
+      const updated = { ...mockContactResponse, fullName: 'Ana López' };
+      mockUpdateEmergencyContact.mockResolvedValue(updated);
+
+      const result = await controller.updateEmergencyContact(
+        mockAuthUser,
+        mockContactResponse.id,
+        dto,
+      );
+
+      expect(mockUpdateEmergencyContact).toHaveBeenCalledWith(
+        mockAuthUser.id,
+        mockContactResponse.id,
+        dto,
+      );
+      expect(result).toEqual(updated);
+    });
+
+    it('propagates NotFoundException from the service', async () => {
+      mockUpdateEmergencyContact.mockRejectedValue(new NotFoundException());
+
+      await expect(
+        controller.updateEmergencyContact(mockAuthUser, 'nonexistent-id', {}),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('DELETE /v1/users/me/emergency-contacts/:id', () => {
+    it('delegates to usersService.deleteEmergencyContact with the user id and contact id', async () => {
+      await controller.deleteEmergencyContact(mockAuthUser, mockContactResponse.id);
+
+      expect(mockDeleteEmergencyContact).toHaveBeenCalledWith(
+        mockAuthUser.id,
+        mockContactResponse.id,
+      );
+    });
+
+    it('propagates ConflictException from the service', async () => {
+      mockDeleteEmergencyContact.mockRejectedValue(new ConflictException());
+
+      await expect(
+        controller.deleteEmergencyContact(mockAuthUser, mockContactResponse.id),
+      ).rejects.toThrow(ConflictException);
     });
   });
 });

--- a/apps/api/src/modules/users/users.controller.ts
+++ b/apps/api/src/modules/users/users.controller.ts
@@ -1,8 +1,20 @@
-import { BadRequestException, Body, Controller, Get, HttpCode, Patch, Query } from '@nestjs/common';
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  Param,
+  Patch,
+  Post,
+  Query,
+} from '@nestjs/common';
 import {
   ApiBody,
   ApiBearerAuth,
   ApiOperation,
+  ApiParam,
   ApiQuery,
   ApiResponse,
   ApiTags,
@@ -13,6 +25,7 @@ import { Public } from '@/common/decorators/public.decorator';
 import type { AuthenticatedUser } from '@/types/express';
 import { UsersService } from './users.service';
 import { UpdateUserDto } from './dto/update-user.dto';
+import { EmergencyContactDto, UpdateEmergencyContactDto } from './dto/emergency-contact.dto';
 import { UpdateUserHealthDto } from './dto/update-user-health.dto';
 import { UpdateUserPreferencesDto } from './dto/update-user-preferences.dto';
 import { UpdateUserProfileDto } from './dto/update-user-profile.dto';
@@ -102,6 +115,83 @@ export class UsersController {
     @Body() dto: UpdateUserHealthDto,
   ): Promise<UserHealthResponseDto> {
     return this.usersService.updateHealth(user.id, dto);
+  }
+
+  @Get('me/emergency-contacts')
+  @ApiOperation({
+    summary: "List the current user's emergency contacts",
+    description: "Returns all emergency contacts stored on the authenticated user's profile.",
+  })
+  @ApiResponse({ status: 200, type: EmergencyContactDto, isArray: true })
+  @ApiResponse({ status: 401, description: 'Missing or invalid Firebase ID token' })
+  @ApiResponse({ status: 404, description: 'User profile not found' })
+  getEmergencyContacts(@CurrentUser() user: AuthenticatedUser): Promise<EmergencyContactDto[]> {
+    return this.usersService.getEmergencyContacts(user.id);
+  }
+
+  @Post('me/emergency-contacts')
+  @HttpCode(201)
+  @ApiBody({ type: EmergencyContactDto })
+  @ApiOperation({
+    summary: 'Add an emergency contact',
+    description:
+      'Adds a new emergency contact. The id must be a client-generated UUID. ' +
+      'If isPrimary is true, the current primary contact is automatically demoted.',
+  })
+  @ApiResponse({ status: 201, type: EmergencyContactDto })
+  @ApiResponse({ status: 400, description: 'Validation failed — invalid field value' })
+  @ApiResponse({ status: 401, description: 'Missing or invalid Firebase ID token' })
+  @ApiResponse({ status: 404, description: 'User profile not found' })
+  addEmergencyContact(
+    @CurrentUser() user: AuthenticatedUser,
+    @Body() dto: EmergencyContactDto,
+  ): Promise<EmergencyContactDto> {
+    return this.usersService.addEmergencyContact(user.id, dto);
+  }
+
+  @Patch('me/emergency-contacts/:id')
+  @HttpCode(200)
+  @ApiParam({ name: 'id', description: 'UUID of the emergency contact to update' })
+  @ApiBody({ type: UpdateEmergencyContactDto })
+  @ApiOperation({
+    summary: 'Update an emergency contact',
+    description:
+      'Updates any subset of fields on a single emergency contact identified by its UUID. ' +
+      'If isPrimary is set to true, all other contacts are automatically demoted.',
+  })
+  @ApiResponse({ status: 200, type: EmergencyContactDto })
+  @ApiResponse({ status: 400, description: 'Validation failed — invalid field value' })
+  @ApiResponse({ status: 401, description: 'Missing or invalid Firebase ID token' })
+  @ApiResponse({ status: 404, description: 'User profile or emergency contact not found' })
+  updateEmergencyContact(
+    @CurrentUser() user: AuthenticatedUser,
+    @Param('id') contactId: string,
+    @Body() dto: UpdateEmergencyContactDto,
+  ): Promise<EmergencyContactDto> {
+    return this.usersService.updateEmergencyContact(user.id, contactId, dto);
+  }
+
+  @Delete('me/emergency-contacts/:id')
+  @HttpCode(204)
+  @ApiParam({ name: 'id', description: 'UUID of the emergency contact to delete' })
+  @ApiOperation({
+    summary: 'Delete an emergency contact',
+    description:
+      'Removes a single emergency contact. ' +
+      'Returns 409 if the contact is the primary and other contacts exist — re-assign primary first.',
+  })
+  @ApiResponse({ status: 204, description: 'Contact deleted' })
+  @ApiResponse({ status: 401, description: 'Missing or invalid Firebase ID token' })
+  @ApiResponse({ status: 404, description: 'User profile or emergency contact not found' })
+  @ApiResponse({
+    status: 409,
+    description: 'Cannot delete primary contact while other contacts exist',
+  })
+  deleteEmergencyContact(
+    @CurrentUser() user: AuthenticatedUser,
+    @Param('id') contactId: string,
+  ): Promise<void> {
+    return this.usersService.deleteEmergencyContact(user.id, contactId);
   }
 
   @Get('me/profile')

--- a/apps/api/src/modules/users/users.controller.ts
+++ b/apps/api/src/modules/users/users.controller.ts
@@ -160,7 +160,11 @@ export class UsersController {
       'If isPrimary is set to true, all other contacts are automatically demoted.',
   })
   @ApiResponse({ status: 200, type: EmergencyContactDto })
-  @ApiResponse({ status: 400, description: 'Validation failed — invalid field value' })
+  @ApiResponse({
+    status: 400,
+    description:
+      'Validation failed — invalid field value, or isPrimary: false (assign a new primary instead)',
+  })
   @ApiResponse({ status: 401, description: 'Missing or invalid Firebase ID token' })
   @ApiResponse({ status: 404, description: 'User profile or emergency contact not found' })
   updateEmergencyContact(

--- a/apps/api/src/modules/users/users.service.spec.ts
+++ b/apps/api/src/modules/users/users.service.spec.ts
@@ -1,4 +1,4 @@
-import { ConflictException, NotFoundException } from '@nestjs/common';
+import { BadRequestException, ConflictException, NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import {
   AppCurrency,
@@ -841,6 +841,17 @@ describe('UsersService', () => {
           ]),
         }),
       );
+    });
+
+    it('throws BadRequestException when isPrimary is explicitly set to false', async () => {
+      mockProfileFindFirst.mockResolvedValue({
+        ...mockHealthProfile,
+        emergencyContacts: [contactA, contactB],
+      });
+
+      await expect(
+        service.updateEmergencyContact('user-uuid', contactA.id, { isPrimary: false }),
+      ).rejects.toThrow(BadRequestException);
     });
 
     it('throws NotFoundException when contact id is not found', async () => {

--- a/apps/api/src/modules/users/users.service.spec.ts
+++ b/apps/api/src/modules/users/users.service.spec.ts
@@ -1,4 +1,4 @@
-import { NotFoundException } from '@nestjs/common';
+import { ConflictException, NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import {
   AppCurrency,
@@ -17,6 +17,7 @@ import { UsersService } from './users.service';
 import type { UpdateUserDto } from './dto/update-user.dto';
 import type { UpdateUserHealthDto } from './dto/update-user-health.dto';
 import type { UpdateUserPreferencesDto } from './dto/update-user-preferences.dto';
+import type { EmergencyContactDto, UpdateEmergencyContactDto } from './dto/emergency-contact.dto';
 import type { UpdateUserProfileDto } from './dto/update-user-profile.dto';
 import type { UserHealthResponseDto } from './dto/user-health-response.dto';
 import type { AuthenticatedUser } from '@/types/express';
@@ -613,6 +614,357 @@ describe('UsersService', () => {
       await expect(service.updateProfile('user-uuid', { firstName: 'Jane' })).rejects.toThrow(
         dbError,
       );
+    });
+  });
+
+  describe('getEmergencyContacts', () => {
+    const contact: EmergencyContactDto = {
+      id: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+      fullName: 'María López',
+      phoneCountryCode: '+57',
+      phoneLocalNumber: '3001234567',
+      relationship: 'mother',
+      isPrimary: true,
+    };
+
+    it('returns the contacts array when found', async () => {
+      mockProfileFindFirst.mockResolvedValue({
+        ...mockHealthProfile,
+        emergencyContacts: [contact],
+      });
+
+      const result = await service.getEmergencyContacts('user-uuid');
+
+      expect(result).toEqual([contact]);
+    });
+
+    it('returns an empty array when emergencyContacts is empty', async () => {
+      mockProfileFindFirst.mockResolvedValue({ ...mockHealthProfile, emergencyContacts: [] });
+
+      const result = await service.getEmergencyContacts('user-uuid');
+
+      expect(result).toEqual([]);
+    });
+
+    it('throws NotFoundException when the profile does not exist', async () => {
+      mockProfileFindFirst.mockResolvedValue(undefined);
+
+      await expect(service.getEmergencyContacts('unknown-uuid')).rejects.toThrow(NotFoundException);
+    });
+
+    it('propagates unexpected database errors', async () => {
+      const dbError = new Error('connection lost');
+      mockProfileFindFirst.mockRejectedValue(dbError);
+
+      await expect(service.getEmergencyContacts('user-uuid')).rejects.toThrow(dbError);
+    });
+  });
+
+  describe('addEmergencyContact', () => {
+    const existingPrimary: EmergencyContactDto = {
+      id: 'existing-id-0001-0000-0000-000000000001',
+      fullName: 'Carlos Ruiz',
+      phoneCountryCode: '+57',
+      phoneLocalNumber: '3109876543',
+      relationship: 'father',
+      isPrimary: true,
+    };
+    const newContact: EmergencyContactDto = {
+      id: 'new-uuid-0000-0000-0000-000000000002',
+      fullName: 'María López',
+      phoneCountryCode: '+57',
+      phoneLocalNumber: '3001234567',
+      relationship: 'mother',
+      isPrimary: false,
+    };
+
+    it('appends the contact and returns it', async () => {
+      mockProfileFindFirst.mockResolvedValue({
+        ...mockHealthProfile,
+        emergencyContacts: [existingPrimary],
+      });
+      mockReturning.mockResolvedValue([
+        { ...mockHealthProfile, emergencyContacts: [existingPrimary, newContact] },
+      ]);
+
+      const result = await service.addEmergencyContact('user-uuid', newContact);
+
+      expect(result).toEqual(newContact);
+    });
+
+    it('unsets the current primary when new contact has isPrimary: true', async () => {
+      const primaryContact: EmergencyContactDto = { ...newContact, isPrimary: true };
+      mockProfileFindFirst.mockResolvedValue({
+        ...mockHealthProfile,
+        emergencyContacts: [existingPrimary],
+      });
+      const savedContacts = [{ ...existingPrimary, isPrimary: false }, primaryContact];
+      mockReturning.mockResolvedValue([{ ...mockHealthProfile, emergencyContacts: savedContacts }]);
+
+      await service.addEmergencyContact('user-uuid', primaryContact);
+
+      expect(mockSet).toHaveBeenCalledWith(
+        expect.objectContaining({
+          emergencyContacts: expect.arrayContaining([
+            expect.objectContaining({ id: existingPrimary.id, isPrimary: false }),
+          ]),
+        }),
+      );
+    });
+
+    it('does not touch existing primaries when isPrimary is false', async () => {
+      mockProfileFindFirst.mockResolvedValue({
+        ...mockHealthProfile,
+        emergencyContacts: [existingPrimary],
+      });
+      mockReturning.mockResolvedValue([
+        { ...mockHealthProfile, emergencyContacts: [existingPrimary, newContact] },
+      ]);
+
+      await service.addEmergencyContact('user-uuid', newContact);
+
+      expect(mockSet).toHaveBeenCalledWith(
+        expect.objectContaining({
+          emergencyContacts: expect.arrayContaining([
+            expect.objectContaining({ id: existingPrimary.id, isPrimary: true }),
+          ]),
+        }),
+      );
+    });
+
+    it('throws NotFoundException when the profile does not exist', async () => {
+      mockProfileFindFirst.mockResolvedValue(undefined);
+
+      await expect(service.addEmergencyContact('unknown-uuid', newContact)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('throws NotFoundException when the profile is deleted between check and insert', async () => {
+      mockProfileFindFirst.mockResolvedValue({
+        ...mockHealthProfile,
+        emergencyContacts: [existingPrimary],
+      });
+      mockReturning.mockResolvedValue([]);
+
+      await expect(service.addEmergencyContact('user-uuid', newContact)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('propagates unexpected database errors', async () => {
+      mockProfileFindFirst.mockResolvedValue({
+        ...mockHealthProfile,
+        emergencyContacts: [existingPrimary],
+      });
+      const dbError = new Error('update failed');
+      mockReturning.mockRejectedValue(dbError);
+
+      await expect(service.addEmergencyContact('user-uuid', newContact)).rejects.toThrow(dbError);
+    });
+  });
+
+  describe('updateEmergencyContact', () => {
+    const contactA: EmergencyContactDto = {
+      id: 'contact-a-0000-0000-0000-000000000001',
+      fullName: 'Carlos Ruiz',
+      phoneCountryCode: '+57',
+      phoneLocalNumber: '3109876543',
+      relationship: 'father',
+      isPrimary: true,
+    };
+    const contactB: EmergencyContactDto = {
+      id: 'contact-b-0000-0000-0000-000000000002',
+      fullName: 'María López',
+      phoneCountryCode: '+57',
+      phoneLocalNumber: '3001234567',
+      relationship: 'mother',
+      isPrimary: false,
+    };
+
+    it('updates the specified fields and returns the updated contact', async () => {
+      mockProfileFindFirst.mockResolvedValue({
+        ...mockHealthProfile,
+        emergencyContacts: [contactA, contactB],
+      });
+      const updated = { ...contactB, fullName: 'María González', relationship: 'sister' };
+      mockReturning.mockResolvedValue([
+        { ...mockHealthProfile, emergencyContacts: [contactA, updated] },
+      ]);
+
+      const result = await service.updateEmergencyContact('user-uuid', contactB.id, {
+        fullName: 'María González',
+        relationship: 'sister',
+      } as UpdateEmergencyContactDto);
+
+      expect(result.fullName).toBe('María González');
+      expect(result.relationship).toBe('sister');
+    });
+
+    it('unsets other primaries when isPrimary: true', async () => {
+      mockProfileFindFirst.mockResolvedValue({
+        ...mockHealthProfile,
+        emergencyContacts: [contactA, contactB],
+      });
+      const savedContacts = [
+        { ...contactA, isPrimary: false },
+        { ...contactB, isPrimary: true },
+      ];
+      mockReturning.mockResolvedValue([{ ...mockHealthProfile, emergencyContacts: savedContacts }]);
+
+      await service.updateEmergencyContact('user-uuid', contactB.id, { isPrimary: true });
+
+      expect(mockSet).toHaveBeenCalledWith(
+        expect.objectContaining({
+          emergencyContacts: expect.arrayContaining([
+            expect.objectContaining({ id: contactA.id, isPrimary: false }),
+            expect.objectContaining({ id: contactB.id, isPrimary: true }),
+          ]),
+        }),
+      );
+    });
+
+    it('does not touch primaries when isPrimary is not in the dto', async () => {
+      mockProfileFindFirst.mockResolvedValue({
+        ...mockHealthProfile,
+        emergencyContacts: [contactA, contactB],
+      });
+      const saved = [contactA, { ...contactB, fullName: 'Ana' }];
+      mockReturning.mockResolvedValue([{ ...mockHealthProfile, emergencyContacts: saved }]);
+
+      await service.updateEmergencyContact('user-uuid', contactB.id, { fullName: 'Ana' });
+
+      expect(mockSet).toHaveBeenCalledWith(
+        expect.objectContaining({
+          emergencyContacts: expect.arrayContaining([
+            expect.objectContaining({ id: contactA.id, isPrimary: true }),
+          ]),
+        }),
+      );
+    });
+
+    it('throws NotFoundException when contact id is not found', async () => {
+      mockProfileFindFirst.mockResolvedValue({
+        ...mockHealthProfile,
+        emergencyContacts: [contactA],
+      });
+
+      await expect(
+        service.updateEmergencyContact('user-uuid', 'nonexistent-id', { fullName: 'X' }),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('throws NotFoundException when the profile does not exist', async () => {
+      mockProfileFindFirst.mockResolvedValue(undefined);
+
+      await expect(
+        service.updateEmergencyContact('unknown-uuid', contactA.id, { fullName: 'X' }),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('throws NotFoundException when the profile is deleted between check and update', async () => {
+      mockProfileFindFirst.mockResolvedValue({
+        ...mockHealthProfile,
+        emergencyContacts: [contactA],
+      });
+      mockReturning.mockResolvedValue([]);
+
+      await expect(
+        service.updateEmergencyContact('user-uuid', contactA.id, { fullName: 'X' }),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('propagates unexpected database errors', async () => {
+      mockProfileFindFirst.mockResolvedValue({
+        ...mockHealthProfile,
+        emergencyContacts: [contactA],
+      });
+      const dbError = new Error('update failed');
+      mockReturning.mockRejectedValue(dbError);
+
+      await expect(
+        service.updateEmergencyContact('user-uuid', contactA.id, { fullName: 'X' }),
+      ).rejects.toThrow(dbError);
+    });
+  });
+
+  describe('deleteEmergencyContact', () => {
+    const primaryContact: EmergencyContactDto = {
+      id: 'primary-id-0000-0000-0000-000000000001',
+      fullName: 'Carlos Ruiz',
+      phoneCountryCode: '+57',
+      phoneLocalNumber: '3109876543',
+      relationship: 'father',
+      isPrimary: true,
+    };
+    const secondaryContact: EmergencyContactDto = {
+      id: 'secondary-id-0000-0000-0000-00000000002',
+      fullName: 'María López',
+      phoneCountryCode: '+57',
+      phoneLocalNumber: '3001234567',
+      relationship: 'mother',
+      isPrimary: false,
+    };
+
+    it('deletes the contact and saves the remaining contacts', async () => {
+      mockProfileFindFirst.mockResolvedValue({
+        ...mockHealthProfile,
+        emergencyContacts: [primaryContact, secondaryContact],
+      });
+
+      await service.deleteEmergencyContact('user-uuid', secondaryContact.id);
+
+      expect(mockSet).toHaveBeenCalledWith(
+        expect.objectContaining({
+          emergencyContacts: [primaryContact],
+        }),
+      );
+    });
+
+    it('throws ConflictException when deleting the primary with other contacts remaining', async () => {
+      mockProfileFindFirst.mockResolvedValue({
+        ...mockHealthProfile,
+        emergencyContacts: [primaryContact, secondaryContact],
+      });
+
+      await expect(service.deleteEmergencyContact('user-uuid', primaryContact.id)).rejects.toThrow(
+        ConflictException,
+      );
+    });
+
+    it('allows deleting the primary when it is the only contact', async () => {
+      mockProfileFindFirst.mockResolvedValue({
+        ...mockHealthProfile,
+        emergencyContacts: [primaryContact],
+      });
+
+      await service.deleteEmergencyContact('user-uuid', primaryContact.id);
+
+      expect(mockSet).toHaveBeenCalledWith(expect.objectContaining({ emergencyContacts: [] }));
+    });
+
+    it('throws NotFoundException when the contact id is not found', async () => {
+      mockProfileFindFirst.mockResolvedValue({
+        ...mockHealthProfile,
+        emergencyContacts: [primaryContact],
+      });
+
+      await expect(service.deleteEmergencyContact('user-uuid', 'nonexistent-id')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('propagates unexpected database errors', async () => {
+      mockProfileFindFirst.mockResolvedValue({
+        ...mockHealthProfile,
+        emergencyContacts: [primaryContact, secondaryContact],
+      });
+      const dbError = new Error('update failed');
+      mockSet.mockReturnValue({ where: jest.fn().mockRejectedValue(dbError) });
+
+      await expect(
+        service.deleteEmergencyContact('user-uuid', secondaryContact.id),
+      ).rejects.toThrow(dbError);
     });
   });
 });

--- a/apps/api/src/modules/users/users.service.ts
+++ b/apps/api/src/modules/users/users.service.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable, NotFoundException } from '@nestjs/common';
+import { ConflictException, Inject, Injectable, NotFoundException } from '@nestjs/common';
 import { eq } from 'drizzle-orm';
 import { DRIZZLE_CLIENT, DrizzleClient } from '@/database/drizzle.provider';
 import { userPreferences } from '@/modules/users/schema/user-preferences.schema';
@@ -7,6 +7,7 @@ import { users } from '@/modules/users/schema/users.schema';
 import type { AuthenticatedUser } from '@/types/express';
 import type { DateOfBirthDto } from './dto/date-of-birth.dto';
 import type { UpdateUserDto } from './dto/update-user.dto';
+import type { EmergencyContactDto, UpdateEmergencyContactDto } from './dto/emergency-contact.dto';
 import type { UpdateUserHealthDto } from './dto/update-user-health.dto';
 import type { UpdateUserPreferencesDto } from './dto/update-user-preferences.dto';
 import type { UpdateUserProfileDto } from './dto/update-user-profile.dto';
@@ -192,6 +193,106 @@ export class UsersService {
       throw new NotFoundException('User profile not found');
     }
     return this.mapHealthResponse(updated);
+  }
+
+  async getEmergencyContacts(userId: string): Promise<EmergencyContactDto[]> {
+    const { contacts } = await this.fetchContacts(userId);
+    return contacts;
+  }
+
+  async addEmergencyContact(
+    userId: string,
+    dto: EmergencyContactDto,
+  ): Promise<EmergencyContactDto> {
+    const { contacts } = await this.fetchContacts(userId);
+
+    const updated = dto.isPrimary
+      ? contacts.map((c) => ({ ...c, isPrimary: false }))
+      : [...contacts];
+    updated.push(dto);
+
+    const [saved] = await this.db
+      .update(userProfiles)
+      .set({ emergencyContacts: updated })
+      .where(eq(userProfiles.userId, userId))
+      .returning();
+
+    if (!saved) {
+      throw new NotFoundException('User profile not found');
+    }
+    return (saved.emergencyContacts as EmergencyContactDto[]).find((c) => c.id === dto.id)!;
+  }
+
+  async updateEmergencyContact(
+    userId: string,
+    contactId: string,
+    dto: UpdateEmergencyContactDto,
+  ): Promise<EmergencyContactDto> {
+    const { contacts } = await this.fetchContacts(userId);
+
+    const index = contacts.findIndex((c) => c.id === contactId);
+    if (index === -1) {
+      throw new NotFoundException('Emergency contact not found');
+    }
+
+    const withPrimary =
+      dto.isPrimary === true
+        ? contacts.map((c) => ({ ...c, isPrimary: c.id === contactId ? true : false }))
+        : contacts;
+
+    const updated = withPrimary.map((c, i) =>
+      i === index
+        ? { ...c, ...Object.fromEntries(Object.entries(dto).filter(([, v]) => v !== undefined)) }
+        : c,
+    );
+
+    const [saved] = await this.db
+      .update(userProfiles)
+      .set({ emergencyContacts: updated })
+      .where(eq(userProfiles.userId, userId))
+      .returning();
+
+    if (!saved) {
+      throw new NotFoundException('User profile not found');
+    }
+    return (saved.emergencyContacts as EmergencyContactDto[]).find((c) => c.id === contactId)!;
+  }
+
+  async deleteEmergencyContact(userId: string, contactId: string): Promise<void> {
+    const { contacts } = await this.fetchContacts(userId);
+
+    const contact = contacts.find((c) => c.id === contactId);
+    if (!contact) {
+      throw new NotFoundException('Emergency contact not found');
+    }
+
+    if (contact.isPrimary && contacts.length > 1) {
+      throw new ConflictException(
+        'Cannot delete the primary emergency contact. Re-assign primary first.',
+      );
+    }
+
+    const updated = contacts.filter((c) => c.id !== contactId);
+
+    await this.db
+      .update(userProfiles)
+      .set({ emergencyContacts: updated })
+      .where(eq(userProfiles.userId, userId));
+  }
+
+  private async fetchContacts(
+    userId: string,
+  ): Promise<{ profile: typeof userProfiles.$inferSelect; contacts: EmergencyContactDto[] }> {
+    const profile = await this.db.query.userProfiles.findFirst({
+      where: eq(userProfiles.userId, userId),
+    });
+    if (!profile) {
+      throw new NotFoundException('User profile not found');
+    }
+    return {
+      profile,
+      contacts: (profile.emergencyContacts as EmergencyContactDto[]) ?? [],
+    };
   }
 
   private mapUserResponse(user: typeof users.$inferSelect): UserResponseDto {

--- a/apps/api/src/modules/users/users.service.ts
+++ b/apps/api/src/modules/users/users.service.ts
@@ -1,4 +1,10 @@
-import { ConflictException, Inject, Injectable, NotFoundException } from '@nestjs/common';
+import {
+  BadRequestException,
+  ConflictException,
+  Inject,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
 import { eq } from 'drizzle-orm';
 import { DRIZZLE_CLIENT, DrizzleClient } from '@/database/drizzle.provider';
 import { userPreferences } from '@/modules/users/schema/user-preferences.schema';
@@ -235,9 +241,15 @@ export class UsersService {
       throw new NotFoundException('Emergency contact not found');
     }
 
+    if (dto.isPrimary === false) {
+      throw new BadRequestException(
+        'Cannot unset the primary contact directly — assign a new primary first.',
+      );
+    }
+
     const withPrimary =
       dto.isPrimary === true
-        ? contacts.map((c) => ({ ...c, isPrimary: c.id === contactId ? true : false }))
+        ? contacts.map((c) => ({ ...c, isPrimary: c.id === contactId }))
         : contacts;
 
     const updated = withPrimary.map((c, i) =>


### PR DESCRIPTION
## Summary

Implements the four emergency-contact endpoints backed by the `emergency_contacts` JSONB array on `user_profiles`. Each operation targets individual array elements by client-supplied UUID, unlike health items (wholesale array replacement). Business rules: exactly one contact must be primary at all times; deleting the primary while other contacts exist is rejected with 409.

Phone numbers follow the split pattern established in #105: `phoneCountryCode` (E.164 prefix, `/^\+[1-9]\d{0,2}$/`) and `phoneLocalNumber` (digits only, 4–14 chars).

## Changes

**New DTO** — `emergency-contact.dto.ts`
- `EmergencyContactDto`: full validation with `@IsUUID`, trimmed string fields, regex-validated phone fields, `@IsBoolean` for `isPrimary`
- `UpdateEmergencyContactDto`: all fields optional, same validators

**Service** — `users.service.ts`
- `getEmergencyContacts`, `addEmergencyContact`, `updateEmergencyContact`, `deleteEmergencyContact`
- `fetchContacts` private helper centralises profile fetch + cast
- `addEmergencyContact`: demotes current primary when new contact is `isPrimary: true`
- `updateEmergencyContact`: unsets all other primaries when `isPrimary: true`; merges only defined fields via `Object.fromEntries`
- `deleteEmergencyContact`: 409 when deleting primary while other contacts remain

**Controller** — `users.controller.ts`
- Four endpoints with full OpenAPI (`@ApiOperation`, `@ApiResponse`, `@ApiParam`, `@ApiBody`, `@ApiBearerAuth`)

## Testing

- `emergency-contact.dto.spec.ts`: 14 tests covering valid input, every validation constraint, trim behaviour, `@Transform` else branch (non-string values), missing required fields
- `users.service.spec.ts`: 22 new tests covering happy paths, primary demotion, race-condition guards (`NotFoundException` when profile deleted between check and write), `ConflictException` on primary deletion, DB error propagation
- `users.controller.spec.ts`: 8 new tests (delegates + propagates error per endpoint)
- All 299 tests pass; coverage ≥ 90% across lines, statements, functions, branches

## Notes

No migration needed — `emergency_contacts jsonb NOT NULL DEFAULT '[]'::jsonb` already exists from prior migrations.

Closes #107