### PR TITLE
security(web): harden routing cookies with __Host- prefix and gate /api/cities

### DIFF
--- a/apps/web/src/app/api/cities/route.test.ts
+++ b/apps/web/src/app/api/cities/route.test.ts
@@ -1,0 +1,112 @@
+import { NextRequest } from 'next/server';
+import { GET } from './route';
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+function makeRequest(url: string, cookies: Record<string, string> = {}): NextRequest {
+  const req = new NextRequest(url);
+  vi.spyOn(req.cookies, 'has').mockImplementation((name) =>
+    Object.prototype.hasOwnProperty.call(cookies, name),
+  );
+  return req;
+}
+
+const AUTH_COOKIE = { '__Host-chamuco-auth': '1' };
+
+beforeEach(() => {
+  mockFetch.mockReset();
+  vi.stubEnv('GEONAMES_USERNAME', 'testuser');
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe('GET /api/cities', () => {
+  describe('auth gate', () => {
+    it('returns 401 when __Host-chamuco-auth cookie is absent', async () => {
+      const req = makeRequest('http://localhost/api/cities?q=Med&country=CO');
+      const res = await GET(req);
+      expect(res.status).toBe(401);
+      expect(await res.json()).toEqual({ geonames: [] });
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('proceeds when __Host-chamuco-auth cookie is present', async () => {
+      mockFetch.mockResolvedValue({ ok: true, json: () => Promise.resolve({ geonames: [] }) });
+      const req = makeRequest('http://localhost/api/cities?q=Med&country=CO', AUTH_COOKIE);
+      const res = await GET(req);
+      expect(res.status).toBe(200);
+    });
+  });
+
+  describe('input validation', () => {
+    it('returns empty when q is shorter than 2 chars', async () => {
+      const req = makeRequest('http://localhost/api/cities?q=M&country=CO', AUTH_COOKIE);
+      const res = await GET(req);
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ geonames: [] });
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('returns empty when country is absent', async () => {
+      const req = makeRequest('http://localhost/api/cities?q=Med', AUTH_COOKIE);
+      const res = await GET(req);
+      expect(await res.json()).toEqual({ geonames: [] });
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('GEONAMES_USERNAME env var', () => {
+    it('returns empty when GEONAMES_USERNAME is not set', async () => {
+      vi.stubEnv('GEONAMES_USERNAME', '');
+      const req = makeRequest('http://localhost/api/cities?q=Med&country=CO', AUTH_COOKIE);
+      const res = await GET(req);
+      expect(await res.json()).toEqual({ geonames: [] });
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('GeoNames API', () => {
+    it('forwards results from GeoNames', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            geonames: [{ name: 'Medellín', adminName1: 'Antioquia' }],
+          }),
+      });
+      const req = makeRequest('http://localhost/api/cities?q=Med&country=CO', AUTH_COOKIE);
+      const res = await GET(req);
+      expect(await res.json()).toEqual({
+        geonames: [{ name: 'Medellín', adminName1: 'Antioquia' }],
+      });
+    });
+
+    it('includes correct query params in the GeoNames request', async () => {
+      mockFetch.mockResolvedValue({ ok: true, json: () => Promise.resolve({ geonames: [] }) });
+      const req = makeRequest('http://localhost/api/cities?q=Med&country=CO', AUTH_COOKIE);
+      await GET(req);
+      const calledUrl = String(mockFetch.mock.calls[0]?.[0]);
+      expect(calledUrl).toContain('q=Med');
+      expect(calledUrl).toContain('country=CO');
+      expect(calledUrl).toContain('username=testuser');
+      expect(calledUrl).toContain('featureClass=P');
+    });
+
+    it('returns empty on non-ok GeoNames response', async () => {
+      mockFetch.mockResolvedValue({ ok: false });
+      const req = makeRequest('http://localhost/api/cities?q=Med&country=CO', AUTH_COOKIE);
+      const res = await GET(req);
+      expect(await res.json()).toEqual({ geonames: [] });
+    });
+
+    it('returns empty on network error', async () => {
+      mockFetch.mockRejectedValue(new Error('network error'));
+      const req = makeRequest('http://localhost/api/cities?q=Med&country=CO', AUTH_COOKIE);
+      const res = await GET(req);
+      expect(await res.json()).toEqual({ geonames: [] });
+    });
+  });
+});

--- a/apps/web/src/app/api/cities/route.ts
+++ b/apps/web/src/app/api/cities/route.ts
@@ -7,6 +7,12 @@ interface GeonamesResult {
 }
 
 export async function GET(req: NextRequest) {
+  // Require the routing cookie as a lightweight gate against unauthenticated bots.
+  // Not cryptographic auth — real auth happens via Firebase on the NestJS API.
+  if (!req.cookies.has('__Host-chamuco-auth')) {
+    return NextResponse.json({ geonames: [] }, { status: 401 });
+  }
+
   const { searchParams } = req.nextUrl;
   const q = searchParams.get('q') ?? '';
   const country = searchParams.get('country') ?? '';

--- a/apps/web/src/lib/auth-cookies.ts
+++ b/apps/web/src/lib/auth-cookies.ts
@@ -1,11 +1,13 @@
 /** Shared 30-day lifetime for both auth cookies (seconds) */
 const MAX_AGE = 2592000;
+// __Host- prefix enforces: Secure, path=/, no Domain — cookie is bound to
+// chamucotravel.com only and cannot be set or read by any subdomain (e.g. api.chamucotravel.com).
 const BASE = 'path=/; SameSite=Strict; Secure';
 
 /** Set when Firebase reports a signed-in user (AuthProvider.onAuthStateChanged). */
-export const COOKIE_CHAMUCO_AUTH_SET = `chamuco-auth=1; ${BASE}; Max-Age=${MAX_AGE}`;
-export const COOKIE_CHAMUCO_AUTH_CLEAR = `chamuco-auth=; ${BASE}; Max-Age=0`;
+export const COOKIE_CHAMUCO_AUTH_SET = `__Host-chamuco-auth=1; ${BASE}; Max-Age=${MAX_AGE}`;
+export const COOKIE_CHAMUCO_AUTH_CLEAR = `__Host-chamuco-auth=; ${BASE}; Max-Age=0`;
 
 /** Set once Chamuco registration is confirmed (sign-in 200 or onboarding register 201). */
-export const COOKIE_CHAMUCO_REGISTERED_SET = `chamuco-registered=1; ${BASE}; Max-Age=${MAX_AGE}`;
-export const COOKIE_CHAMUCO_REGISTERED_CLEAR = `chamuco-registered=; ${BASE}; Max-Age=0`;
+export const COOKIE_CHAMUCO_REGISTERED_SET = `__Host-chamuco-registered=1; ${BASE}; Max-Age=${MAX_AGE}`;
+export const COOKIE_CHAMUCO_REGISTERED_CLEAR = `__Host-chamuco-registered=; ${BASE}; Max-Age=0`;

--- a/apps/web/src/proxy.test.ts
+++ b/apps/web/src/proxy.test.ts
@@ -38,7 +38,7 @@ beforeEach(() => {
 });
 
 describe('proxy', () => {
-  describe('/sign-in — unauthenticated (no chamuco-auth cookie)', () => {
+  describe('/sign-in — unauthenticated (no __Host-chamuco-auth cookie)', () => {
     it('calls NextResponse.next() when no cookies are present', () => {
       const request = makeRequest('https://app.chamucotravel.com/sign-in');
       proxy(request);
@@ -53,10 +53,10 @@ describe('proxy', () => {
     });
   });
 
-  describe('/sign-in — auth but not registered (chamuco-auth only)', () => {
+  describe('/sign-in — auth but not registered (__Host-chamuco-auth only)', () => {
     it('redirects to /onboarding', () => {
       const request = makeRequest('https://app.chamucotravel.com/sign-in', {
-        'chamuco-auth': '1',
+        '__Host-chamuco-auth': '1',
       });
       proxy(request);
       expect(mockRedirect).toHaveBeenCalledOnce();
@@ -67,7 +67,7 @@ describe('proxy', () => {
 
     it('does not call NextResponse.next()', () => {
       const request = makeRequest('https://app.chamucotravel.com/sign-in', {
-        'chamuco-auth': '1',
+        '__Host-chamuco-auth': '1',
       });
       proxy(request);
       expect(mockNext).not.toHaveBeenCalled();
@@ -77,8 +77,8 @@ describe('proxy', () => {
   describe('/sign-in — fully authenticated (both cookies present)', () => {
     it('redirects to /', () => {
       const request = makeRequest('https://app.chamucotravel.com/sign-in', {
-        'chamuco-auth': '1',
-        'chamuco-registered': '1',
+        '__Host-chamuco-auth': '1',
+        '__Host-chamuco-registered': '1',
       });
       proxy(request);
       expect(mockRedirect).toHaveBeenCalledOnce();
@@ -89,8 +89,8 @@ describe('proxy', () => {
 
     it('does not call NextResponse.next() when fully authenticated', () => {
       const request = makeRequest('https://app.chamucotravel.com/sign-in', {
-        'chamuco-auth': '1',
-        'chamuco-registered': '1',
+        '__Host-chamuco-auth': '1',
+        '__Host-chamuco-registered': '1',
       });
       proxy(request);
       expect(mockNext).not.toHaveBeenCalled();
@@ -98,15 +98,15 @@ describe('proxy', () => {
 
     it('returns the result of NextResponse.redirect()', () => {
       const request = makeRequest('https://app.chamucotravel.com/sign-in', {
-        'chamuco-auth': '1',
-        'chamuco-registered': '1',
+        '__Host-chamuco-auth': '1',
+        '__Host-chamuco-registered': '1',
       });
       const result = proxy(request);
       expect(result).toEqual({ type: 'redirect' });
     });
   });
 
-  describe('/onboarding — unauthenticated (no chamuco-auth cookie)', () => {
+  describe('/onboarding — unauthenticated (no __Host-chamuco-auth cookie)', () => {
     it('redirects to /sign-in', () => {
       const request = makeRequest('https://app.chamucotravel.com/onboarding');
       proxy(request);
@@ -123,10 +123,10 @@ describe('proxy', () => {
     });
   });
 
-  describe('/onboarding — auth but not registered (chamuco-auth only)', () => {
+  describe('/onboarding — auth but not registered (__Host-chamuco-auth only)', () => {
     it('calls NextResponse.next()', () => {
       const request = makeRequest('https://app.chamucotravel.com/onboarding', {
-        'chamuco-auth': '1',
+        '__Host-chamuco-auth': '1',
       });
       proxy(request);
       expect(mockNext).toHaveBeenCalledOnce();
@@ -135,7 +135,7 @@ describe('proxy', () => {
 
     it('returns the result of NextResponse.next()', () => {
       const request = makeRequest('https://app.chamucotravel.com/onboarding', {
-        'chamuco-auth': '1',
+        '__Host-chamuco-auth': '1',
       });
       const result = proxy(request);
       expect(result).toEqual({ type: 'next' });
@@ -145,8 +145,8 @@ describe('proxy', () => {
   describe('/onboarding — fully authenticated (both cookies present)', () => {
     it('redirects to /', () => {
       const request = makeRequest('https://app.chamucotravel.com/onboarding', {
-        'chamuco-auth': '1',
-        'chamuco-registered': '1',
+        '__Host-chamuco-auth': '1',
+        '__Host-chamuco-registered': '1',
       });
       proxy(request);
       expect(mockRedirect).toHaveBeenCalledOnce();
@@ -166,7 +166,7 @@ describe('proxy', () => {
 
     it('calls NextResponse.next() when authenticated but not registered', () => {
       const request = makeRequest(`https://app.chamucotravel.com${route}`, {
-        'chamuco-auth': '1',
+        '__Host-chamuco-auth': '1',
       });
       proxy(request);
       expect(mockNext).toHaveBeenCalledOnce();
@@ -175,8 +175,8 @@ describe('proxy', () => {
 
     it('calls NextResponse.next() when fully authenticated', () => {
       const request = makeRequest(`https://app.chamucotravel.com${route}`, {
-        'chamuco-auth': '1',
-        'chamuco-registered': '1',
+        '__Host-chamuco-auth': '1',
+        '__Host-chamuco-registered': '1',
       });
       proxy(request);
       expect(mockNext).toHaveBeenCalledOnce();
@@ -196,7 +196,7 @@ describe('proxy', () => {
 
     it('redirects auth-but-unregistered request to /onboarding', () => {
       const request = makeRequest('https://app.chamucotravel.com/', {
-        'chamuco-auth': '1',
+        '__Host-chamuco-auth': '1',
       });
       proxy(request);
       expect(mockRedirect).toHaveBeenCalledOnce();
@@ -207,8 +207,8 @@ describe('proxy', () => {
 
     it('calls NextResponse.next() when both cookies are present', () => {
       const request = makeRequest('https://app.chamucotravel.com/', {
-        'chamuco-auth': '1',
-        'chamuco-registered': '1',
+        '__Host-chamuco-auth': '1',
+        '__Host-chamuco-registered': '1',
       });
       proxy(request);
       expect(mockNext).toHaveBeenCalledOnce();
@@ -225,7 +225,7 @@ describe('proxy', () => {
 
     it('redirects auth-but-unregistered /trips request to /onboarding', () => {
       const request = makeRequest('https://app.chamucotravel.com/trips', {
-        'chamuco-auth': '1',
+        '__Host-chamuco-auth': '1',
       });
       proxy(request);
       expect(mockRedirect).toHaveBeenCalledWith(
@@ -235,8 +235,8 @@ describe('proxy', () => {
 
     it('calls NextResponse.next() for /trips when fully authenticated', () => {
       const request = makeRequest('https://app.chamucotravel.com/trips', {
-        'chamuco-auth': '1',
-        'chamuco-registered': '1',
+        '__Host-chamuco-auth': '1',
+        '__Host-chamuco-registered': '1',
       });
       proxy(request);
       expect(mockNext).toHaveBeenCalledOnce();

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -5,16 +5,16 @@ import type { NextRequest } from 'next/server';
  * Route-level auth guards with three-state logic.
  *
  * Two cookies drive routing decisions:
- *   chamuco-auth        — set by AuthProvider when Firebase reports a signed-in user
- *   chamuco-registered  — set by sign-in and onboarding pages when Chamuco registration
- *                         is confirmed (GET /users/me → 200 or POST /auth/register → 201)
+ *   __Host-chamuco-auth        — set by AuthProvider when Firebase reports a signed-in user
+ *   __Host-chamuco-registered  — set by sign-in and onboarding pages when Chamuco registration
+ *                                is confirmed (GET /users/me → 200 or POST /auth/register → 201)
  *
  * Neither cookie is cryptographically verified here — they are used for routing only.
  * Real auth verification always happens server-side via Firebase Admin SDK.
  *
  * Three states:
- *   unauthenticated     — no chamuco-auth            → redirect to /sign-in
- *   auth + unregistered — chamuco-auth, no chamuco-registered → redirect to /onboarding
+ *   unauthenticated     — no __Host-chamuco-auth                         → redirect to /sign-in
+ *   auth + unregistered — __Host-chamuco-auth, no __Host-chamuco-registered → redirect to /onboarding
  *   auth + registered   — both cookies present       → allow through
  *
  * Route overrides:
@@ -23,8 +23,8 @@ import type { NextRequest } from 'next/server';
  *   all others  — unauthenticated → /sign-in; auth+unregistered → /onboarding; auth+registered → next()
  */
 export function proxy(request: NextRequest): NextResponse {
-  const isAuthenticated = request.cookies.has('chamuco-auth');
-  const isRegistered = request.cookies.has('chamuco-registered');
+  const isAuthenticated = request.cookies.has('__Host-chamuco-auth');
+  const isRegistered = request.cookies.has('__Host-chamuco-registered');
   const { pathname } = request.nextUrl;
 
   if (pathname === '/sign-in') {
@@ -50,8 +50,10 @@ export function proxy(request: NextRequest): NextResponse {
   return NextResponse.next();
 }
 
-// api/ is excluded from the matcher so Next.js Route Handlers (/api/*) are never
-// intercepted by this middleware — they handle their own auth at the handler level.
+// api/ is excluded from the matcher so cookie-redirect logic never intercepts
+// Next.js Route Handlers. Without this, /api/cities would receive a 307 redirect
+// instead of JSON when called from the onboarding page (chamuco-auth present,
+// chamuco-registered absent). Route Handlers must implement their own auth if needed.
 export const config = {
   matcher: ['/((?!_next/static|_next/image|favicon.ico|icons|api/|.*\\..*).*)'],
 };


### PR DESCRIPTION
## Summary

Hardens frontend cookie security and adds a lightweight auth gate to the GeoNames city search proxy, discovered during review of PR #161.

## Changes

**`__Host-` cookie prefix** (`auth-cookies.ts`, `proxy.ts`, `proxy.test.ts`)
- Renamed `chamuco-auth` → `__Host-chamuco-auth` and `chamuco-registered` → `__Host-chamuco-registered`
- The `__Host-` prefix is browser-enforced: requires `Secure`, `path=/`, and no `Domain` attribute — all already present
- Binds both cookies to `chamucotravel.com` only; no subdomain (`api.chamucotravel.com`) can set or receive them
- Local development unaffected: Chrome/Firefox treat `http://localhost` as a secure context

**`/api/cities` auth gate** (`route.ts`, `route.test.ts`)
- Added presence check for `__Host-chamuco-auth` before proxying to GeoNames
- Returns `401 { geonames: [] }` for requests without the cookie
- Deters opportunistic bots/scanners; not cryptographic auth
- Full rate limiter tracked in #164

**`proxy.ts` comment fix**
- Corrected misleading comment: the real reason `api/` is excluded from the middleware matcher is that cookie-redirect logic would return `307 HTML` instead of JSON to the onboarding page's city search calls

## Testing

- All existing proxy tests updated for new cookie names
- 9 new tests for `/api/cities` route handler covering: auth gate (401), input validation, missing env var, GeoNames forwarding, error handling

## Notes

- The `__Host-` prefix is additive security — behavior is identical for valid sessions
- Until #164 is implemented, authenticated users scripting requests to `/api/cities` can still exhaust GeoNames quota; the cookie check only blocks unauthenticated callers