### PR TITLE
feat(users): add /users/me/nationalities CRUD endpoints

### DIFF
--- a/apps/api/src/modules/users/dto/nationality.dto.spec.ts
+++ b/apps/api/src/modules/users/dto/nationality.dto.spec.ts
@@ -1,0 +1,207 @@
+import 'reflect-metadata';
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { CreateNationalityDto, UpdateNationalityDto } from './nationality.dto';
+
+const validBase = {
+  countryCode: 'CO',
+  isPrimary: true,
+};
+
+const validPassport = {
+  passportNumber: 'AB123456',
+  passportIssueDate: '2020-01-15',
+  passportExpiryDate: '2030-01-15',
+};
+
+describe('CreateNationalityDto', () => {
+  it('accepts a valid nationality without passport data', async () => {
+    const dto = plainToInstance(CreateNationalityDto, validBase);
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(0);
+  });
+
+  it('accepts a valid nationality with full passport data', async () => {
+    const dto = plainToInstance(CreateNationalityDto, { ...validBase, ...validPassport });
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(0);
+  });
+
+  it('accepts nationalIdNumber when provided', async () => {
+    const dto = plainToInstance(CreateNationalityDto, {
+      ...validBase,
+      nationalIdNumber: '12345678',
+    });
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(0);
+  });
+
+  it('rejects nationalIdNumber as empty string', async () => {
+    const dto = plainToInstance(CreateNationalityDto, { ...validBase, nationalIdNumber: '' });
+    const errors = await validate(dto);
+    expect(errors.some((e) => e.property === 'nationalIdNumber')).toBe(true);
+  });
+
+  it('rejects countryCode with more than 2 letters', async () => {
+    const dto = plainToInstance(CreateNationalityDto, { ...validBase, countryCode: 'COL' });
+    const errors = await validate(dto);
+    expect(errors.some((e) => e.property === 'countryCode')).toBe(true);
+  });
+
+  it('rejects countryCode with fewer than 2 letters', async () => {
+    const dto = plainToInstance(CreateNationalityDto, { ...validBase, countryCode: 'C' });
+    const errors = await validate(dto);
+    expect(errors.some((e) => e.property === 'countryCode')).toBe(true);
+  });
+
+  it('rejects countryCode with lowercase letters', async () => {
+    const dto = plainToInstance(CreateNationalityDto, { ...validBase, countryCode: 'co' });
+    const errors = await validate(dto);
+    expect(errors.some((e) => e.property === 'countryCode')).toBe(true);
+  });
+
+  it('rejects missing isPrimary', async () => {
+    const dto = plainToInstance(CreateNationalityDto, { countryCode: 'CO' });
+    const errors = await validate(dto);
+    expect(errors.some((e) => e.property === 'isPrimary')).toBe(true);
+  });
+
+  it('rejects missing required fields', async () => {
+    const dto = plainToInstance(CreateNationalityDto, {});
+    const errors = await validate(dto);
+    const properties = errors.map((e) => e.property);
+    expect(properties).toContain('countryCode');
+    expect(properties).toContain('isPrimary');
+  });
+
+  describe('passport data consistency', () => {
+    it('requires passportIssueDate and passportExpiryDate when only passportNumber is provided', async () => {
+      const dto = plainToInstance(CreateNationalityDto, {
+        ...validBase,
+        passportNumber: 'AB123456',
+      });
+      const errors = await validate(dto);
+      expect(errors.some((e) => e.property === 'passportIssueDate')).toBe(true);
+      expect(errors.some((e) => e.property === 'passportExpiryDate')).toBe(true);
+    });
+
+    it('requires passportNumber and passportExpiryDate when only passportIssueDate is provided', async () => {
+      const dto = plainToInstance(CreateNationalityDto, {
+        ...validBase,
+        passportIssueDate: '2020-01-15',
+      });
+      const errors = await validate(dto);
+      expect(errors.some((e) => e.property === 'passportNumber')).toBe(true);
+      expect(errors.some((e) => e.property === 'passportExpiryDate')).toBe(true);
+    });
+
+    it('requires passportNumber and passportIssueDate when only passportExpiryDate is provided', async () => {
+      const dto = plainToInstance(CreateNationalityDto, {
+        ...validBase,
+        passportExpiryDate: '2030-01-15',
+      });
+      const errors = await validate(dto);
+      expect(errors.some((e) => e.property === 'passportNumber')).toBe(true);
+      expect(errors.some((e) => e.property === 'passportIssueDate')).toBe(true);
+    });
+
+    it('rejects two of three passport fields provided', async () => {
+      const dto = plainToInstance(CreateNationalityDto, {
+        ...validBase,
+        passportNumber: 'AB123456',
+        passportIssueDate: '2020-01-15',
+      });
+      const errors = await validate(dto);
+      expect(errors.some((e) => e.property === 'passportExpiryDate')).toBe(true);
+    });
+
+    it('rejects passportIssueDate in non-ISO format', async () => {
+      const dto = plainToInstance(CreateNationalityDto, {
+        ...validBase,
+        ...validPassport,
+        passportIssueDate: '15/01/2020',
+      });
+      const errors = await validate(dto);
+      expect(errors.some((e) => e.property === 'passportIssueDate')).toBe(true);
+    });
+
+    it('rejects passportExpiryDate in non-ISO format', async () => {
+      const dto = plainToInstance(CreateNationalityDto, {
+        ...validBase,
+        ...validPassport,
+        passportExpiryDate: 'January 15 2030',
+      });
+      const errors = await validate(dto);
+      expect(errors.some((e) => e.property === 'passportExpiryDate')).toBe(true);
+    });
+
+    it('rejects passportNumber as empty string', async () => {
+      const dto = plainToInstance(CreateNationalityDto, {
+        ...validBase,
+        ...validPassport,
+        passportNumber: '',
+      });
+      const errors = await validate(dto);
+      expect(errors.some((e) => e.property === 'passportNumber')).toBe(true);
+    });
+  });
+});
+
+describe('UpdateNationalityDto', () => {
+  it('accepts an empty object (all fields optional)', async () => {
+    const dto = plainToInstance(UpdateNationalityDto, {});
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(0);
+  });
+
+  it('accepts a partial update with only isPrimary', async () => {
+    const dto = plainToInstance(UpdateNationalityDto, { isPrimary: true });
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(0);
+  });
+
+  it('accepts a partial update with only nationalIdNumber', async () => {
+    const dto = plainToInstance(UpdateNationalityDto, { nationalIdNumber: '99887766' });
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(0);
+  });
+
+  it('accepts a full passport data update', async () => {
+    const dto = plainToInstance(UpdateNationalityDto, validPassport);
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(0);
+  });
+
+  it('rejects non-boolean isPrimary', async () => {
+    const dto = plainToInstance(UpdateNationalityDto, { isPrimary: 'yes' });
+    const errors = await validate(dto);
+    expect(errors.some((e) => e.property === 'isPrimary')).toBe(true);
+  });
+
+  it('rejects nationalIdNumber as empty string', async () => {
+    const dto = plainToInstance(UpdateNationalityDto, { nationalIdNumber: '' });
+    const errors = await validate(dto);
+    expect(errors.some((e) => e.property === 'nationalIdNumber')).toBe(true);
+  });
+
+  describe('passport data consistency', () => {
+    it('requires all three passport fields when only one is provided', async () => {
+      const dto = plainToInstance(UpdateNationalityDto, { passportNumber: 'AB123456' });
+      const errors = await validate(dto);
+      expect(errors.some((e) => e.property === 'passportIssueDate')).toBe(true);
+      expect(errors.some((e) => e.property === 'passportExpiryDate')).toBe(true);
+    });
+
+    it('accepts all three passport fields provided', async () => {
+      const dto = plainToInstance(UpdateNationalityDto, validPassport);
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('accepts when no passport fields are provided', async () => {
+      const dto = plainToInstance(UpdateNationalityDto, { isPrimary: false });
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+    });
+  });
+});

--- a/apps/api/src/modules/users/dto/nationality.dto.ts
+++ b/apps/api/src/modules/users/dto/nationality.dto.ts
@@ -119,7 +119,12 @@ export class CreateNationalityDto {
 }
 
 export class UpdateNationalityDto {
-  @ApiProperty({ example: true, required: false })
+  @ApiProperty({
+    example: true,
+    description:
+      'Promote this nationality to primary. isPrimary: false is rejected — assign a new primary instead.',
+    required: false,
+  })
   @IsOptional()
   @IsBoolean()
   isPrimary?: boolean;

--- a/apps/api/src/modules/users/dto/nationality.dto.ts
+++ b/apps/api/src/modules/users/dto/nationality.dto.ts
@@ -1,0 +1,168 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  IsBoolean,
+  IsDefined,
+  IsDateString,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  Matches,
+  ValidateIf,
+} from 'class-validator';
+import { PassportStatus } from '@chamuco/shared-types';
+
+// Condition: any passport field present in the payload
+const anyPassportFieldPresent = (o: {
+  passportNumber?: unknown;
+  passportIssueDate?: unknown;
+  passportExpiryDate?: unknown;
+}): boolean =>
+  o.passportNumber !== undefined ||
+  o.passportIssueDate !== undefined ||
+  o.passportExpiryDate !== undefined;
+
+export class NationalityResponseDto {
+  @ApiProperty({
+    example: 'b3c4d5e6-f7a8-9012-bcde-f01234567890',
+    description: 'Server-generated UUID',
+  })
+  id!: string;
+
+  @ApiProperty({ example: 'CO', description: 'ISO 3166-1 alpha-2 country code' })
+  countryCode!: string;
+
+  @ApiProperty({ example: true, description: 'Exactly one nationality must be primary' })
+  isPrimary!: boolean;
+
+  @ApiProperty({ example: '12345678', description: 'National ID / Cédula / DNI', nullable: true })
+  nationalIdNumber!: string | null;
+
+  @ApiProperty({ example: 'AB123456', description: 'Passport document number', nullable: true })
+  passportNumber!: string | null;
+
+  @ApiProperty({
+    example: '2020-01-15',
+    description: 'Passport issue date (YYYY-MM-DD)',
+    nullable: true,
+  })
+  passportIssueDate!: string | null;
+
+  @ApiProperty({
+    example: '2030-01-15',
+    description: 'Passport expiry date (YYYY-MM-DD)',
+    nullable: true,
+  })
+  passportExpiryDate!: string | null;
+
+  @ApiProperty({
+    enum: PassportStatus,
+    example: PassportStatus.ACTIVE,
+    description: 'Computed by the server — not provided by the client',
+  })
+  passportStatus!: PassportStatus;
+}
+
+export class CreateNationalityDto {
+  @ApiProperty({
+    example: 'CO',
+    description: 'ISO 3166-1 alpha-2 country code (two uppercase letters)',
+  })
+  @Matches(/^[A-Z]{2}$/, { message: 'countryCode must be a 2-letter uppercase ISO country code' })
+  @IsString()
+  countryCode!: string;
+
+  @ApiProperty({ example: true, description: 'Exactly one nationality must be primary' })
+  @IsBoolean()
+  isPrimary!: boolean;
+
+  @ApiProperty({
+    example: '12345678',
+    description: 'National ID / Cédula / DNI. Omit or set null to leave empty.',
+    nullable: true,
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty({ message: 'nationalIdNumber must not be an empty string' })
+  nationalIdNumber?: string | null;
+
+  @ApiProperty({
+    example: 'AB123456',
+    description: 'Passport document number. Required when any passport field is provided.',
+    required: false,
+  })
+  @ValidateIf(anyPassportFieldPresent)
+  @IsDefined({ message: 'passportNumber is required when any passport field is provided' })
+  @IsString()
+  @IsNotEmpty({ message: 'passportNumber must not be an empty string' })
+  passportNumber?: string;
+
+  @ApiProperty({
+    example: '2020-01-15',
+    description: 'Passport issue date (YYYY-MM-DD). Required when any passport field is provided.',
+    required: false,
+  })
+  @ValidateIf(anyPassportFieldPresent)
+  @IsDefined({ message: 'passportIssueDate is required when any passport field is provided' })
+  @IsDateString({}, { message: 'passportIssueDate must be a valid ISO 8601 date (YYYY-MM-DD)' })
+  passportIssueDate?: string;
+
+  @ApiProperty({
+    example: '2030-01-15',
+    description: 'Passport expiry date (YYYY-MM-DD). Required when any passport field is provided.',
+    required: false,
+  })
+  @ValidateIf(anyPassportFieldPresent)
+  @IsDefined({ message: 'passportExpiryDate is required when any passport field is provided' })
+  @IsDateString({}, { message: 'passportExpiryDate must be a valid ISO 8601 date (YYYY-MM-DD)' })
+  passportExpiryDate?: string;
+}
+
+export class UpdateNationalityDto {
+  @ApiProperty({ example: true, required: false })
+  @IsOptional()
+  @IsBoolean()
+  isPrimary?: boolean;
+
+  @ApiProperty({
+    example: '12345678',
+    description: 'National ID / Cédula / DNI. Omit to leave unchanged.',
+    nullable: true,
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty({ message: 'nationalIdNumber must not be an empty string' })
+  nationalIdNumber?: string | null;
+
+  @ApiProperty({
+    example: 'AB123456',
+    description: 'Passport document number. Required when any passport field is provided.',
+    required: false,
+  })
+  @ValidateIf(anyPassportFieldPresent)
+  @IsDefined({ message: 'passportNumber is required when any passport field is provided' })
+  @IsString()
+  @IsNotEmpty({ message: 'passportNumber must not be an empty string' })
+  passportNumber?: string;
+
+  @ApiProperty({
+    example: '2020-01-15',
+    description: 'Passport issue date (YYYY-MM-DD). Required when any passport field is provided.',
+    required: false,
+  })
+  @ValidateIf(anyPassportFieldPresent)
+  @IsDefined({ message: 'passportIssueDate is required when any passport field is provided' })
+  @IsDateString({}, { message: 'passportIssueDate must be a valid ISO 8601 date (YYYY-MM-DD)' })
+  passportIssueDate?: string;
+
+  @ApiProperty({
+    example: '2030-01-15',
+    description: 'Passport expiry date (YYYY-MM-DD). Required when any passport field is provided.',
+    required: false,
+  })
+  @ValidateIf(anyPassportFieldPresent)
+  @IsDefined({ message: 'passportExpiryDate is required when any passport field is provided' })
+  @IsDateString({}, { message: 'passportExpiryDate must be a valid ISO 8601 date (YYYY-MM-DD)' })
+  passportExpiryDate?: string;
+}

--- a/apps/api/src/modules/users/users.controller.spec.ts
+++ b/apps/api/src/modules/users/users.controller.spec.ts
@@ -7,12 +7,18 @@ import {
   AuthProvider,
   DietaryPreference,
   FoodAllergen,
+  PassportStatus,
   PlatformRole,
 } from '@chamuco/shared-types';
 import { UsersController } from './users.controller';
 import { UsersService } from './users.service';
 import type { UpdateUserDto } from './dto/update-user.dto';
 import type { EmergencyContactDto, UpdateEmergencyContactDto } from './dto/emergency-contact.dto';
+import type {
+  CreateNationalityDto,
+  NationalityResponseDto,
+  UpdateNationalityDto,
+} from './dto/nationality.dto';
 import type { UpdateUserHealthDto } from './dto/update-user-health.dto';
 import type { UpdateUserPreferencesDto } from './dto/update-user-preferences.dto';
 import type { UpdateUserProfileDto } from './dto/update-user-profile.dto';
@@ -86,6 +92,10 @@ describe('UsersController', () => {
   let mockAddEmergencyContact: jest.Mock;
   let mockUpdateEmergencyContact: jest.Mock;
   let mockDeleteEmergencyContact: jest.Mock;
+  let mockGetNationalities: jest.Mock;
+  let mockAddNationality: jest.Mock;
+  let mockUpdateNationality: jest.Mock;
+  let mockDeleteNationality: jest.Mock;
 
   const mockContactResponse: EmergencyContactDto = {
     id: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
@@ -94,6 +104,17 @@ describe('UsersController', () => {
     phoneLocalNumber: '3001234567',
     relationship: 'mother',
     isPrimary: true,
+  };
+
+  const mockNationalityResponse: NationalityResponseDto = {
+    id: 'nat-uuid',
+    countryCode: 'CO',
+    isPrimary: true,
+    nationalIdNumber: null,
+    passportNumber: null,
+    passportIssueDate: null,
+    passportExpiryDate: null,
+    passportStatus: PassportStatus.OMITTED,
   };
 
   beforeEach(async () => {
@@ -112,6 +133,10 @@ describe('UsersController', () => {
     mockAddEmergencyContact = jest.fn().mockResolvedValue(mockContactResponse);
     mockUpdateEmergencyContact = jest.fn().mockResolvedValue(mockContactResponse);
     mockDeleteEmergencyContact = jest.fn().mockResolvedValue(undefined);
+    mockGetNationalities = jest.fn().mockResolvedValue([mockNationalityResponse]);
+    mockAddNationality = jest.fn().mockResolvedValue(mockNationalityResponse);
+    mockUpdateNationality = jest.fn().mockResolvedValue(mockNationalityResponse);
+    mockDeleteNationality = jest.fn().mockResolvedValue(undefined);
 
     const module: TestingModule = await Test.createTestingModule({
       controllers: [UsersController],
@@ -132,6 +157,10 @@ describe('UsersController', () => {
             addEmergencyContact: mockAddEmergencyContact,
             updateEmergencyContact: mockUpdateEmergencyContact,
             deleteEmergencyContact: mockDeleteEmergencyContact,
+            getNationalities: mockGetNationalities,
+            addNationality: mockAddNationality,
+            updateNationality: mockUpdateNationality,
+            deleteNationality: mockDeleteNationality,
           },
         },
       ],
@@ -419,6 +448,80 @@ describe('UsersController', () => {
       await expect(
         controller.deleteEmergencyContact(mockAuthUser, mockContactResponse.id),
       ).rejects.toThrow(ConflictException);
+    });
+  });
+
+  describe('GET /v1/users/me/nationalities', () => {
+    it('delegates to usersService.getNationalities with the authenticated user id', async () => {
+      const result = await controller.getNationalities(mockAuthUser);
+
+      expect(mockGetNationalities).toHaveBeenCalledWith(mockAuthUser.id);
+      expect(result).toEqual([mockNationalityResponse]);
+    });
+
+    it('propagates unexpected errors from the service', async () => {
+      mockGetNationalities.mockRejectedValue(new Error('db error'));
+
+      await expect(controller.getNationalities(mockAuthUser)).rejects.toThrow('db error');
+    });
+  });
+
+  describe('POST /v1/users/me/nationalities', () => {
+    it('delegates to usersService.addNationality with the user id and dto', async () => {
+      const dto: CreateNationalityDto = { countryCode: 'CO', isPrimary: true };
+
+      const result = await controller.addNationality(mockAuthUser, dto);
+
+      expect(mockAddNationality).toHaveBeenCalledWith(mockAuthUser.id, dto);
+      expect(result).toEqual(mockNationalityResponse);
+    });
+
+    it('propagates ConflictException from the service', async () => {
+      mockAddNationality.mockRejectedValue(new ConflictException());
+
+      await expect(
+        controller.addNationality(mockAuthUser, { countryCode: 'CO', isPrimary: true }),
+      ).rejects.toThrow(ConflictException);
+    });
+  });
+
+  describe('PATCH /v1/users/me/nationalities/:id', () => {
+    it('delegates to usersService.updateNationality with the user id, nationality id, and dto', async () => {
+      const dto: UpdateNationalityDto = { nationalIdNumber: '12345678' };
+      const updated: NationalityResponseDto = {
+        ...mockNationalityResponse,
+        nationalIdNumber: '12345678',
+      };
+      mockUpdateNationality.mockResolvedValue(updated);
+
+      const result = await controller.updateNationality(mockAuthUser, 'nat-uuid', dto);
+
+      expect(mockUpdateNationality).toHaveBeenCalledWith(mockAuthUser.id, 'nat-uuid', dto);
+      expect(result).toEqual(updated);
+    });
+
+    it('propagates NotFoundException from the service', async () => {
+      mockUpdateNationality.mockRejectedValue(new NotFoundException());
+
+      await expect(
+        controller.updateNationality(mockAuthUser, 'nonexistent-uuid', {}),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('DELETE /v1/users/me/nationalities/:id', () => {
+    it('delegates to usersService.deleteNationality with the user id and nationality id', async () => {
+      await controller.deleteNationality(mockAuthUser, 'nat-uuid');
+
+      expect(mockDeleteNationality).toHaveBeenCalledWith(mockAuthUser.id, 'nat-uuid');
+    });
+
+    it('propagates ConflictException from the service', async () => {
+      mockDeleteNationality.mockRejectedValue(new ConflictException());
+
+      await expect(controller.deleteNationality(mockAuthUser, 'nat-uuid')).rejects.toThrow(
+        ConflictException,
+      );
     });
   });
 });

--- a/apps/api/src/modules/users/users.controller.ts
+++ b/apps/api/src/modules/users/users.controller.ts
@@ -26,6 +26,11 @@ import type { AuthenticatedUser } from '@/types/express';
 import { UsersService } from './users.service';
 import { UpdateUserDto } from './dto/update-user.dto';
 import { EmergencyContactDto, UpdateEmergencyContactDto } from './dto/emergency-contact.dto';
+import {
+  CreateNationalityDto,
+  NationalityResponseDto,
+  UpdateNationalityDto,
+} from './dto/nationality.dto';
 import { UpdateUserHealthDto } from './dto/update-user-health.dto';
 import { UpdateUserPreferencesDto } from './dto/update-user-preferences.dto';
 import { UpdateUserProfileDto } from './dto/update-user-profile.dto';
@@ -196,6 +201,93 @@ export class UsersController {
     @Param('id') contactId: string,
   ): Promise<void> {
     return this.usersService.deleteEmergencyContact(user.id, contactId);
+  }
+
+  @Get('me/nationalities')
+  @ApiOperation({
+    summary: "List the current user's nationalities",
+    description:
+      'Returns all nationality records for the authenticated user, ordered by primary first.',
+  })
+  @ApiResponse({ status: 200, type: NationalityResponseDto, isArray: true })
+  @ApiResponse({ status: 401, description: 'Missing or invalid Firebase ID token' })
+  getNationalities(@CurrentUser() user: AuthenticatedUser): Promise<NationalityResponseDto[]> {
+    return this.usersService.getNationalities(user.id);
+  }
+
+  @Post('me/nationalities')
+  @HttpCode(201)
+  @ApiBody({ type: CreateNationalityDto })
+  @ApiOperation({
+    summary: 'Add a nationality',
+    description:
+      'Adds a new nationality record. If isPrimary is true, the current primary is automatically demoted. ' +
+      'Returns 409 if a nationality for the same country already exists. ' +
+      'If any passport field is provided, all three must be present.',
+  })
+  @ApiResponse({ status: 201, type: NationalityResponseDto })
+  @ApiResponse({
+    status: 400,
+    description: 'Validation failed — invalid field value or incomplete passport data',
+  })
+  @ApiResponse({ status: 401, description: 'Missing or invalid Firebase ID token' })
+  @ApiResponse({ status: 409, description: 'Nationality for this country already exists' })
+  addNationality(
+    @CurrentUser() user: AuthenticatedUser,
+    @Body() dto: CreateNationalityDto,
+  ): Promise<NationalityResponseDto> {
+    return this.usersService.addNationality(user.id, dto);
+  }
+
+  @Patch('me/nationalities/:id')
+  @HttpCode(200)
+  @ApiParam({ name: 'id', description: 'UUID of the nationality record to update' })
+  @ApiBody({ type: UpdateNationalityDto })
+  @ApiOperation({
+    summary: 'Update a nationality',
+    description:
+      'Updates any subset of fields on a single nationality record. ' +
+      'If isPrimary is true, all other nationalities are automatically demoted. ' +
+      'isPrimary: false is rejected — assign a new primary instead. ' +
+      'If any passport field is provided, all three must be present.',
+  })
+  @ApiResponse({ status: 200, type: NationalityResponseDto })
+  @ApiResponse({
+    status: 400,
+    description:
+      'Validation failed — invalid field value, incomplete passport data, or isPrimary: false',
+  })
+  @ApiResponse({ status: 401, description: 'Missing or invalid Firebase ID token' })
+  @ApiResponse({ status: 404, description: 'Nationality not found' })
+  updateNationality(
+    @CurrentUser() user: AuthenticatedUser,
+    @Param('id') nationalityId: string,
+    @Body() dto: UpdateNationalityDto,
+  ): Promise<NationalityResponseDto> {
+    return this.usersService.updateNationality(user.id, nationalityId, dto);
+  }
+
+  @Delete('me/nationalities/:id')
+  @HttpCode(204)
+  @ApiParam({ name: 'id', description: 'UUID of the nationality record to delete' })
+  @ApiOperation({
+    summary: 'Delete a nationality',
+    description:
+      'Removes a single nationality record. ' +
+      'Returns 409 if the record is the primary and other nationalities exist — re-assign primary first.',
+  })
+  @ApiResponse({ status: 204, description: 'Nationality deleted' })
+  @ApiResponse({ status: 401, description: 'Missing or invalid Firebase ID token' })
+  @ApiResponse({ status: 404, description: 'Nationality not found' })
+  @ApiResponse({
+    status: 409,
+    description: 'Cannot delete primary nationality while other nationalities exist',
+  })
+  deleteNationality(
+    @CurrentUser() user: AuthenticatedUser,
+    @Param('id') nationalityId: string,
+  ): Promise<void> {
+    return this.usersService.deleteNationality(user.id, nationalityId);
   }
 
   @Get('me/profile')

--- a/apps/api/src/modules/users/users.service.spec.ts
+++ b/apps/api/src/modules/users/users.service.spec.ts
@@ -8,6 +8,7 @@ import {
   DietaryPreference,
   FoodAllergen,
   MedicalConditionType,
+  PassportStatus,
   PhobiaType,
   PhysicalLimitationType,
   PlatformRole,
@@ -18,6 +19,7 @@ import type { UpdateUserDto } from './dto/update-user.dto';
 import type { UpdateUserHealthDto } from './dto/update-user-health.dto';
 import type { UpdateUserPreferencesDto } from './dto/update-user-preferences.dto';
 import type { EmergencyContactDto, UpdateEmergencyContactDto } from './dto/emergency-contact.dto';
+import type { CreateNationalityDto, UpdateNationalityDto } from './dto/nationality.dto';
 import type { UpdateUserProfileDto } from './dto/update-user-profile.dto';
 import type { UserHealthResponseDto } from './dto/user-health-response.dto';
 import type { AuthenticatedUser } from '@/types/express';
@@ -77,16 +79,27 @@ describe('UsersService', () => {
   let mockPrefFindFirst: jest.Mock;
   let mockReturning: jest.Mock;
   let mockSet: jest.Mock;
+  let mockNationalitiesFindFirst: jest.Mock;
+  let mockNationalitiesFindMany: jest.Mock;
+  let mockInsertReturning: jest.Mock;
+  let mockDeleteWhere: jest.Mock;
 
   beforeEach(async () => {
     mockFindFirst = jest.fn();
     mockProfileFindFirst = jest.fn();
     mockPrefFindFirst = jest.fn();
     mockReturning = jest.fn();
+    mockNationalitiesFindFirst = jest.fn();
+    mockNationalitiesFindMany = jest.fn();
+    mockInsertReturning = jest.fn();
+    mockDeleteWhere = jest.fn();
 
     const mockWhere = jest.fn().mockReturnValue({ returning: mockReturning });
     mockSet = jest.fn().mockReturnValue({ where: mockWhere });
     const mockUpdate = jest.fn().mockReturnValue({ set: mockSet });
+    const mockInsertValues = jest.fn().mockReturnValue({ returning: mockInsertReturning });
+    const mockInsert = jest.fn().mockReturnValue({ values: mockInsertValues });
+    const mockDelete = jest.fn().mockReturnValue({ where: mockDeleteWhere });
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -98,8 +111,14 @@ describe('UsersService', () => {
               users: { findFirst: mockFindFirst },
               userProfiles: { findFirst: mockProfileFindFirst },
               userPreferences: { findFirst: mockPrefFindFirst },
+              userNationalities: {
+                findFirst: mockNationalitiesFindFirst,
+                findMany: mockNationalitiesFindMany,
+              },
             },
             update: mockUpdate,
+            insert: mockInsert,
+            delete: mockDelete,
           },
         },
       ],
@@ -976,6 +995,303 @@ describe('UsersService', () => {
       await expect(
         service.deleteEmergencyContact('user-uuid', secondaryContact.id),
       ).rejects.toThrow(dbError);
+    });
+  });
+
+  describe('getNationalities', () => {
+    const mockNationality = {
+      id: 'nat-uuid',
+      userId: 'user-uuid',
+      countryCode: 'CO',
+      isPrimary: true,
+      nationalIdNumber: null,
+      passportNumber: null,
+      passportIssueDate: null,
+      passportExpiryDate: null,
+      passportStatus: PassportStatus.OMITTED,
+      updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+    };
+
+    it('returns mapped nationalities array', async () => {
+      mockNationalitiesFindMany.mockResolvedValue([mockNationality]);
+
+      const result = await service.getNationalities('user-uuid');
+
+      expect(result).toEqual([
+        {
+          id: mockNationality.id,
+          countryCode: mockNationality.countryCode,
+          isPrimary: mockNationality.isPrimary,
+          nationalIdNumber: null,
+          passportNumber: null,
+          passportIssueDate: null,
+          passportExpiryDate: null,
+          passportStatus: PassportStatus.OMITTED,
+        },
+      ]);
+    });
+
+    it('returns empty array when user has no nationalities', async () => {
+      mockNationalitiesFindMany.mockResolvedValue([]);
+
+      const result = await service.getNationalities('user-uuid');
+
+      expect(result).toEqual([]);
+    });
+
+    it('propagates unexpected database errors', async () => {
+      const dbError = new Error('connection lost');
+      mockNationalitiesFindMany.mockRejectedValue(dbError);
+
+      await expect(service.getNationalities('user-uuid')).rejects.toThrow(dbError);
+    });
+  });
+
+  describe('addNationality', () => {
+    const mockNationality = {
+      id: 'nat-uuid',
+      userId: 'user-uuid',
+      countryCode: 'CO',
+      isPrimary: false,
+      nationalIdNumber: null,
+      passportNumber: null,
+      passportIssueDate: null,
+      passportExpiryDate: null,
+      passportStatus: PassportStatus.OMITTED,
+      updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+    };
+
+    it('inserts and returns the new nationality', async () => {
+      mockNationalitiesFindFirst.mockResolvedValue(undefined);
+      mockInsertReturning.mockResolvedValue([mockNationality]);
+
+      const dto: CreateNationalityDto = { countryCode: 'CO', isPrimary: false };
+      const result = await service.addNationality('user-uuid', dto);
+
+      expect(result).toEqual(expect.objectContaining({ countryCode: 'CO', isPrimary: false }));
+      expect(mockInsertReturning).toHaveBeenCalledTimes(1);
+    });
+
+    it('demotes current primary when isPrimary is true', async () => {
+      mockNationalitiesFindFirst.mockResolvedValue(undefined);
+      mockInsertReturning.mockResolvedValue([{ ...mockNationality, isPrimary: true }]);
+
+      const dto: CreateNationalityDto = { countryCode: 'CO', isPrimary: true };
+      await service.addNationality('user-uuid', dto);
+
+      expect(mockSet).toHaveBeenCalledWith({ isPrimary: false });
+    });
+
+    it('does not call demote update when isPrimary is false', async () => {
+      mockNationalitiesFindFirst.mockResolvedValue(undefined);
+      mockInsertReturning.mockResolvedValue([mockNationality]);
+
+      const dto: CreateNationalityDto = { countryCode: 'CO', isPrimary: false };
+      await service.addNationality('user-uuid', dto);
+
+      expect(mockSet).not.toHaveBeenCalled();
+    });
+
+    it('throws ConflictException on duplicate countryCode', async () => {
+      mockNationalitiesFindFirst.mockResolvedValue(mockNationality);
+
+      const dto: CreateNationalityDto = { countryCode: 'CO', isPrimary: false };
+      await expect(service.addNationality('user-uuid', dto)).rejects.toThrow(ConflictException);
+    });
+
+    it('computes passportStatus ACTIVE for a far-future expiry date', async () => {
+      mockNationalitiesFindFirst.mockResolvedValue(undefined);
+      const withPassport = {
+        ...mockNationality,
+        passportNumber: 'AB123456',
+        passportIssueDate: '2020-01-15',
+        passportExpiryDate: '2035-01-15',
+        passportStatus: PassportStatus.ACTIVE,
+      };
+      mockInsertReturning.mockResolvedValue([withPassport]);
+
+      const dto: CreateNationalityDto = {
+        countryCode: 'CO',
+        isPrimary: false,
+        passportNumber: 'AB123456',
+        passportIssueDate: '2020-01-15',
+        passportExpiryDate: '2035-01-15',
+      };
+      const result = await service.addNationality('user-uuid', dto);
+
+      expect(result.passportStatus).toBe(PassportStatus.ACTIVE);
+    });
+
+    it('propagates unexpected database errors', async () => {
+      mockNationalitiesFindFirst.mockResolvedValue(undefined);
+      const dbError = new Error('insert failed');
+      mockInsertReturning.mockRejectedValue(dbError);
+
+      const dto: CreateNationalityDto = { countryCode: 'CO', isPrimary: false };
+      await expect(service.addNationality('user-uuid', dto)).rejects.toThrow(dbError);
+    });
+  });
+
+  describe('updateNationality', () => {
+    const mockNationality = {
+      id: 'nat-uuid',
+      userId: 'user-uuid',
+      countryCode: 'CO',
+      isPrimary: false,
+      nationalIdNumber: null,
+      passportNumber: null,
+      passportIssueDate: null,
+      passportExpiryDate: null,
+      passportStatus: PassportStatus.OMITTED,
+      updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+    };
+
+    it('updates fields and returns updated nationality', async () => {
+      mockNationalitiesFindFirst.mockResolvedValue(mockNationality);
+      const updated = { ...mockNationality, nationalIdNumber: '12345678' };
+      mockReturning.mockResolvedValue([updated]);
+
+      const dto: UpdateNationalityDto = { nationalIdNumber: '12345678' };
+      const result = await service.updateNationality('user-uuid', 'nat-uuid', dto);
+
+      expect(result.nationalIdNumber).toBe('12345678');
+    });
+
+    it('demotes other nationalities when isPrimary is true', async () => {
+      mockNationalitiesFindFirst.mockResolvedValue(mockNationality);
+      mockReturning.mockResolvedValue([{ ...mockNationality, isPrimary: true }]);
+
+      const dto: UpdateNationalityDto = { isPrimary: true };
+      await service.updateNationality('user-uuid', 'nat-uuid', dto);
+
+      expect(mockSet).toHaveBeenNthCalledWith(1, { isPrimary: false });
+    });
+
+    it('does not demote when isPrimary is not in dto', async () => {
+      mockNationalitiesFindFirst.mockResolvedValue(mockNationality);
+      mockReturning.mockResolvedValue([mockNationality]);
+
+      const dto: UpdateNationalityDto = { nationalIdNumber: '12345' };
+      await service.updateNationality('user-uuid', 'nat-uuid', dto);
+
+      expect(mockSet).toHaveBeenCalledTimes(1);
+      expect(mockSet).not.toHaveBeenCalledWith({ isPrimary: false });
+    });
+
+    it('throws BadRequestException when isPrimary is false', async () => {
+      mockNationalitiesFindFirst.mockResolvedValue(mockNationality);
+
+      const dto: UpdateNationalityDto = { isPrimary: false };
+      await expect(service.updateNationality('user-uuid', 'nat-uuid', dto)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('throws NotFoundException when nationality does not exist', async () => {
+      mockNationalitiesFindFirst.mockResolvedValue(undefined);
+
+      const dto: UpdateNationalityDto = { nationalIdNumber: '12345' };
+      await expect(service.updateNationality('user-uuid', 'nat-uuid', dto)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('recomputes passportStatus when passport fields are in the dto', async () => {
+      mockNationalitiesFindFirst.mockResolvedValue(mockNationality);
+      mockReturning.mockResolvedValue([
+        { ...mockNationality, passportStatus: PassportStatus.ACTIVE },
+      ]);
+
+      const dto: UpdateNationalityDto = {
+        passportNumber: 'AB123456',
+        passportIssueDate: '2020-01-15',
+        passportExpiryDate: '2035-01-15',
+      };
+      await service.updateNationality('user-uuid', 'nat-uuid', dto);
+
+      expect(mockSet).toHaveBeenCalledWith(
+        expect.objectContaining({ passportStatus: PassportStatus.ACTIVE }),
+      );
+    });
+
+    it('preserves existing passportStatus when no passport fields are in the dto', async () => {
+      const withActiveStatus = { ...mockNationality, passportStatus: PassportStatus.ACTIVE };
+      mockNationalitiesFindFirst.mockResolvedValue(withActiveStatus);
+      mockReturning.mockResolvedValue([withActiveStatus]);
+
+      const dto: UpdateNationalityDto = { nationalIdNumber: '12345' };
+      await service.updateNationality('user-uuid', 'nat-uuid', dto);
+
+      expect(mockSet).toHaveBeenCalledWith(
+        expect.objectContaining({ passportStatus: PassportStatus.ACTIVE }),
+      );
+    });
+
+    it('propagates unexpected database errors', async () => {
+      mockNationalitiesFindFirst.mockResolvedValue(mockNationality);
+      const dbError = new Error('update failed');
+      mockReturning.mockRejectedValue(dbError);
+
+      const dto: UpdateNationalityDto = { nationalIdNumber: '12345' };
+      await expect(service.updateNationality('user-uuid', 'nat-uuid', dto)).rejects.toThrow(
+        dbError,
+      );
+    });
+  });
+
+  describe('deleteNationality', () => {
+    const mockNationality = {
+      id: 'nat-uuid',
+      userId: 'user-uuid',
+      countryCode: 'CO',
+      isPrimary: false,
+      nationalIdNumber: null,
+      passportNumber: null,
+      passportIssueDate: null,
+      passportExpiryDate: null,
+      passportStatus: PassportStatus.OMITTED,
+      updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+    };
+    const primaryNationality = { ...mockNationality, id: 'nat-primary-uuid', isPrimary: true };
+
+    it('deletes the nationality successfully', async () => {
+      mockNationalitiesFindMany.mockResolvedValue([mockNationality]);
+
+      await service.deleteNationality('user-uuid', 'nat-uuid');
+
+      expect(mockDeleteWhere).toHaveBeenCalledTimes(1);
+    });
+
+    it('throws ConflictException when deleting the primary with other nationalities remaining', async () => {
+      mockNationalitiesFindMany.mockResolvedValue([primaryNationality, mockNationality]);
+
+      await expect(service.deleteNationality('user-uuid', 'nat-primary-uuid')).rejects.toThrow(
+        ConflictException,
+      );
+    });
+
+    it('allows deleting the primary when it is the only nationality', async () => {
+      mockNationalitiesFindMany.mockResolvedValue([primaryNationality]);
+
+      await service.deleteNationality('user-uuid', 'nat-primary-uuid');
+
+      expect(mockDeleteWhere).toHaveBeenCalledTimes(1);
+    });
+
+    it('throws NotFoundException when nationality does not exist', async () => {
+      mockNationalitiesFindMany.mockResolvedValue([mockNationality]);
+
+      await expect(service.deleteNationality('user-uuid', 'nonexistent-uuid')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('propagates unexpected database errors', async () => {
+      mockNationalitiesFindMany.mockResolvedValue([mockNationality]);
+      const dbError = new Error('delete failed');
+      mockDeleteWhere.mockRejectedValue(dbError);
+
+      await expect(service.deleteNationality('user-uuid', 'nat-uuid')).rejects.toThrow(dbError);
     });
   });
 });

--- a/apps/api/src/modules/users/users.service.spec.ts
+++ b/apps/api/src/modules/users/users.service.spec.ts
@@ -1101,14 +1101,13 @@ describe('UsersService', () => {
 
     it('computes passportStatus ACTIVE for a far-future expiry date', async () => {
       mockNationalitiesFindFirst.mockResolvedValue(undefined);
-      const withPassport = {
-        ...mockNationality,
-        passportNumber: 'AB123456',
-        passportIssueDate: '2020-01-15',
-        passportExpiryDate: '2035-01-15',
-        passportStatus: PassportStatus.ACTIVE,
-      };
-      mockInsertReturning.mockResolvedValue([withPassport]);
+      mockInsertReturning.mockResolvedValue([
+        {
+          ...mockNationality,
+          passportExpiryDate: '2035-01-15',
+          passportStatus: PassportStatus.ACTIVE,
+        },
+      ]);
 
       const dto: CreateNationalityDto = {
         countryCode: 'CO',
@@ -1120,6 +1119,53 @@ describe('UsersService', () => {
       const result = await service.addNationality('user-uuid', dto);
 
       expect(result.passportStatus).toBe(PassportStatus.ACTIVE);
+    });
+
+    it('computes passportStatus EXPIRED for a past expiry date', async () => {
+      mockNationalitiesFindFirst.mockResolvedValue(undefined);
+      mockInsertReturning.mockResolvedValue([
+        {
+          ...mockNationality,
+          passportExpiryDate: '2000-01-01',
+          passportStatus: PassportStatus.EXPIRED,
+        },
+      ]);
+
+      const dto: CreateNationalityDto = {
+        countryCode: 'CO',
+        isPrimary: false,
+        passportNumber: 'AB123456',
+        passportIssueDate: '1995-01-01',
+        passportExpiryDate: '2000-01-01',
+      };
+      const result = await service.addNationality('user-uuid', dto);
+
+      expect(result.passportStatus).toBe(PassportStatus.EXPIRED);
+    });
+
+    it('computes passportStatus EXPIRING_SOON for an expiry within 6 months', async () => {
+      mockNationalitiesFindFirst.mockResolvedValue(undefined);
+      const soonExpiry = new Date();
+      soonExpiry.setUTCMonth(soonExpiry.getUTCMonth() + 2);
+      const expiryStr = soonExpiry.toISOString().slice(0, 10);
+      mockInsertReturning.mockResolvedValue([
+        {
+          ...mockNationality,
+          passportExpiryDate: expiryStr,
+          passportStatus: PassportStatus.EXPIRING_SOON,
+        },
+      ]);
+
+      const dto: CreateNationalityDto = {
+        countryCode: 'CO',
+        isPrimary: false,
+        passportNumber: 'AB123456',
+        passportIssueDate: '2020-01-15',
+        passportExpiryDate: expiryStr,
+      };
+      const result = await service.addNationality('user-uuid', dto);
+
+      expect(result.passportStatus).toBe(PassportStatus.EXPIRING_SOON);
     });
 
     it('propagates unexpected database errors', async () => {
@@ -1155,6 +1201,15 @@ describe('UsersService', () => {
       const result = await service.updateNationality('user-uuid', 'nat-uuid', dto);
 
       expect(result.nationalIdNumber).toBe('12345678');
+    });
+
+    it('returns existing record without a DB write when dto is empty', async () => {
+      mockNationalitiesFindFirst.mockResolvedValue(mockNationality);
+
+      const result = await service.updateNationality('user-uuid', 'nat-uuid', {});
+
+      expect(mockSet).not.toHaveBeenCalled();
+      expect(result.countryCode).toBe(mockNationality.countryCode);
     });
 
     it('demotes other nationalities when isPrimary is true', async () => {
@@ -1223,7 +1278,7 @@ describe('UsersService', () => {
       await service.updateNationality('user-uuid', 'nat-uuid', dto);
 
       expect(mockSet).toHaveBeenCalledWith(
-        expect.objectContaining({ passportStatus: PassportStatus.ACTIVE }),
+        expect.not.objectContaining({ passportStatus: expect.anything() }),
       );
     });
 

--- a/apps/api/src/modules/users/users.service.ts
+++ b/apps/api/src/modules/users/users.service.ts
@@ -342,7 +342,7 @@ export class UsersService {
       .returning();
 
     if (!inserted) {
-      throw new NotFoundException('User not found');
+      throw new NotFoundException('Nationality not found after insert');
     }
     return this.mapNationalityResponse(inserted);
   }
@@ -377,10 +377,6 @@ export class UsersService {
       dto.passportIssueDate !== undefined ||
       dto.passportExpiryDate !== undefined;
 
-    const newPassportStatus = passportChanged
-      ? this.computePassportStatus(dto.passportExpiryDate)
-      : (existing.passportStatus as PassportStatus);
-
     const patch: Partial<typeof userNationalities.$inferInsert> = {};
     if (dto.isPrimary !== undefined) patch.isPrimary = dto.isPrimary;
     if (dto.nationalIdNumber !== undefined) patch.nationalIdNumber = dto.nationalIdNumber;
@@ -389,7 +385,11 @@ export class UsersService {
       patch.passportIssueDate = dto.passportIssueDate ?? null;
     if (dto.passportExpiryDate !== undefined)
       patch.passportExpiryDate = dto.passportExpiryDate ?? null;
-    patch.passportStatus = newPassportStatus;
+    if (passportChanged) patch.passportStatus = this.computePassportStatus(dto.passportExpiryDate);
+
+    if (Object.keys(patch).length === 0) {
+      return this.mapNationalityResponse(existing);
+    }
 
     const [updated] = await this.db
       .update(userNationalities)
@@ -427,9 +427,9 @@ export class UsersService {
   private computePassportStatus(expiryDate: string | undefined | null): PassportStatus {
     if (!expiryDate) return PassportStatus.OMITTED;
     const today = new Date();
-    today.setHours(0, 0, 0, 0);
+    today.setUTCHours(0, 0, 0, 0);
     const sixMonthsFromNow = new Date(today);
-    sixMonthsFromNow.setMonth(sixMonthsFromNow.getMonth() + 6);
+    sixMonthsFromNow.setUTCMonth(sixMonthsFromNow.getUTCMonth() + 6);
     const expiry = new Date(expiryDate);
     if (expiry < today) return PassportStatus.EXPIRED;
     if (expiry < sixMonthsFromNow) return PassportStatus.EXPIRING_SOON;

--- a/apps/api/src/modules/users/users.service.ts
+++ b/apps/api/src/modules/users/users.service.ts
@@ -5,14 +5,21 @@ import {
   Injectable,
   NotFoundException,
 } from '@nestjs/common';
-import { eq } from 'drizzle-orm';
+import { and, eq, ne } from 'drizzle-orm';
 import { DRIZZLE_CLIENT, DrizzleClient } from '@/database/drizzle.provider';
+import { userNationalities } from '@/modules/users/schema/user-nationalities.schema';
 import { userPreferences } from '@/modules/users/schema/user-preferences.schema';
 import { userProfiles } from '@/modules/users/schema/user-profiles.schema';
 import { users } from '@/modules/users/schema/users.schema';
+import { PassportStatus } from '@chamuco/shared-types';
 import type { AuthenticatedUser } from '@/types/express';
 import type { DateOfBirthDto } from './dto/date-of-birth.dto';
 import type { UpdateUserDto } from './dto/update-user.dto';
+import type {
+  CreateNationalityDto,
+  NationalityResponseDto,
+  UpdateNationalityDto,
+} from './dto/nationality.dto';
 import type { EmergencyContactDto, UpdateEmergencyContactDto } from './dto/emergency-contact.dto';
 import type { UpdateUserHealthDto } from './dto/update-user-health.dto';
 import type { UpdateUserPreferencesDto } from './dto/update-user-preferences.dto';
@@ -290,6 +297,158 @@ export class UsersService {
       .update(userProfiles)
       .set({ emergencyContacts: updated })
       .where(eq(userProfiles.userId, userId));
+  }
+
+  async getNationalities(userId: string): Promise<NationalityResponseDto[]> {
+    const records = await this.db.query.userNationalities.findMany({
+      where: eq(userNationalities.userId, userId),
+      orderBy: (t, { desc, asc }) => [desc(t.isPrimary), asc(t.countryCode)],
+    });
+    return records.map((r) => this.mapNationalityResponse(r));
+  }
+
+  async addNationality(userId: string, dto: CreateNationalityDto): Promise<NationalityResponseDto> {
+    const existing = await this.db.query.userNationalities.findFirst({
+      where: and(
+        eq(userNationalities.userId, userId),
+        eq(userNationalities.countryCode, dto.countryCode),
+      ),
+    });
+    if (existing) {
+      throw new ConflictException('Nationality for this country already exists');
+    }
+
+    if (dto.isPrimary) {
+      await this.db
+        .update(userNationalities)
+        .set({ isPrimary: false })
+        .where(and(eq(userNationalities.userId, userId), eq(userNationalities.isPrimary, true)));
+    }
+
+    const passportStatus = this.computePassportStatus(dto.passportExpiryDate);
+
+    const [inserted] = await this.db
+      .insert(userNationalities)
+      .values({
+        userId,
+        countryCode: dto.countryCode,
+        isPrimary: dto.isPrimary,
+        nationalIdNumber: dto.nationalIdNumber ?? null,
+        passportNumber: dto.passportNumber ?? null,
+        passportIssueDate: dto.passportIssueDate ?? null,
+        passportExpiryDate: dto.passportExpiryDate ?? null,
+        passportStatus,
+      })
+      .returning();
+
+    if (!inserted) {
+      throw new NotFoundException('User not found');
+    }
+    return this.mapNationalityResponse(inserted);
+  }
+
+  async updateNationality(
+    userId: string,
+    nationalityId: string,
+    dto: UpdateNationalityDto,
+  ): Promise<NationalityResponseDto> {
+    const existing = await this.db.query.userNationalities.findFirst({
+      where: and(eq(userNationalities.id, nationalityId), eq(userNationalities.userId, userId)),
+    });
+    if (!existing) {
+      throw new NotFoundException('Nationality not found');
+    }
+
+    if (dto.isPrimary === false) {
+      throw new BadRequestException(
+        'Cannot unset the primary nationality directly — assign a new primary first.',
+      );
+    }
+
+    if (dto.isPrimary === true) {
+      await this.db
+        .update(userNationalities)
+        .set({ isPrimary: false })
+        .where(and(eq(userNationalities.userId, userId), ne(userNationalities.id, nationalityId)));
+    }
+
+    const passportChanged =
+      dto.passportNumber !== undefined ||
+      dto.passportIssueDate !== undefined ||
+      dto.passportExpiryDate !== undefined;
+
+    const newPassportStatus = passportChanged
+      ? this.computePassportStatus(dto.passportExpiryDate)
+      : (existing.passportStatus as PassportStatus);
+
+    const patch: Partial<typeof userNationalities.$inferInsert> = {};
+    if (dto.isPrimary !== undefined) patch.isPrimary = dto.isPrimary;
+    if (dto.nationalIdNumber !== undefined) patch.nationalIdNumber = dto.nationalIdNumber;
+    if (dto.passportNumber !== undefined) patch.passportNumber = dto.passportNumber ?? null;
+    if (dto.passportIssueDate !== undefined)
+      patch.passportIssueDate = dto.passportIssueDate ?? null;
+    if (dto.passportExpiryDate !== undefined)
+      patch.passportExpiryDate = dto.passportExpiryDate ?? null;
+    patch.passportStatus = newPassportStatus;
+
+    const [updated] = await this.db
+      .update(userNationalities)
+      .set(patch)
+      .where(and(eq(userNationalities.id, nationalityId), eq(userNationalities.userId, userId)))
+      .returning();
+
+    if (!updated) {
+      throw new NotFoundException('Nationality not found');
+    }
+    return this.mapNationalityResponse(updated);
+  }
+
+  async deleteNationality(userId: string, nationalityId: string): Promise<void> {
+    const all = await this.db.query.userNationalities.findMany({
+      where: eq(userNationalities.userId, userId),
+    });
+
+    const target = all.find((n) => n.id === nationalityId);
+    if (!target) {
+      throw new NotFoundException('Nationality not found');
+    }
+
+    if (target.isPrimary && all.length > 1) {
+      throw new ConflictException(
+        'Cannot delete the primary nationality. Re-assign primary first.',
+      );
+    }
+
+    await this.db
+      .delete(userNationalities)
+      .where(and(eq(userNationalities.id, nationalityId), eq(userNationalities.userId, userId)));
+  }
+
+  private computePassportStatus(expiryDate: string | undefined | null): PassportStatus {
+    if (!expiryDate) return PassportStatus.OMITTED;
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    const sixMonthsFromNow = new Date(today);
+    sixMonthsFromNow.setMonth(sixMonthsFromNow.getMonth() + 6);
+    const expiry = new Date(expiryDate);
+    if (expiry < today) return PassportStatus.EXPIRED;
+    if (expiry < sixMonthsFromNow) return PassportStatus.EXPIRING_SOON;
+    return PassportStatus.ACTIVE;
+  }
+
+  private mapNationalityResponse(
+    record: typeof userNationalities.$inferSelect,
+  ): NationalityResponseDto {
+    return {
+      id: record.id,
+      countryCode: record.countryCode,
+      isPrimary: record.isPrimary,
+      nationalIdNumber: record.nationalIdNumber ?? null,
+      passportNumber: record.passportNumber ?? null,
+      passportIssueDate: record.passportIssueDate ?? null,
+      passportExpiryDate: record.passportExpiryDate ?? null,
+      passportStatus: record.passportStatus as PassportStatus,
+    };
   }
 
   private async fetchContacts(


### PR DESCRIPTION
## Summary

Users need to manage multiple nationalities and travel documents (passport data). This PR exposes a full CRUD sub-resource over the `user_nationalities` table — a dedicated 1:many table with server-generated UUIDs, distinct from the JSONB-based emergency contacts. The `passportStatus` field (`OMITTED | ACTIVE | EXPIRING_SOON | EXPIRED`) is computed server-side at save time based on a 6-month threshold, not stored by the client.

## Changes

**New DTO (`nationality.dto.ts`)**
- `NationalityResponseDto` — full response shape including server-computed `passportStatus`
- `CreateNationalityDto` — requires `countryCode` (ISO 3166-1 alpha-2 uppercase) and `isPrimary`; passport group validation via `@ValidateIf`: all three fields (`passportNumber`, `passportIssueDate`, `passportExpiryDate`) or none
- `UpdateNationalityDto` — written manually (not `PartialType`) to preserve `@ValidateIf` semantics for the passport cross-field constraint

**Service (`users.service.ts`)**
- `getNationalities` — ordered by primary first, then country code; returns empty array (no 404) when user has none
- `addNationality` — 409 on duplicate `countryCode`; demotes current primary before insert when `isPrimary: true`; computes `passportStatus` immediately
- `updateNationality` — 400 on `isPrimary: false`; demotes other nationalities when `isPrimary: true`; recomputes `passportStatus` only when passport fields are in the dto
- `deleteNationality` — 409 when deleting the primary while other nationalities exist; allows deleting the only nationality even if primary
- `computePassportStatus` private helper — normalizes today to start-of-day; returns `EXPIRED`, `EXPIRING_SOON` (< 6 months), or `ACTIVE`

**Controller (`users.controller.ts`)**
- 4 endpoints with full Swagger (`@ApiOperation`, `@ApiResponse`, `@ApiParam`, `@ApiBody`) under `GET/POST/PATCH/DELETE /v1/users/me/nationalities[/:id]`

## Testing

- **`nationality.dto.spec.ts`** (22 tests): valid/invalid `countryCode` formats, missing `isPrimary`, passport cross-field consistency (each single field fails, two fields fail, all three pass, none passes), non-ISO date rejection, empty string rejection
- **`users.service.spec.ts`** (22 new tests): all four methods covered — empty array return, primary demotion, duplicate 409, `passportStatus` computation and preservation, `isPrimary: false` 400, primary-delete 409, single-nationality delete allowed, DB error propagation
- **`users.controller.spec.ts`** (8 new tests): delegation and error propagation for all 4 endpoints

Closes #109