### PR TITLE
fix(docker): build shared packages before next build

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -52,6 +52,10 @@ RUN pnpm install --frozen-lockfile --ignore-scripts
 COPY packages/shared-types ./packages/shared-types
 COPY packages/shared-utils ./packages/shared-utils
 
+# Build shared packages so their dist/ is available for type checking
+RUN pnpm --filter @chamuco/shared-types build
+RUN pnpm --filter @chamuco/shared-utils build
+
 # Copy web source code
 COPY apps/web ./apps/web
 


### PR DESCRIPTION
## Summary

- `@chamuco/shared-types` was never compiled before `next build` ran in the web Docker builder stage
- `dist/index.d.ts` didn't exist → TypeScript couldn't resolve the module → build failed
- The API Dockerfile already did this correctly on line 54; web Dockerfile was missing the equivalent step

## Changes

Adds two `RUN pnpm --filter` steps in `apps/web/Dockerfile` to compile `shared-types` and `shared-utils` before copying the web source and running `next build`.

## Testing

- Pre-commit typecheck passed locally
- Mirrors the already-working pattern in `apps/api/Dockerfile`

Closes #171