### PR TITLE
test(users): fill coverage gaps in UsersModule — 99%+ lines

### DIFF
--- a/apps/api/src/modules/users/dto/public-profile-response.dto.spec.ts
+++ b/apps/api/src/modules/users/dto/public-profile-response.dto.spec.ts
@@ -1,0 +1,36 @@
+import { KeyStatsDto, PublicProfileResponseDto } from './public-profile-response.dto';
+
+describe('KeyStatsDto', () => {
+  it('can be instantiated and assigned values', () => {
+    const dto = new KeyStatsDto();
+    dto.tripsCompleted = 12;
+    dto.countriesVisited = 8;
+    dto.citiesVisited = 25;
+    dto.kmTraveled = 45000;
+    dto.tripsAsOrganizer = 3;
+
+    expect(dto.tripsCompleted).toBe(12);
+    expect(dto.countriesVisited).toBe(8);
+    expect(dto.citiesVisited).toBe(25);
+    expect(dto.kmTraveled).toBe(45000);
+    expect(dto.tripsAsOrganizer).toBe(3);
+  });
+});
+
+describe('PublicProfileResponseDto', () => {
+  it('can be instantiated and assigned values', () => {
+    const dto = new PublicProfileResponseDto();
+    dto.username = 'jsmith';
+    dto.displayName = 'John Smith';
+    dto.avatarUrl = null;
+    dto.bio = null;
+    dto.travelerScore = null;
+    dto.achievements = null;
+    dto.recognitions = null;
+    dto.keyStats = null;
+    dto.discoveryMap = null;
+
+    expect(dto.username).toBe('jsmith');
+    expect(dto.keyStats).toBeNull();
+  });
+});

--- a/apps/api/src/modules/users/users.service.spec.ts
+++ b/apps/api/src/modules/users/users.service.spec.ts
@@ -1170,6 +1170,14 @@ describe('UsersService', () => {
       expect(result.passportStatus).toBe(PassportStatus.EXPIRING_SOON);
     });
 
+    it('throws NotFoundException when the insert returns an empty array', async () => {
+      mockNationalitiesFindFirst.mockResolvedValue(undefined);
+      mockInsertReturning.mockResolvedValue([]);
+
+      const dto: CreateNationalityDto = { countryCode: 'CO', isPrimary: false };
+      await expect(service.addNationality('user-uuid', dto)).rejects.toThrow(NotFoundException);
+    });
+
     it('propagates unexpected database errors', async () => {
       mockNationalitiesFindFirst.mockResolvedValue(undefined);
       const dbError = new Error('insert failed');
@@ -1281,6 +1289,16 @@ describe('UsersService', () => {
 
       expect(mockSet).toHaveBeenCalledWith(
         expect.not.objectContaining({ passportStatus: expect.anything() }),
+      );
+    });
+
+    it('throws NotFoundException when the update returns an empty array', async () => {
+      mockNationalitiesFindFirst.mockResolvedValue(mockNationality);
+      mockReturning.mockResolvedValue([]);
+
+      const dto: UpdateNationalityDto = { nationalIdNumber: '12345' };
+      await expect(service.updateNationality('user-uuid', 'nat-uuid', dto)).rejects.toThrow(
+        NotFoundException,
       );
     });
 
@@ -1421,6 +1439,15 @@ describe('UsersService', () => {
       );
     });
 
+    it('throws NotFoundException when the update returns an empty array', async () => {
+      mockProfileFindFirst.mockResolvedValue({ ...mockHealthProfile, loyaltyPrograms: [] });
+      mockReturning.mockResolvedValue([]);
+
+      await expect(service.addLoyaltyProgram('user-uuid', newProgram)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
     it('throws NotFoundException when user profile does not exist', async () => {
       mockProfileFindFirst.mockResolvedValue(undefined);
 
@@ -1480,6 +1507,18 @@ describe('UsersService', () => {
 
       await expect(
         service.updateLoyaltyProgram('user-uuid', 'nonexistent-uuid', { memberId: 'X' }),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('throws NotFoundException when the update returns an empty array', async () => {
+      mockProfileFindFirst.mockResolvedValue({
+        ...mockHealthProfile,
+        loyaltyPrograms: [existingProgram],
+      });
+      mockReturning.mockResolvedValue([]);
+
+      await expect(
+        service.updateLoyaltyProgram('user-uuid', 'prog-uuid', { memberId: 'X' }),
       ).rejects.toThrow(NotFoundException);
     });
 


### PR DESCRIPTION
## Summary

The previous Epic #4 PRs shipped with 90%+ coverage on each merge but left a handful of defensive code paths untested: the four `NotFoundException` guards that fire when a database write returns an empty array (a race-condition safeguard), and the `KeyStatsDto` class that was only referenced as a type and therefore never instantiated. This PR closes those specific gaps, raising `users.service.ts` from 97.74% to 99.54% lines and `public-profile-response.dto.ts` to 100%.

## Changes

**New tests — defensive NotFoundException paths**
- `addNationality`: covers the guard at `if (!inserted)` when `db.insert().returning()` resolves to `[]`
- `updateNationality`: covers the guard at `if (!updated)` when `db.update().returning()` resolves to `[]`
- `addLoyaltyProgram`: covers the guard at `if (!saved)` when `db.update().returning()` resolves to `[]`
- `updateLoyaltyProgram`: covers the guard at `if (!saved)` when `db.update().returning()` resolves to `[]`

**New spec — `public-profile-response.dto.spec.ts`**
- Instantiates `KeyStatsDto` and `PublicProfileResponseDto`, covering the class constructor statements that Istanbul marks as uncovered when the class is only used as a type annotation

## Notes

Line 307 of `users.service.ts` (the `orderBy` callback inside `getNationalities`'s `findMany` config) remains the single uncovered line. This callback is never invoked when `findMany` is fully mocked at the method level — it is a known limitation of mock-based unit tests and cannot be covered without a real database connection. Overall coverage is 99.54% lines, well above the 90% threshold.

Closes #112