### PR TITLE
fix(validation): sanitize names/cities, reject impossible DOBs, fix SW redirect, loyalty UX

### DIFF
--- a/.claude/commands/gh.md
+++ b/.claude/commands/gh.md
@@ -184,6 +184,16 @@ gh release create <TAG> \
 
 ---
 
+## Multi-account gh CLI — credential errors
+
+Multiple GitHub accounts may be configured. On any auth or permission error:
+
+1. Run `gh auth status` to see which account is active.
+2. If the wrong account is active, switch with `gh auth switch --user <correct-user>` and retry.
+3. The correct account for this project is `manuelnt11`.
+
+---
+
 ## How to respond
 
 The user will describe what they want to do. Pick the right command(s) from above, fill in the known values (repo, owner, project number), and only ask for what's truly missing (e.g. an issue number, a title).

--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,6 @@ backups/
 # Misc
 .cache
 .parcel-cache
+
+# Playwright
+.playwright-mcp

--- a/apps/api/CLAUDE.md
+++ b/apps/api/CLAUDE.md
@@ -22,7 +22,15 @@ Then verify and update:
 
 No endpoint may be left without a summary (`@ApiOperation`), at least one `@ApiResponse`, and fully annotated DTO fields.
 
-### 2. Migration file on every schema change
+### 2. City fields — minimum length is 1
+
+All city fields across all DTOs (`homeCity`, `birthCity`, `departure_city`, etc.) use **minimum length = 1** and maximum length = 100. The floor is 1 (not 2) because single-character city names are valid (e.g. "Å" in Norway). When adding a new city field:
+
+- `@MinLength(1)` + `@MaxLength(100)` (or `@Length(1, 100)`)
+- `@Matches(/^[\p{L}\s]+$/u)` — Unicode letters and spaces only, no digits or symbols
+- `@Transform(({ value }) => sanitizeProperNoun(value))` — trims, collapses spaces, uppercases
+
+### 3. Migration file on every schema change
 
 When any Drizzle schema file (`*.schema.ts`) is modified — new table, new column, renamed column, dropped column, new index, constraint change — a migration file must be generated:
 

--- a/apps/api/src/common/transforms/proper-noun.transform.spec.ts
+++ b/apps/api/src/common/transforms/proper-noun.transform.spec.ts
@@ -1,0 +1,29 @@
+import { sanitizeProperNoun } from './proper-noun.transform';
+
+describe('sanitizeProperNoun', () => {
+  it('trims leading and trailing whitespace', () => {
+    expect(sanitizeProperNoun('  JUAN  ')).toBe('JUAN');
+  });
+
+  it('collapses repeated internal spaces', () => {
+    expect(sanitizeProperNoun('JUAN   CARLOS')).toBe('JUAN CARLOS');
+  });
+
+  it('converts to uppercase', () => {
+    expect(sanitizeProperNoun('juan carlos')).toBe('JUAN CARLOS');
+  });
+
+  it('handles accented characters', () => {
+    expect(sanitizeProperNoun('  garcía   lópez  ')).toBe('GARCÍA LÓPEZ');
+  });
+
+  it('trims and collapses in one pass', () => {
+    expect(sanitizeProperNoun('  MANUEL     JOANN  ')).toBe('MANUEL JOANN');
+  });
+
+  it('returns non-string values unchanged', () => {
+    expect(sanitizeProperNoun(null)).toBeNull();
+    expect(sanitizeProperNoun(undefined)).toBeUndefined();
+    expect(sanitizeProperNoun(42)).toBe(42);
+  });
+});

--- a/apps/api/src/common/transforms/proper-noun.transform.ts
+++ b/apps/api/src/common/transforms/proper-noun.transform.ts
@@ -1,0 +1,4 @@
+export function sanitizeProperNoun(value: unknown): unknown {
+  if (typeof value !== 'string') return value;
+  return value.trim().replace(/\s+/g, ' ').toUpperCase();
+}

--- a/apps/api/src/modules/auth/dto/register.dto.ts
+++ b/apps/api/src/modules/auth/dto/register.dto.ts
@@ -15,6 +15,7 @@ import { DateOfBirthDto } from '@/modules/users/dto/date-of-birth.dto';
 import { CreateNationalityDto } from '@/modules/users/dto/nationality.dto';
 import { EmergencyContactDto } from '@/modules/users/dto/emergency-contact.dto';
 import { IsMinimumAge } from '@/modules/users/dto/minimum-age.validator';
+import { sanitizeProperNoun } from '@/common/transforms/proper-noun.transform';
 
 export class RegisterDto {
   @ApiProperty({
@@ -55,10 +56,12 @@ export class RegisterDto {
   })
   @IsString()
   @Length(2, 100)
+  @Matches(/^[\p{L}\s]+$/u, {
+    message:
+      'firstName must contain only letters and spaces (accents allowed, no digits or symbols)',
+  })
   // Uppercase normalization: travel forms (visas, airlines, passports) require all-caps names.
-  @Transform(({ value }: { value: unknown }) =>
-    typeof value === 'string' ? value.trim().toUpperCase() : value,
-  )
+  @Transform(({ value }: { value: unknown }) => sanitizeProperNoun(value))
   firstName!: string;
 
   @ApiProperty({
@@ -70,10 +73,12 @@ export class RegisterDto {
   })
   @IsString()
   @Length(2, 100)
+  @Matches(/^[\p{L}\s]+$/u, {
+    message:
+      'lastName must contain only letters and spaces (accents allowed, no digits or symbols)',
+  })
   // Uppercase normalization: travel forms (visas, airlines, passports) require all-caps names.
-  @Transform(({ value }: { value: unknown }) =>
-    typeof value === 'string' ? value.trim().toUpperCase() : value,
-  )
+  @Transform(({ value }: { value: unknown }) => sanitizeProperNoun(value))
   lastName!: string;
 
   @ApiProperty({
@@ -102,9 +107,11 @@ export class RegisterDto {
   @IsOptional()
   @IsString()
   @Length(1, 100)
-  @Transform(({ value }: { value: unknown }) =>
-    typeof value === 'string' ? value.trim().toUpperCase() : value,
-  )
+  @Matches(/^[\p{L}\s]+$/u, {
+    message:
+      'homeCity must contain only letters and spaces (accents allowed, no digits or symbols)',
+  })
+  @Transform(({ value }: { value: unknown }) => sanitizeProperNoun(value))
   homeCity?: string;
 
   @ApiProperty({

--- a/apps/api/src/modules/auth/dto/register.dto.ts
+++ b/apps/api/src/modules/auth/dto/register.dto.ts
@@ -54,14 +54,14 @@ export class RegisterDto {
     minLength: 2,
     maxLength: 100,
   })
+  // Uppercase normalization: travel forms (visas, airlines, passports) require all-caps names.
+  @Transform(({ value }: { value: unknown }) => sanitizeProperNoun(value))
   @IsString()
   @Length(2, 100)
   @Matches(/^[\p{L}\s]+$/u, {
     message:
       'firstName must contain only letters and spaces (accents allowed, no digits or symbols)',
   })
-  // Uppercase normalization: travel forms (visas, airlines, passports) require all-caps names.
-  @Transform(({ value }: { value: unknown }) => sanitizeProperNoun(value))
   firstName!: string;
 
   @ApiProperty({
@@ -71,14 +71,14 @@ export class RegisterDto {
     minLength: 2,
     maxLength: 100,
   })
+  // Uppercase normalization: travel forms (visas, airlines, passports) require all-caps names.
+  @Transform(({ value }: { value: unknown }) => sanitizeProperNoun(value))
   @IsString()
   @Length(2, 100)
   @Matches(/^[\p{L}\s]+$/u, {
     message:
       'lastName must contain only letters and spaces (accents allowed, no digits or symbols)',
   })
-  // Uppercase normalization: travel forms (visas, airlines, passports) require all-caps names.
-  @Transform(({ value }: { value: unknown }) => sanitizeProperNoun(value))
   lastName!: string;
 
   @ApiProperty({
@@ -105,13 +105,13 @@ export class RegisterDto {
     description: 'Home city. Stored in uppercase to match travel document conventions.',
   })
   @IsOptional()
+  @Transform(({ value }: { value: unknown }) => sanitizeProperNoun(value))
   @IsString()
   @Length(1, 100)
   @Matches(/^[\p{L}\s]+$/u, {
     message:
       'homeCity must contain only letters and spaces (accents allowed, no digits or symbols)',
   })
-  @Transform(({ value }: { value: unknown }) => sanitizeProperNoun(value))
   homeCity?: string;
 
   @ApiProperty({

--- a/apps/api/src/modules/users/dto/calendar-date.validator.spec.ts
+++ b/apps/api/src/modules/users/dto/calendar-date.validator.spec.ts
@@ -1,5 +1,5 @@
 import { plainToInstance } from 'class-transformer';
-import { validate } from 'class-validator';
+import { validate, ValidationArguments } from 'class-validator';
 import { IsRealCalendarDayConstraint } from './calendar-date.validator';
 import { DateOfBirthDto } from './date-of-birth.dto';
 
@@ -9,8 +9,8 @@ async function validateDob(day: number, month: number, year: number): Promise<st
   return errors.flatMap((e) => Object.values(e.constraints ?? {}));
 }
 
-function makeArgs(object: object) {
-  return { object } as never;
+function makeArgs(object: object): ValidationArguments {
+  return { object, value: undefined, constraints: [], targetName: '', property: '' };
 }
 
 describe('IsRealCalendarDayConstraint — guard branches', () => {

--- a/apps/api/src/modules/users/dto/calendar-date.validator.spec.ts
+++ b/apps/api/src/modules/users/dto/calendar-date.validator.spec.ts
@@ -1,0 +1,76 @@
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { IsRealCalendarDayConstraint } from './calendar-date.validator';
+import { DateOfBirthDto } from './date-of-birth.dto';
+
+async function validateDob(day: number, month: number, year: number): Promise<string[]> {
+  const dto = plainToInstance(DateOfBirthDto, { day, month, year, yearVisible: true });
+  const errors = await validate(dto);
+  return errors.flatMap((e) => Object.values(e.constraints ?? {}));
+}
+
+function makeArgs(object: object) {
+  return { object } as never;
+}
+
+describe('IsRealCalendarDayConstraint — guard branches', () => {
+  const constraint = new IsRealCalendarDayConstraint();
+
+  it('returns true for non-number day', () => {
+    expect(constraint.validate('foo', makeArgs({ month: 2, year: 2000 }))).toBe(true);
+  });
+
+  it('returns true when month is missing', () => {
+    expect(constraint.validate(15, makeArgs({ year: 2000 }))).toBe(true);
+  });
+
+  it('returns true when year is missing', () => {
+    expect(constraint.validate(15, makeArgs({ month: 6 }))).toBe(true);
+  });
+
+  it('returns true when month is out of range (>12)', () => {
+    expect(constraint.validate(15, makeArgs({ month: 13, year: 2000 }))).toBe(true);
+  });
+
+  it('returns true when year is before 1900', () => {
+    expect(constraint.validate(15, makeArgs({ month: 6, year: 1899 }))).toBe(true);
+  });
+
+  it('has a default error message mentioning calendar', () => {
+    expect(constraint.defaultMessage()).toContain('calendar');
+  });
+});
+
+describe('DateOfBirthDto — calendar date validation', () => {
+  it('accepts a valid date (Feb 28)', async () => {
+    expect(await validateDob(28, 2, 1990)).toHaveLength(0);
+  });
+
+  it('accepts Feb 29 on a leap year', async () => {
+    expect(await validateDob(29, 2, 2000)).toHaveLength(0);
+  });
+
+  it('rejects Feb 29 on a non-leap year', async () => {
+    const errors = await validateDob(29, 2, 1990);
+    expect(errors.some((e) => e.includes('calendar'))).toBe(true);
+  });
+
+  it('rejects Feb 30', async () => {
+    const errors = await validateDob(30, 2, 2000);
+    expect(errors.some((e) => e.includes('calendar'))).toBe(true);
+  });
+
+  it('rejects Feb 31', async () => {
+    const errors = await validateDob(31, 2, 2000);
+    expect(errors.some((e) => e.includes('calendar'))).toBe(true);
+  });
+
+  it('rejects April 31 (month with 30 days)', async () => {
+    const errors = await validateDob(31, 4, 2000);
+    expect(errors.some((e) => e.includes('calendar'))).toBe(true);
+  });
+
+  it('accepts December 31', async () => {
+    expect(await validateDob(31, 12, 1990)).toHaveLength(0);
+  });
+});

--- a/apps/api/src/modules/users/dto/calendar-date.validator.ts
+++ b/apps/api/src/modules/users/dto/calendar-date.validator.ts
@@ -1,0 +1,42 @@
+import {
+  registerDecorator,
+  ValidationArguments,
+  ValidationOptions,
+  ValidatorConstraint,
+  ValidatorConstraintInterface,
+} from 'class-validator';
+
+interface DateFields {
+  month?: number;
+  year?: number;
+}
+
+@ValidatorConstraint({ name: 'isRealCalendarDay', async: false })
+export class IsRealCalendarDayConstraint implements ValidatorConstraintInterface {
+  validate(day: unknown, args: ValidationArguments): boolean {
+    if (typeof day !== 'number') return true;
+    const { month, year } = args.object as DateFields;
+    if (!month || !year) return true;
+    // Skip when month/year are out of their valid ranges — those validators handle it.
+    if (month < 1 || month > 12) return true;
+    if (year < 1900) return true;
+    const d = new Date(year, month - 1, day);
+    return d.getFullYear() === year && d.getMonth() === month - 1 && d.getDate() === day;
+  }
+
+  defaultMessage(): string {
+    return 'date does not exist in the calendar (e.g. February 31 is invalid)';
+  }
+}
+
+export function IsRealCalendarDay(validationOptions?: ValidationOptions): PropertyDecorator {
+  return function (object: object, propertyName: string | symbol) {
+    registerDecorator({
+      target: object.constructor,
+      propertyName: propertyName as string,
+      options: validationOptions,
+      constraints: [],
+      validator: IsRealCalendarDayConstraint,
+    });
+  };
+}

--- a/apps/api/src/modules/users/dto/date-of-birth.dto.ts
+++ b/apps/api/src/modules/users/dto/date-of-birth.dto.ts
@@ -1,11 +1,13 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsBoolean, IsInt, Max, Min } from 'class-validator';
+import { IsRealCalendarDay } from './calendar-date.validator';
 
 export class DateOfBirthDto {
   @ApiProperty({ example: 15, minimum: 1, maximum: 31 })
   @IsInt()
   @Min(1)
   @Max(31)
+  @IsRealCalendarDay()
   day!: number;
 
   @ApiProperty({ example: 6, minimum: 1, maximum: 12 })

--- a/apps/api/src/modules/users/dto/update-user-profile.dto.spec.ts
+++ b/apps/api/src/modules/users/dto/update-user-profile.dto.spec.ts
@@ -59,9 +59,9 @@ describe('UpdateUserProfileDto', () => {
       expect(errors.some((e) => e.property === 'firstName')).toBe(true);
     });
 
-    it('trims firstName before validating', async () => {
+    it('trims and uppercases firstName before validating', async () => {
       const dto = plainToInstance(UpdateUserProfileDto, { firstName: '  John  ' });
-      expect(dto.firstName).toBe('John');
+      expect(dto.firstName).toBe('JOHN');
       const errors = await validate(dto);
       expect(errors).toHaveLength(0);
     });
@@ -120,6 +120,42 @@ describe('UpdateUserProfileDto', () => {
       expect(errors.some((e) => e.property === 'lastName')).toBe(true);
       expect(errors.some((e) => e.property === 'phoneCountryCode')).toBe(true);
       expect(errors.some((e) => e.property === 'phoneLocalNumber')).toBe(true);
+    });
+  });
+
+  describe('city field validation (birthCity / homeCity)', () => {
+    it('accepts valid city names with accents', async () => {
+      const dto = plainToInstance(UpdateUserProfileDto, {
+        birthCity: 'bogotá',
+        homeCity: 'medellín',
+      });
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+      expect(dto.birthCity).toBe('BOGOTÁ');
+      expect(dto.homeCity).toBe('MEDELLÍN');
+    });
+
+    it('collapses repeated spaces in city names', async () => {
+      const dto = plainToInstance(UpdateUserProfileDto, { homeCity: '  SAN   JOSE  ' });
+      expect(dto.homeCity).toBe('SAN JOSE');
+    });
+
+    it('rejects city names with digits', async () => {
+      const dto = plainToInstance(UpdateUserProfileDto, { birthCity: 'CIUDAD123' });
+      const errors = await validate(dto);
+      expect(errors.some((e) => e.property === 'birthCity')).toBe(true);
+    });
+
+    it('rejects city names with symbols', async () => {
+      const dto = plainToInstance(UpdateUserProfileDto, { homeCity: 'SAN-JOSE' });
+      const errors = await validate(dto);
+      expect(errors.some((e) => e.property === 'homeCity')).toBe(true);
+    });
+
+    it('accepts null to clear city fields', async () => {
+      const dto = plainToInstance(UpdateUserProfileDto, { birthCity: null, homeCity: null });
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
     });
   });
 

--- a/apps/api/src/modules/users/dto/update-user-profile.dto.spec.ts
+++ b/apps/api/src/modules/users/dto/update-user-profile.dto.spec.ts
@@ -152,6 +152,13 @@ describe('UpdateUserProfileDto', () => {
       expect(errors.some((e) => e.property === 'homeCity')).toBe(true);
     });
 
+    it('accepts single-character city name (e.g. Norwegian city "Å")', async () => {
+      const dto = plainToInstance(UpdateUserProfileDto, { homeCity: 'Å' });
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+      expect(dto.homeCity).toBe('Å');
+    });
+
     it('accepts null to clear city fields', async () => {
       const dto = plainToInstance(UpdateUserProfileDto, { birthCity: null, homeCity: null });
       const errors = await validate(dto);

--- a/apps/api/src/modules/users/dto/update-user-profile.dto.ts
+++ b/apps/api/src/modules/users/dto/update-user-profile.dto.ts
@@ -69,11 +69,13 @@ export class UpdateUserProfileDto {
     description: 'City of birth. Uppercase only, accents allowed, no digits or symbols.',
     nullable: true,
     required: false,
+    minLength: 1,
     maxLength: 100,
   })
   @IsOptional()
   @Transform(({ value }) => sanitizeProperNoun(value))
   @IsString()
+  @MinLength(1)
   @MaxLength(100)
   @Matches(/^[\p{L}\s]+$/u, {
     message:
@@ -95,11 +97,13 @@ export class UpdateUserProfileDto {
     description: 'Home city. Uppercase only, accents allowed, no digits or symbols.',
     nullable: true,
     required: false,
+    minLength: 1,
     maxLength: 100,
   })
   @IsOptional()
   @Transform(({ value }) => sanitizeProperNoun(value))
   @IsString()
+  @MinLength(1)
   @MaxLength(100)
   @Matches(/^[\p{L}\s]+$/u, {
     message:

--- a/apps/api/src/modules/users/dto/update-user-profile.dto.ts
+++ b/apps/api/src/modules/users/dto/update-user-profile.dto.ts
@@ -9,22 +9,43 @@ import {
   ValidateNested,
 } from 'class-validator';
 import { DateOfBirthDto } from './date-of-birth.dto';
+import { sanitizeProperNoun } from '@/common/transforms/proper-noun.transform';
 
 export class UpdateUserProfileDto {
-  @ApiProperty({ example: 'John', minLength: 2, maxLength: 100, required: false })
+  @ApiProperty({
+    example: 'JUAN CARLOS',
+    description: 'Given name(s). Uppercase only, accents allowed, no digits or symbols.',
+    minLength: 2,
+    maxLength: 100,
+    required: false,
+  })
   @IsOptional()
-  @Transform(({ value }) => (typeof value === 'string' ? value.trim() : value))
+  @Transform(({ value }) => sanitizeProperNoun(value))
   @IsString()
   @MinLength(2)
   @MaxLength(100)
+  @Matches(/^[\p{L}\s]+$/u, {
+    message:
+      'firstName must contain only letters and spaces (accents allowed, no digits or symbols)',
+  })
   firstName?: string;
 
-  @ApiProperty({ example: 'Doe', minLength: 2, maxLength: 100, required: false })
+  @ApiProperty({
+    example: 'GARCÍA LÓPEZ',
+    description: 'Surname(s). Uppercase only, accents allowed, no digits or symbols.',
+    minLength: 2,
+    maxLength: 100,
+    required: false,
+  })
   @IsOptional()
-  @Transform(({ value }) => (typeof value === 'string' ? value.trim() : value))
+  @Transform(({ value }) => sanitizeProperNoun(value))
   @IsString()
   @MinLength(2)
   @MaxLength(100)
+  @Matches(/^[\p{L}\s]+$/u, {
+    message:
+      'lastName must contain only letters and spaces (accents allowed, no digits or symbols)',
+  })
   lastName?: string;
 
   @ApiProperty({ type: DateOfBirthDto, required: false })
@@ -43,9 +64,21 @@ export class UpdateUserProfileDto {
   @Matches(/^[A-Z]{2}$/, { message: 'birthCountry must be a 2-letter uppercase ISO country code' })
   birthCountry?: string | null;
 
-  @ApiProperty({ example: 'Bogotá', nullable: true, required: false })
+  @ApiProperty({
+    example: 'BOGOTÁ',
+    description: 'City of birth. Uppercase only, accents allowed, no digits or symbols.',
+    nullable: true,
+    required: false,
+    maxLength: 100,
+  })
   @IsOptional()
+  @Transform(({ value }) => sanitizeProperNoun(value))
   @IsString()
+  @MaxLength(100)
+  @Matches(/^[\p{L}\s]+$/u, {
+    message:
+      'birthCity must contain only letters and spaces (accents allowed, no digits or symbols)',
+  })
   birthCity?: string | null;
 
   @ApiProperty({
@@ -57,9 +90,21 @@ export class UpdateUserProfileDto {
   @Matches(/^[A-Z]{2}$/, { message: 'homeCountry must be a 2-letter uppercase ISO country code' })
   homeCountry?: string;
 
-  @ApiProperty({ example: 'Medellín', nullable: true, required: false })
+  @ApiProperty({
+    example: 'MEDELLÍN',
+    description: 'Home city. Uppercase only, accents allowed, no digits or symbols.',
+    nullable: true,
+    required: false,
+    maxLength: 100,
+  })
   @IsOptional()
+  @Transform(({ value }) => sanitizeProperNoun(value))
   @IsString()
+  @MaxLength(100)
+  @Matches(/^[\p{L}\s]+$/u, {
+    message:
+      'homeCity must contain only letters and spaces (accents allowed, no digits or symbols)',
+  })
   homeCity?: string | null;
 
   @ApiProperty({

--- a/apps/api/test/auth.e2e-spec.ts
+++ b/apps/api/test/auth.e2e-spec.ts
@@ -51,7 +51,7 @@ const VALID_DECODED_TOKEN = {
 const validRegisterPayload = {
   username: 'E2E_Test_User',
   displayName: 'E2E Test User',
-  firstName: 'E2E',
+  firstName: 'JUAN',
   lastName: 'TEST',
   dateOfBirth: { day: 15, month: 6, year: 2000, yearVisible: false },
   homeCountry: 'CO',

--- a/apps/api/test/auth.e2e-spec.ts
+++ b/apps/api/test/auth.e2e-spec.ts
@@ -190,6 +190,29 @@ describe('Auth endpoints (integration)', () => {
         .expect(400);
     });
 
+    it('returns 400 when firstName contains digits', async () => {
+      mockVerifyIdToken.mockResolvedValue(VALID_DECODED_TOKEN);
+
+      await request(app.getHttpServer())
+        .post('/v1/auth/register')
+        .set('Authorization', VALID_GOOGLE_TOKEN)
+        .send({ ...validRegisterPayload, firstName: 'JUAN123' })
+        .expect(400);
+    });
+
+    it('returns 400 when dateOfBirth is a calendar-impossible date (Feb 31)', async () => {
+      mockVerifyIdToken.mockResolvedValue(VALID_DECODED_TOKEN);
+
+      await request(app.getHttpServer())
+        .post('/v1/auth/register')
+        .set('Authorization', VALID_GOOGLE_TOKEN)
+        .send({
+          ...validRegisterPayload,
+          dateOfBirth: { day: 31, month: 2, year: 2000, yearVisible: false },
+        })
+        .expect(400);
+    });
+
     it('returns 400 when no primary nationality is provided', async () => {
       mockVerifyIdToken.mockResolvedValue({
         ...VALID_DECODED_TOKEN,

--- a/apps/web/public/sw.js
+++ b/apps/web/public/sw.js
@@ -1,8 +1,8 @@
 // Chamuco Travel Service Worker
-// Version: 2.0.0
+// Version: 2.1.0
 
-const CACHE_NAME = 'chamuco-v2';
-const RUNTIME_CACHE = 'chamuco-runtime-v2';
+const CACHE_NAME = 'chamuco-v3';
+const RUNTIME_CACHE = 'chamuco-runtime-v3';
 
 // Static assets to cache on install
 const PRECACHE_URLS = [
@@ -68,22 +68,23 @@ self.addEventListener('fetch', (event) => {
     return;
   }
 
-  // Navigation requests (HTML pages) — stale-while-revalidate
-  // Serve from cache immediately, update cache in background for next visit
+  // Navigation requests (HTML pages) — network-first.
+  // Always hit the network so server-side auth redirects (307) are respected.
+  // Fall back to cache only when offline.
   if (event.request.mode === 'navigate') {
     event.respondWith(
-      caches.match(event.request).then((cachedResponse) => {
-        const networkFetch = fetch(event.request)
-          .then((response) => {
-            if (response && response.status === 200) {
-              caches.open(CACHE_NAME).then((cache) => cache.put(event.request, response.clone()));
-            }
-            return response;
-          })
-          .catch(() => cachedResponse || caches.match('/offline'));
-
-        return cachedResponse || networkFetch;
-      }),
+      fetch(event.request)
+        .then((response) => {
+          if (response && response.status === 200) {
+            caches.open(CACHE_NAME).then((cache) => cache.put(event.request, response.clone()));
+          }
+          return response;
+        })
+        .catch(() =>
+          caches
+            .match(event.request)
+            .then((cached) => cached || caches.match('/offline')),
+        ),
     );
     return;
   }

--- a/apps/web/src/components/profile/LoyaltyProgramsSection.tsx
+++ b/apps/web/src/components/profile/LoyaltyProgramsSection.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, type FormEvent } from 'react';
+import { useEffect, useState, type FormEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { Button } from '@/components/ui/button';
@@ -108,6 +108,13 @@ export function LoyaltyProgramsSection({ programs, onRefresh }: LoyaltyProgramsS
   const [editForm, setEditForm] = useState<FormState>(EMPTY_FORM);
   const [isSaving, setIsSaving] = useState(false);
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!confirmDeleteId) return;
+    const reset = () => setConfirmDeleteId(null);
+    document.addEventListener('mousedown', reset);
+    return () => document.removeEventListener('mousedown', reset);
+  }, [confirmDeleteId]);
 
   function startEdit(program: LoyaltyProgramDto) {
     setEditingId(program.id);
@@ -247,6 +254,9 @@ export function LoyaltyProgramsSection({ programs, onRefresh }: LoyaltyProgramsS
                   type="button"
                   size="sm"
                   variant={confirmDeleteId === program.id ? 'destructive' : 'outline'}
+                  onMouseDown={(e) => {
+                    if (confirmDeleteId === program.id) e.stopPropagation();
+                  }}
                   onClick={() => handleDelete(program.id)}
                   disabled={isSaving}
                 >


### PR DESCRIPTION
## Summary

Several validation gaps and UX bugs were discovered in onboarding and profile forms. The backend was not enforcing the same sanitization rules the frontend applies (uppercase, trim, collapse spaces), was accepting calendar-impossible dates like February 31, and the service worker was masking server-side auth redirects by serving stale cached responses.

## Changes

**Backend — name/city sanitization**
- Add `sanitizeProperNoun()` helper (trim + collapse repeated spaces + uppercase) in `common/transforms`
- Apply to `firstName`, `lastName`, `homeCity` in `RegisterDto` and `UpdateUserProfileDto`
- Add `@Matches(/^[\p{L}\s]+$/u)` on all name and city fields — rejects digits and symbols, allows accents

**Backend — impossible date rejection**
- Add `IsRealCalendarDayConstraint` custom validator: reconstructs `new Date(year, month-1, day)` and compares components back against inputs; JS `Date` silently overflows (Feb 31 → Mar 3), so overflow detection requires this round-trip comparison
- Apply `@IsRealCalendarDay()` to `DateOfBirthDto.day`

**Frontend — service worker redirect fix**
- Change navigation fetch handler from stale-while-revalidate to network-first so server 307 redirects (auth middleware) are respected instead of being masked by a cached 200 response
- Bump cache version to `chamuco-v3` to force reinstall on existing clients

**Frontend — loyalty programs UX**
- Reset delete confirmation state on outside click via `mousedown` listener; `stopPropagation` on the confirm button prevents the button's own `mousedown` from triggering the reset

## Testing

- Unit tests added for `sanitizeProperNoun`: trim, space collapse, uppercase, accents, non-string passthrough
- Unit tests added for `IsRealCalendarDayConstraint`: valid dates, leap years, Feb 29 on non-leap year, Feb 30/31, Apr 31, guard branches (out-of-range month, pre-1900 year, missing siblings)
- All 470 backend + 517 frontend tests pass; coverage remains above 90% thresholds

## Notes

`departure_city`, `return_city`, and `trip_destinations.city` (trips module) are out of scope — trips module not yet implemented.

Closes #170