### PR TITLE
feat(profile): add Personal Details tab and harden onboarding step 2 validation

### DIFF
--- a/apps/web/src/app/onboarding/page.test.tsx
+++ b/apps/web/src/app/onboarding/page.test.tsx
@@ -465,6 +465,7 @@ describe('OnboardingPage', () => {
     async function renderFormWithAvailableUsername(
       authOverrides: Partial<AuthContextValue> = {},
       username = 'newuser',
+      step2: { firstName?: string; lastName?: string } = {},
     ) {
       vi.mocked(useAuth).mockReturnValue(makeAuth(authOverrides));
       mockGetByUrl(); // /username-available → { available: true }
@@ -496,8 +497,8 @@ describe('OnboardingPage', () => {
       await waitFor(() => expect(screen.getByTestId('firstname-input')).toBeInTheDocument());
 
       // Fill required step 2 fields
-      await user.type(screen.getByTestId('firstname-input'), 'JOHN');
-      await user.type(screen.getByTestId('lastname-input'), 'DOE');
+      await user.type(screen.getByTestId('firstname-input'), step2.firstName ?? 'JOHN');
+      await user.type(screen.getByTestId('lastname-input'), step2.lastName ?? 'DOE');
       await user.type(screen.getByTestId('dob-day-input'), '15');
       await user.type(screen.getByTestId('dob-month-input'), '6');
       await user.type(screen.getByTestId('dob-year-input'), '1990');
@@ -559,6 +560,96 @@ describe('OnboardingPage', () => {
       expect(screen.queryByTestId('firstname-input')).not.toBeInTheDocument();
     });
 
+    it('shows firstName, lastName, and DOB errors simultaneously when all step 2 fields are empty', async () => {
+      vi.mocked(useAuth).mockReturnValue(
+        makeAuth({ currentUser: makeUser({ displayName: 'Test User' }) }),
+      );
+      mockGetByUrl();
+      const user = userEvent.setup({
+        advanceTimers: vi.advanceTimersByTime.bind(vi),
+        delay: null,
+      });
+      render(<OnboardingPage />);
+      await waitFor(() => expect(screen.getByTestId('username-input')).toBeInTheDocument());
+      await user.type(screen.getByTestId('username-input'), 'newuser');
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(300);
+      });
+      await waitFor(() =>
+        expect(screen.getByText('onboarding.username.available')).toBeInTheDocument(),
+      );
+      await user.click(screen.getByTestId('next-btn'));
+      await waitFor(() => expect(screen.getByTestId('firstname-input')).toBeInTheDocument());
+      // Click Next without filling any fields — all three groups should be invalid at once
+      await user.click(screen.getByTestId('next-btn'));
+      expect(screen.getByTestId('firstname-input')).toHaveAttribute('aria-invalid', 'true');
+      expect(screen.getByTestId('lastname-input')).toHaveAttribute('aria-invalid', 'true');
+      expect(screen.getByTestId('dob-day-input')).toHaveAttribute('aria-invalid', 'true');
+      expect(screen.queryByTestId('terms-checkbox')).not.toBeInTheDocument();
+    });
+
+    it('blocks navigation and shows invalidName error when firstName has numbers', async () => {
+      vi.mocked(useAuth).mockReturnValue(
+        makeAuth({ currentUser: makeUser({ displayName: 'Test User' }) }),
+      );
+      mockGetByUrl();
+      const user = userEvent.setup({
+        advanceTimers: vi.advanceTimersByTime.bind(vi),
+        delay: null,
+      });
+      render(<OnboardingPage />);
+      await waitFor(() => expect(screen.getByTestId('username-input')).toBeInTheDocument());
+      await user.type(screen.getByTestId('username-input'), 'newuser');
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(300);
+      });
+      await waitFor(() =>
+        expect(screen.getByText('onboarding.username.available')).toBeInTheDocument(),
+      );
+      await user.click(screen.getByTestId('next-btn'));
+      await waitFor(() => expect(screen.getByTestId('firstname-input')).toBeInTheDocument());
+      await user.type(screen.getByTestId('firstname-input'), 'JOHN123');
+      await user.type(screen.getByTestId('lastname-input'), 'DOE');
+      await user.type(screen.getByTestId('dob-day-input'), '15');
+      await user.type(screen.getByTestId('dob-month-input'), '6');
+      await user.type(screen.getByTestId('dob-year-input'), '1990');
+      await user.type(screen.getByTestId('phone-number-input'), '3001234567');
+      await user.click(screen.getByTestId('next-btn'));
+      expect(screen.getByText('onboarding.validation.invalidName')).toBeInTheDocument();
+      expect(screen.queryByTestId('terms-checkbox')).not.toBeInTheDocument();
+    });
+
+    it('blocks navigation and shows invalidName error when lastName has special characters', async () => {
+      vi.mocked(useAuth).mockReturnValue(
+        makeAuth({ currentUser: makeUser({ displayName: 'Test User' }) }),
+      );
+      mockGetByUrl();
+      const user = userEvent.setup({
+        advanceTimers: vi.advanceTimersByTime.bind(vi),
+        delay: null,
+      });
+      render(<OnboardingPage />);
+      await waitFor(() => expect(screen.getByTestId('username-input')).toBeInTheDocument());
+      await user.type(screen.getByTestId('username-input'), 'newuser');
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(300);
+      });
+      await waitFor(() =>
+        expect(screen.getByText('onboarding.username.available')).toBeInTheDocument(),
+      );
+      await user.click(screen.getByTestId('next-btn'));
+      await waitFor(() => expect(screen.getByTestId('firstname-input')).toBeInTheDocument());
+      await user.type(screen.getByTestId('firstname-input'), 'JOHN');
+      await user.type(screen.getByTestId('lastname-input'), 'DOE@#$');
+      await user.type(screen.getByTestId('dob-day-input'), '15');
+      await user.type(screen.getByTestId('dob-month-input'), '6');
+      await user.type(screen.getByTestId('dob-year-input'), '1990');
+      await user.type(screen.getByTestId('phone-number-input'), '3001234567');
+      await user.click(screen.getByTestId('next-btn'));
+      expect(screen.getByText('onboarding.validation.invalidName')).toBeInTheDocument();
+      expect(screen.queryByTestId('terms-checkbox')).not.toBeInTheDocument();
+    });
+
     it('submit button is disabled while isSubmitting', async () => {
       mocks.mockApiPost.mockReturnValue(new Promise(() => undefined)); // never resolves
       const user = await renderFormWithAvailableUsername({
@@ -592,6 +683,22 @@ describe('OnboardingPage', () => {
           phoneCountryCode: '+57',
           phoneLocalNumber: '3001234567',
         }),
+      );
+    });
+
+    it('normalizes whitespace in firstName and lastName before sending to API', async () => {
+      mocks.mockApiPost.mockResolvedValue({ status: 201 });
+      const user = await renderFormWithAvailableUsername(
+        { currentUser: makeUser({ displayName: 'Test User' }) },
+        'newuser',
+        { firstName: ' JUAN  CARLOS ', lastName: ' GARCIA  LOPEZ ' },
+      );
+      await user.click(screen.getByTestId('submit-btn'));
+      await waitFor(() =>
+        expect(mocks.mockApiPost).toHaveBeenCalledWith(
+          '/v1/auth/register',
+          expect.objectContaining({ firstName: 'JUAN CARLOS', lastName: 'GARCIA LOPEZ' }),
+        ),
       );
     });
 

--- a/apps/web/src/app/onboarding/page.tsx
+++ b/apps/web/src/app/onboarding/page.tsx
@@ -76,6 +76,11 @@ function normalizeName(name: string): string {
   return name.trim().replace(/\s+/g, ' ');
 }
 
+function isValidCalendarDay(day: number, month: number, year: number): boolean {
+  const date = new Date(year, month - 1, day);
+  return date.getFullYear() === year && date.getMonth() === month - 1 && date.getDate() === day;
+}
+
 function validateStep2(
   firstName: string,
   lastName: string,
@@ -97,7 +102,8 @@ function validateStep2(
   const y = parseInt(dobYear, 10);
   if (!dobDay || !dobMonth || !dobYear || isNaN(d) || isNaN(m) || isNaN(y))
     errors.push('dobRequired');
-  else if (d < 1 || d > 31 || m < 1 || m > 12 || y < 1900) errors.push('dobInvalid');
+  else if (d < 1 || d > 31 || m < 1 || m > 12 || y < 1900 || !isValidCalendarDay(d, m, y))
+    errors.push('dobInvalid');
   else if (computeAge(d, m, y) < 16) errors.push('minAge');
   if (!isValidPhoneNumber(phoneNumber, phoneCountry as CountryCode)) errors.push('phoneNumber');
   return errors;

--- a/apps/web/src/app/onboarding/page.tsx
+++ b/apps/web/src/app/onboarding/page.tsx
@@ -63,10 +63,17 @@ type UsernameStatus = 'idle' | 'checking' | 'available' | 'taken' | 'invalid';
 // Step validation helpers
 // ---------------------------------------------------------------------------
 
-function validateStep1(usernameStatus: UsernameStatus, displayName: string): string | null {
-  if (usernameStatus !== 'available') return 'username';
-  if (!displayName.trim()) return 'displayName';
-  return null;
+function validateStep1(usernameStatus: UsernameStatus, displayName: string): string[] {
+  const errors: string[] = [];
+  if (usernameStatus !== 'available') errors.push('username');
+  if (!displayName.trim()) errors.push('displayName');
+  return errors;
+}
+
+const NAME_REGEX = /^[\p{L}\s]+$/u;
+
+function normalizeName(name: string): string {
+  return name.trim().replace(/\s+/g, ' ');
 }
 
 function validateStep2(
@@ -77,23 +84,30 @@ function validateStep2(
   dobYear: string,
   phoneCountry: string,
   phoneNumber: string,
-): string | null {
-  if (!firstName.trim() || firstName.trim().length < 2) return 'firstName';
-  if (!lastName.trim() || lastName.trim().length < 2) return 'lastName';
+): string[] {
+  const errors: string[] = [];
+  const fn = normalizeName(firstName);
+  const ln = normalizeName(lastName);
+  if (!fn || fn.length < 2) errors.push('firstName');
+  else if (fn.length > 100 || !NAME_REGEX.test(fn)) errors.push('firstNameInvalid');
+  if (!ln || ln.length < 2) errors.push('lastName');
+  else if (ln.length > 100 || !NAME_REGEX.test(ln)) errors.push('lastNameInvalid');
   const d = parseInt(dobDay, 10);
   const m = parseInt(dobMonth, 10);
   const y = parseInt(dobYear, 10);
-  if (!dobDay || !dobMonth || !dobYear || isNaN(d) || isNaN(m) || isNaN(y)) return 'dob';
-  if (d < 1 || d > 31 || m < 1 || m > 12 || y < 1900) return 'dob';
-  if (computeAge(d, m, y) < 16) return 'minAge';
-  if (!isValidPhoneNumber(phoneNumber, phoneCountry as CountryCode)) return 'phoneNumber';
-  return null;
+  if (!dobDay || !dobMonth || !dobYear || isNaN(d) || isNaN(m) || isNaN(y))
+    errors.push('dobRequired');
+  else if (d < 1 || d > 31 || m < 1 || m > 12 || y < 1900) errors.push('dobInvalid');
+  else if (computeAge(d, m, y) < 16) errors.push('minAge');
+  if (!isValidPhoneNumber(phoneNumber, phoneCountry as CountryCode)) errors.push('phoneNumber');
+  return errors;
 }
 
-function validateStep3(homeCountry: string, termsAccepted: boolean): string | null {
-  if (!homeCountry) return 'homeCountry';
-  if (!termsAccepted) return 'terms';
-  return null;
+function validateStep3(homeCountry: string, termsAccepted: boolean): string[] {
+  const errors: string[] = [];
+  if (!homeCountry) errors.push('homeCountry');
+  if (!termsAccepted) errors.push('terms');
+  return errors;
 }
 
 // ---------------------------------------------------------------------------
@@ -130,8 +144,8 @@ export default function OnboardingPage() {
   const [homeCity, setHomeCity] = useState('');
   const [termsAccepted, setTermsAccepted] = useState(false);
 
-  // Step-level error key
-  const [stepError, setStepError] = useState<string | null>(null);
+  // Step-level error keys
+  const [stepErrors, setStepErrors] = useState<string[]>([]);
 
   // Pre-fill from OAuth provider
   useEffect(() => {
@@ -201,23 +215,27 @@ export default function OnboardingPage() {
   function handleUsernameChange(value: string) {
     setUsernameUserEdited(true);
     applyUsername(value);
-    setStepError(null);
+    setStepErrors([]);
   }
 
   function handleDisplayNameChange(value: string) {
     setDisplayName(value);
-    setStepError(null);
+    setStepErrors([]);
     if (!usernameUserEdited) {
       applyUsername(toUsernameSlug(value));
     }
   }
 
   function handleNext() {
-    let error: string | null = null;
+    if (step === 2) {
+      setFirstName((v) => normalizeName(v));
+      setLastName((v) => normalizeName(v));
+    }
+    let errors: string[] = [];
     if (step === 1) {
-      error = validateStep1(usernameStatus, displayName);
+      errors = validateStep1(usernameStatus, displayName);
     } else if (step === 2) {
-      error = validateStep2(
+      errors = validateStep2(
         firstName,
         lastName,
         dobDay,
@@ -227,19 +245,19 @@ export default function OnboardingPage() {
         phoneNumber,
       );
     }
-    if (error) {
-      setStepError(error);
+    if (errors.length > 0) {
+      setStepErrors(errors);
       return;
     }
-    setStepError(null);
+    setStepErrors([]);
     setStep((s) => s + 1);
   }
 
   async function handleSubmit(e: SyntheticEvent) {
     e.preventDefault();
-    const error = validateStep3(homeCountry, termsAccepted);
-    if (error) {
-      setStepError(error);
+    const errors = validateStep3(homeCountry, termsAccepted);
+    if (errors.length > 0) {
+      setStepErrors(errors);
       return;
     }
     setIsSubmitting(true);
@@ -247,8 +265,8 @@ export default function OnboardingPage() {
       await apiClient.post('/v1/auth/register', {
         username,
         displayName: displayName.trim(),
-        firstName,
-        lastName,
+        firstName: normalizeName(firstName),
+        lastName: normalizeName(lastName),
         dateOfBirth: {
           day: parseInt(dobDay, 10),
           month: parseInt(dobMonth, 10),
@@ -266,7 +284,7 @@ export default function OnboardingPage() {
     } catch (err) {
       if (isAxiosError(err) && err.response?.status === 409) {
         setStep(1);
-        setStepError(null);
+        setStepErrors([]);
         setUsernameStatus('taken');
         toast.error(t('onboarding.error.usernameTaken'));
       } else {
@@ -320,7 +338,7 @@ export default function OnboardingPage() {
             username={username}
             displayName={displayName}
             usernameStatus={usernameStatus}
-            stepError={stepError}
+            stepErrors={stepErrors}
             onUsernameChange={handleUsernameChange}
             onDisplayNameChange={handleDisplayNameChange}
             t={t}
@@ -336,34 +354,34 @@ export default function OnboardingPage() {
             dobYear={dobYear}
             phoneCountry={phoneCountry}
             phoneNumber={phoneNumber}
-            stepError={stepError}
+            stepErrors={stepErrors}
             onFirstNameChange={(v) => {
               setFirstName(v.toUpperCase());
-              setStepError(null);
+              setStepErrors([]);
             }}
             onLastNameChange={(v) => {
               setLastName(v.toUpperCase());
-              setStepError(null);
+              setStepErrors([]);
             }}
             onDobDayChange={(v) => {
               setDobDay(v);
-              setStepError(null);
+              setStepErrors([]);
             }}
             onDobMonthChange={(v) => {
               setDobMonth(v);
-              setStepError(null);
+              setStepErrors([]);
             }}
             onDobYearChange={(v) => {
               setDobYear(v);
-              setStepError(null);
+              setStepErrors([]);
             }}
             onPhoneCountryChange={(v) => {
               setPhoneCountry(v);
-              setStepError(null);
+              setStepErrors([]);
             }}
             onPhoneNumberChange={(v) => {
               setPhoneNumber(v);
-              setStepError(null);
+              setStepErrors([]);
             }}
             t={t}
           />
@@ -374,15 +392,15 @@ export default function OnboardingPage() {
             homeCountry={homeCountry}
             homeCity={homeCity}
             termsAccepted={termsAccepted}
-            stepError={stepError}
+            stepErrors={stepErrors}
             onHomeCountryChange={(v) => {
               setHomeCountry(v);
-              setStepError(null);
+              setStepErrors([]);
             }}
             onHomeCityChange={(v) => setHomeCity(v.toUpperCase())}
             onTermsChange={(v) => {
               setTermsAccepted(v);
-              setStepError(null);
+              setStepErrors([]);
             }}
             t={t}
           />
@@ -421,7 +439,7 @@ export default function OnboardingPage() {
               size="lg"
               onClick={() => {
                 setStep((s) => s - 1);
-                setStepError(null);
+                setStepErrors([]);
               }}
               disabled={isSubmitting}
               className="h-11 text-muted-foreground hover:text-foreground"
@@ -455,7 +473,7 @@ interface Step1Props {
   username: string;
   displayName: string;
   usernameStatus: UsernameStatus;
-  stepError: string | null;
+  stepErrors: string[];
   onUsernameChange: (v: string) => void;
   onDisplayNameChange: (v: string) => void;
   t: TFunction;
@@ -465,7 +483,7 @@ function Step1({
   username,
   displayName,
   usernameStatus,
-  stepError,
+  stepErrors,
   onUsernameChange,
   onDisplayNameChange,
   t,
@@ -481,10 +499,10 @@ function Step1({
           value={displayName}
           onChange={(e) => onDisplayNameChange(e.target.value)}
           placeholder={t('onboarding.displayName.placeholder')}
-          aria-invalid={stepError === 'displayName'}
+          aria-invalid={stepErrors.includes('displayName')}
           data-testid="displayname-input"
         />
-        {stepError === 'displayName' && (
+        {stepErrors.includes('displayName') && (
           <p className="text-xs text-destructive">{t('onboarding.validation.required')}</p>
         )}
       </div>
@@ -527,7 +545,7 @@ interface Step2Props {
   dobYear: string;
   phoneCountry: string;
   phoneNumber: string;
-  stepError: string | null;
+  stepErrors: string[];
   onFirstNameChange: (v: string) => void;
   onLastNameChange: (v: string) => void;
   onDobDayChange: (v: string) => void;
@@ -546,7 +564,7 @@ function Step2({
   dobYear,
   phoneCountry,
   phoneNumber,
-  stepError,
+  stepErrors,
   onFirstNameChange,
   onLastNameChange,
   onDobDayChange,
@@ -569,12 +587,14 @@ function Step2({
           placeholder={t('onboarding.firstName.placeholder')}
           value={firstName}
           onChange={(e) => onFirstNameChange(e.target.value)}
-          aria-invalid={stepError === 'firstName'}
+          aria-invalid={stepErrors.includes('firstName') || stepErrors.includes('firstNameInvalid')}
           data-testid="firstname-input"
           className="uppercase placeholder:normal-case"
         />
-        {stepError === 'firstName' ? (
+        {stepErrors.includes('firstName') ? (
           <p className="text-xs text-destructive">{t('onboarding.validation.required')}</p>
+        ) : stepErrors.includes('firstNameInvalid') ? (
+          <p className="text-xs text-destructive">{t('onboarding.validation.invalidName')}</p>
         ) : (
           <p className="text-xs text-muted-foreground">{t('onboarding.firstName.hint')}</p>
         )}
@@ -590,12 +610,14 @@ function Step2({
           placeholder={t('onboarding.lastName.placeholder')}
           value={lastName}
           onChange={(e) => onLastNameChange(e.target.value)}
-          aria-invalid={stepError === 'lastName'}
+          aria-invalid={stepErrors.includes('lastName') || stepErrors.includes('lastNameInvalid')}
           data-testid="lastname-input"
           className="uppercase placeholder:normal-case"
         />
-        {stepError === 'lastName' ? (
+        {stepErrors.includes('lastName') ? (
           <p className="text-xs text-destructive">{t('onboarding.validation.required')}</p>
+        ) : stepErrors.includes('lastNameInvalid') ? (
+          <p className="text-xs text-destructive">{t('onboarding.validation.invalidName')}</p>
         ) : (
           <p className="text-xs text-muted-foreground">{t('onboarding.lastName.hint')}</p>
         )}
@@ -612,7 +634,11 @@ function Step2({
             placeholder={t('onboarding.dateOfBirth.day')}
             value={dobDay}
             onChange={(e) => onDobDayChange(e.target.value)}
-            aria-invalid={stepError === 'dob' || stepError === 'minAge'}
+            aria-invalid={
+              stepErrors.includes('dobRequired') ||
+              stepErrors.includes('dobInvalid') ||
+              stepErrors.includes('minAge')
+            }
             data-testid="dob-day-input"
           />
           <Input
@@ -623,7 +649,11 @@ function Step2({
             placeholder={t('onboarding.dateOfBirth.month')}
             value={dobMonth}
             onChange={(e) => onDobMonthChange(e.target.value)}
-            aria-invalid={stepError === 'dob' || stepError === 'minAge'}
+            aria-invalid={
+              stepErrors.includes('dobRequired') ||
+              stepErrors.includes('dobInvalid') ||
+              stepErrors.includes('minAge')
+            }
             data-testid="dob-month-input"
           />
           <Input
@@ -633,14 +663,21 @@ function Step2({
             placeholder={t('onboarding.dateOfBirth.year')}
             value={dobYear}
             onChange={(e) => onDobYearChange(e.target.value)}
-            aria-invalid={stepError === 'dob' || stepError === 'minAge'}
+            aria-invalid={
+              stepErrors.includes('dobRequired') ||
+              stepErrors.includes('dobInvalid') ||
+              stepErrors.includes('minAge')
+            }
             data-testid="dob-year-input"
           />
         </div>
-        {stepError === 'dob' && (
+        {stepErrors.includes('dobRequired') && (
           <p className="text-xs text-destructive">{t('onboarding.validation.required')}</p>
         )}
-        {stepError === 'minAge' && (
+        {stepErrors.includes('dobInvalid') && (
+          <p className="text-xs text-destructive">{t('onboarding.validation.invalidDob')}</p>
+        )}
+        {stepErrors.includes('minAge') && (
           <p className="text-xs text-destructive">{t('onboarding.validation.minAge')}</p>
         )}
       </div>
@@ -655,7 +692,7 @@ function Step2({
             placeholder={t('onboarding.phone.countryPlaceholder')}
             searchPlaceholder={t('onboarding.phone.search')}
             noResultsText={t('onboarding.phone.noResults')}
-            aria-invalid={stepError === 'phoneCode'}
+            aria-invalid={stepErrors.includes('phoneCode')}
             aria-labelledby="phone-country-label"
             data-testid="phone-code-input"
           />
@@ -664,14 +701,14 @@ function Step2({
             value={phoneNumber}
             onChange={(e) => onPhoneNumberChange(e.target.value)}
             placeholder={t('onboarding.phone.number')}
-            aria-invalid={stepError === 'phoneNumber'}
+            aria-invalid={stepErrors.includes('phoneNumber')}
             data-testid="phone-number-input"
           />
         </div>
-        {stepError === 'phoneCode' && (
+        {stepErrors.includes('phoneCode') && (
           <p className="text-xs text-destructive">{t('onboarding.validation.invalidPhoneCode')}</p>
         )}
-        {stepError === 'phoneNumber' && (
+        {stepErrors.includes('phoneNumber') && (
           <p className="text-xs text-destructive">{t('onboarding.validation.invalidPhone')}</p>
         )}
       </div>
@@ -687,7 +724,7 @@ interface Step3Props {
   homeCountry: string;
   homeCity: string;
   termsAccepted: boolean;
-  stepError: string | null;
+  stepErrors: string[];
   onHomeCountryChange: (v: string) => void;
   onHomeCityChange: (v: string) => void;
   onTermsChange: (v: boolean) => void;
@@ -698,7 +735,7 @@ function Step3({
   homeCountry,
   homeCity,
   termsAccepted,
-  stepError,
+  stepErrors,
   onHomeCountryChange,
   onHomeCityChange,
   onTermsChange,
@@ -715,12 +752,12 @@ function Step3({
           placeholder={t('onboarding.homeCountry.placeholder')}
           searchPlaceholder={t('onboarding.homeCountry.search')}
           noResultsText={t('onboarding.homeCountry.noResults')}
-          aria-invalid={stepError === 'homeCountry'}
+          aria-invalid={stepErrors.includes('homeCountry')}
           aria-labelledby="home-country-label"
           data-testid="home-country-input"
           className="w-full"
         />
-        {stepError === 'homeCountry' && (
+        {stepErrors.includes('homeCountry') && (
           <p className="text-xs text-destructive">{t('onboarding.validation.required')}</p>
         )}
       </div>
@@ -770,7 +807,7 @@ function Step3({
           />
         </span>
       </label>
-      {stepError === 'terms' && (
+      {stepErrors.includes('terms') && (
         <p className="text-xs text-destructive">{t('onboarding.terms.required')}</p>
       )}
     </div>

--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -7,9 +7,11 @@ import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
 import { Spinner } from '@/components/ui/spinner';
 import { BasicInfoSection } from '@/components/profile/BasicInfoSection';
+import { PersonalDetailsSection } from '@/components/profile/PersonalDetailsSection';
 import { PreferencesSection } from '@/components/profile/PreferencesSection';
 import { LoyaltyProgramsSection } from '@/components/profile/LoyaltyProgramsSection';
 import type { BasicInfoUser, BasicInfoProfile } from '@/components/profile/BasicInfoSection';
+import type { PersonalDetailsProfile } from '@/components/profile/PersonalDetailsSection';
 import type { PreferencesData } from '@/components/profile/PreferencesSection';
 import type { LoyaltyProgramDto } from '@/components/profile/LoyaltyProgramsSection';
 import { useAuth } from '@/hooks/useAuth';
@@ -18,11 +20,24 @@ import { toast } from '@/components/ui/toast';
 import { AppLanguage, AppCurrency, AppTheme } from '@chamuco/shared-types';
 import { cn } from '@/lib/utils';
 
-type Tab = 'basic' | 'preferences' | 'loyalty';
+type Tab = 'basic' | 'personal' | 'preferences' | 'loyalty';
+
+const DEFAULT_PERSONAL_DETAILS: PersonalDetailsProfile = {
+  firstName: '',
+  lastName: '',
+  dateOfBirth: { day: 1, month: 1, year: 2000, yearVisible: false },
+  phoneCountryCode: '+57',
+  phoneLocalNumber: '',
+  birthCountry: null,
+  birthCity: null,
+  homeCountry: 'CO',
+  homeCity: null,
+};
 
 interface ProfileData {
   user: BasicInfoUser;
   userProfile: BasicInfoProfile;
+  personalDetails: PersonalDetailsProfile;
   preferences: PreferencesData;
   loyaltyPrograms: LoyaltyProgramDto[];
 }
@@ -71,6 +86,10 @@ export default function ProfilePage() {
           profileRes.status === 'fulfilled'
             ? (profileRes.value.data as BasicInfoProfile)
             : { bio: null, homeCountry: null },
+        personalDetails:
+          profileRes.status === 'fulfilled'
+            ? (profileRes.value.data as PersonalDetailsProfile)
+            : DEFAULT_PERSONAL_DETAILS,
         preferences:
           prefRes.status === 'fulfilled'
             ? (prefRes.value.data as PreferencesData)
@@ -127,6 +146,7 @@ export default function ProfilePage() {
 
   const tabs: { key: Tab; label: string }[] = [
     { key: 'basic', label: t('tabs.basicInfo') },
+    { key: 'personal', label: t('tabs.personalDetails') },
     { key: 'preferences', label: t('tabs.preferences') },
     { key: 'loyalty', label: t('tabs.loyaltyPrograms') },
   ];
@@ -198,6 +218,14 @@ export default function ProfilePage() {
         hidden={activeTab !== 'basic'}
       >
         <BasicInfoSection user={data.user} userProfile={data.userProfile} onRefresh={loadData} />
+      </div>
+      <div
+        id="panel-personal"
+        role="tabpanel"
+        aria-labelledby="tab-personal"
+        hidden={activeTab !== 'personal'}
+      >
+        <PersonalDetailsSection profile={data.personalDetails} onRefresh={loadData} />
       </div>
       <div
         id="panel-preferences"

--- a/apps/web/src/components/profile/PersonalDetailsSection.test.tsx
+++ b/apps/web/src/components/profile/PersonalDetailsSection.test.tsx
@@ -1,0 +1,402 @@
+import React from 'react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+const mocks = vi.hoisted(() => ({
+  mockPatch: vi.fn(),
+  mockToastSuccess: vi.fn(),
+  mockToastError: vi.fn(),
+  mockIsValidPhoneNumber: vi.fn(() => true),
+  mockGetCallingCode: vi.fn((iso2: string) => (iso2 === 'CO' ? '+57' : '+1')),
+}));
+
+vi.mock('@/services/api-client', () => ({
+  apiClient: { patch: mocks.mockPatch },
+}));
+
+vi.mock('@/components/ui/toast', () => ({
+  toast: {
+    success: mocks.mockToastSuccess,
+    error: mocks.mockToastError,
+  },
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('libphonenumber-js', () => ({
+  isValidPhoneNumber: mocks.mockIsValidPhoneNumber,
+}));
+
+vi.mock('countries-list', () => ({
+  getCountryDataList: () => [
+    { iso2: 'CO', phone: ['57'] },
+    { iso2: 'US', phone: ['1'] },
+  ],
+}));
+
+vi.mock('@/components/ui/input', () => ({
+  Input: (props: React.ComponentProps<'input'>) => <input {...props} />,
+}));
+
+vi.mock('@/components/ui/country-combobox', () => ({
+  CountryCombobox: ({
+    value,
+    onChange,
+    'data-testid': testId,
+    'aria-invalid': ariaInvalid,
+  }: {
+    value: string;
+    onChange: (iso2: string) => void;
+    'data-testid'?: string;
+    'aria-invalid'?: boolean;
+  }) => (
+    <select
+      data-testid={testId}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      aria-invalid={ariaInvalid}
+    >
+      <option value="CO">Colombia (+57)</option>
+      <option value="US">United States (+1)</option>
+      <option value="">None</option>
+    </select>
+  ),
+  getCallingCode: mocks.mockGetCallingCode,
+}));
+
+vi.mock('@/components/ui/city-combobox', () => ({
+  CityCombobox: ({
+    value,
+    onChange,
+    'data-testid': testId,
+  }: {
+    value: string;
+    onChange: (city: string) => void;
+    country: string;
+    placeholder?: string;
+    'data-testid'?: string;
+  }) => <input data-testid={testId} value={value} onChange={(e) => onChange(e.target.value)} />,
+}));
+
+import { PersonalDetailsSection } from './PersonalDetailsSection';
+import type { PersonalDetailsProfile } from './PersonalDetailsSection';
+
+const baseProfile: PersonalDetailsProfile = {
+  firstName: 'Juan',
+  lastName: 'García',
+  dateOfBirth: { day: 15, month: 6, year: 1990, yearVisible: false },
+  phoneCountryCode: '+57',
+  phoneLocalNumber: '3001234567',
+  birthCountry: 'CO',
+  birthCity: 'Bogotá',
+  homeCountry: 'CO',
+  homeCity: 'Medellín',
+};
+
+function setup(profileOverride?: Partial<PersonalDetailsProfile>) {
+  const onRefresh = vi.fn();
+  const user = userEvent.setup();
+  render(
+    <PersonalDetailsSection
+      profile={{ ...baseProfile, ...profileOverride }}
+      onRefresh={onRefresh}
+    />,
+  );
+  return { user, onRefresh };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.mockPatch.mockResolvedValue({});
+  mocks.mockIsValidPhoneNumber.mockReturnValue(true);
+  mocks.mockGetCallingCode.mockImplementation((iso2: string) => (iso2 === 'CO' ? '+57' : '+1'));
+});
+
+describe('PersonalDetailsSection', () => {
+  describe('rendering', () => {
+    it('renders the section heading', () => {
+      setup();
+      expect(screen.getByText('personalDetails.heading')).toBeInTheDocument();
+    });
+
+    it('renders firstName field with initial value', () => {
+      setup();
+      expect(screen.getByLabelText('personalDetails.firstName')).toHaveValue('Juan');
+    });
+
+    it('renders lastName field with initial value', () => {
+      setup();
+      expect(screen.getByLabelText('personalDetails.lastName')).toHaveValue('García');
+    });
+
+    it('renders DOB day field with initial value', () => {
+      setup();
+      expect(screen.getByLabelText('personalDetails.day')).toHaveValue(15);
+    });
+
+    it('renders DOB month field with initial value', () => {
+      setup();
+      expect(screen.getByLabelText('personalDetails.month')).toHaveValue(6);
+    });
+
+    it('renders DOB year field with initial value', () => {
+      setup();
+      expect(screen.getByLabelText('personalDetails.year')).toHaveValue(1990);
+    });
+
+    it('renders yearVisible checkbox unchecked when yearVisible is false', () => {
+      setup();
+      const checkbox = screen.getByRole('checkbox');
+      expect(checkbox).not.toBeChecked();
+    });
+
+    it('renders yearVisible checkbox checked when yearVisible is true', () => {
+      setup({ dateOfBirth: { day: 15, month: 6, year: 1990, yearVisible: true } });
+      const checkbox = screen.getByRole('checkbox');
+      expect(checkbox).toBeChecked();
+    });
+
+    it('renders phone local number field with initial value', () => {
+      setup();
+      expect(screen.getByLabelText('personalDetails.phoneNumber')).toHaveValue('3001234567');
+    });
+
+    it('renders phone country combobox with derived ISO2', () => {
+      setup();
+      expect(screen.getByTestId('phone-country')).toHaveValue('CO');
+    });
+
+    it('renders birth country combobox with initial value', () => {
+      setup();
+      expect(screen.getByTestId('birth-country')).toHaveValue('CO');
+    });
+
+    it('renders birth city with initial value', () => {
+      setup();
+      expect(screen.getByTestId('birth-city')).toHaveValue('Bogotá');
+    });
+
+    it('renders home country combobox with initial value', () => {
+      setup();
+      expect(screen.getByTestId('home-country')).toHaveValue('CO');
+    });
+
+    it('renders home city with initial value', () => {
+      setup();
+      expect(screen.getByTestId('home-city')).toHaveValue('Medellín');
+    });
+
+    it('renders with empty birth fields when birthCountry and birthCity are null', () => {
+      setup({ birthCountry: null, birthCity: null });
+      expect(screen.getByTestId('birth-country')).toHaveValue('');
+      expect(screen.getByTestId('birth-city')).toHaveValue('');
+    });
+  });
+
+  describe('save button state', () => {
+    it('disables save button when form is pristine', () => {
+      setup();
+      expect(screen.getByRole('button', { name: 'personalDetails.save' })).toBeDisabled();
+    });
+
+    it('enables save button after editing firstName', async () => {
+      const { user } = setup();
+      await user.type(screen.getByLabelText('personalDetails.firstName'), ' Carlos');
+      expect(screen.getByRole('button', { name: 'personalDetails.save' })).toBeEnabled();
+    });
+
+    it('shows unsaved indicator after editing a field', async () => {
+      const { user } = setup();
+      await user.type(screen.getByLabelText('personalDetails.firstName'), ' Carlos');
+      expect(screen.getByTestId('unsaved-indicator')).toBeInTheDocument();
+    });
+
+    it('hides unsaved indicator on pristine form', () => {
+      setup();
+      expect(screen.queryByTestId('unsaved-indicator')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('saving', () => {
+    it('calls PATCH /v1/users/me/profile on submit', async () => {
+      const { user } = setup();
+      await user.type(screen.getByLabelText('personalDetails.firstName'), ' Carlos');
+      await user.click(screen.getByRole('button', { name: 'personalDetails.save' }));
+      await waitFor(() =>
+        expect(mocks.mockPatch).toHaveBeenCalledWith(
+          '/v1/users/me/profile',
+          expect.objectContaining({ firstName: 'Juan Carlos' }),
+        ),
+      );
+    });
+
+    it('sends correct payload with all fields', async () => {
+      const { user } = setup();
+      await user.type(screen.getByLabelText('personalDetails.firstName'), ' Carlos');
+      await user.click(screen.getByRole('button', { name: 'personalDetails.save' }));
+      await waitFor(() =>
+        expect(mocks.mockPatch).toHaveBeenCalledWith('/v1/users/me/profile', {
+          firstName: 'Juan Carlos',
+          lastName: 'García',
+          dateOfBirth: { day: 15, month: 6, year: 1990, yearVisible: false },
+          phoneCountryCode: '+57',
+          phoneLocalNumber: '3001234567',
+          birthCountry: 'CO',
+          birthCity: 'Bogotá',
+          homeCountry: 'CO',
+          homeCity: 'Medellín',
+        }),
+      );
+    });
+
+    it('sends null for empty birth fields', async () => {
+      const { user } = setup({ birthCountry: null, birthCity: null });
+      await user.type(screen.getByLabelText('personalDetails.firstName'), ' Carlos');
+      await user.click(screen.getByRole('button', { name: 'personalDetails.save' }));
+      await waitFor(() =>
+        expect(mocks.mockPatch).toHaveBeenCalledWith(
+          '/v1/users/me/profile',
+          expect.objectContaining({ birthCountry: null, birthCity: null }),
+        ),
+      );
+    });
+
+    it('calls onRefresh after successful save', async () => {
+      const { user, onRefresh } = setup();
+      await user.type(screen.getByLabelText('personalDetails.firstName'), ' Carlos');
+      await user.click(screen.getByRole('button', { name: 'personalDetails.save' }));
+      await waitFor(() => expect(onRefresh).toHaveBeenCalledOnce());
+    });
+
+    it('shows success toast on save', async () => {
+      const { user } = setup();
+      await user.type(screen.getByLabelText('personalDetails.firstName'), ' Carlos');
+      await user.click(screen.getByRole('button', { name: 'personalDetails.save' }));
+      await waitFor(() =>
+        expect(mocks.mockToastSuccess).toHaveBeenCalledWith('personalDetails.saveSuccess'),
+      );
+    });
+
+    it('shows error toast when save fails', async () => {
+      mocks.mockPatch.mockRejectedValue(new Error('network error'));
+      const { user } = setup();
+      await user.type(screen.getByLabelText('personalDetails.firstName'), ' Carlos');
+      await user.click(screen.getByRole('button', { name: 'personalDetails.save' }));
+      await waitFor(() =>
+        expect(mocks.mockToastError).toHaveBeenCalledWith('personalDetails.saveError'),
+      );
+    });
+
+    it('disables button while saving', async () => {
+      mocks.mockPatch.mockImplementation(() => new Promise(() => {}));
+      const { user } = setup();
+      await user.type(screen.getByLabelText('personalDetails.firstName'), ' Carlos');
+      await user.click(screen.getByRole('button', { name: 'personalDetails.save' }));
+      expect(screen.getByRole('button')).toBeDisabled();
+    });
+
+    it('converts yearVisible toggle in payload', async () => {
+      const { user } = setup();
+      await user.click(screen.getByRole('checkbox'));
+      await user.type(screen.getByLabelText('personalDetails.firstName'), ' Carlos');
+      await user.click(screen.getByRole('button', { name: 'personalDetails.save' }));
+      await waitFor(() =>
+        expect(mocks.mockPatch).toHaveBeenCalledWith(
+          '/v1/users/me/profile',
+          expect.objectContaining({
+            dateOfBirth: expect.objectContaining({ yearVisible: true }),
+          }),
+        ),
+      );
+    });
+  });
+
+  describe('validation', () => {
+    it('shows firstName error and blocks save when firstName is empty', async () => {
+      const { user } = setup();
+      const input = screen.getByLabelText('personalDetails.firstName');
+      await user.clear(input);
+      await user.click(screen.getByRole('button', { name: 'personalDetails.save' }));
+      expect(screen.getByText('personalDetails.errors.firstNameRequired')).toBeInTheDocument();
+      expect(mocks.mockPatch).not.toHaveBeenCalled();
+    });
+
+    it('shows firstName error when firstName is one character', async () => {
+      const { user } = setup();
+      const input = screen.getByLabelText('personalDetails.firstName');
+      await user.clear(input);
+      await user.type(input, 'A');
+      await user.click(screen.getByRole('button', { name: 'personalDetails.save' }));
+      expect(screen.getByText('personalDetails.errors.firstNameRequired')).toBeInTheDocument();
+      expect(mocks.mockPatch).not.toHaveBeenCalled();
+    });
+
+    it('shows lastName error and blocks save when lastName is empty', async () => {
+      const { user } = setup();
+      const input = screen.getByLabelText('personalDetails.lastName');
+      await user.clear(input);
+      await user.click(screen.getByRole('button', { name: 'personalDetails.save' }));
+      expect(screen.getByText('personalDetails.errors.lastNameRequired')).toBeInTheDocument();
+      expect(mocks.mockPatch).not.toHaveBeenCalled();
+    });
+
+    it('shows DOB error when year is too recent (min age 15)', async () => {
+      const recentYear = new Date().getFullYear() - 5;
+      setup({
+        dateOfBirth: { day: 15, month: 6, year: recentYear, yearVisible: false },
+      });
+      fireEvent.submit(document.querySelector('form')!);
+      await waitFor(() =>
+        expect(screen.getByText('personalDetails.errors.invalidDob')).toBeInTheDocument(),
+      );
+      expect(mocks.mockPatch).not.toHaveBeenCalled();
+    });
+
+    it('shows DOB error for invalid calendar date (e.g. Feb 30)', async () => {
+      const { user } = setup();
+      const dayInput = screen.getByLabelText('personalDetails.day');
+      const monthInput = screen.getByLabelText('personalDetails.month');
+      await user.clear(dayInput);
+      await user.type(dayInput, '30');
+      await user.clear(monthInput);
+      await user.type(monthInput, '2');
+      await user.click(screen.getByRole('button', { name: 'personalDetails.save' }));
+      expect(screen.getByText('personalDetails.errors.invalidDob')).toBeInTheDocument();
+      expect(mocks.mockPatch).not.toHaveBeenCalled();
+    });
+
+    it('shows phone error when isValidPhoneNumber returns false', async () => {
+      mocks.mockIsValidPhoneNumber.mockReturnValue(false);
+      const { user } = setup();
+      await user.type(screen.getByLabelText('personalDetails.firstName'), ' Carlos');
+      await user.click(screen.getByRole('button', { name: 'personalDetails.save' }));
+      expect(screen.getByText('personalDetails.errors.invalidPhone')).toBeInTheDocument();
+      expect(mocks.mockPatch).not.toHaveBeenCalled();
+    });
+
+    it('shows homeCountry error when homeCountry is empty', async () => {
+      const { user } = setup({ homeCountry: '' });
+      await user.type(screen.getByLabelText('personalDetails.firstName'), ' Carlos');
+      await user.click(screen.getByRole('button', { name: 'personalDetails.save' }));
+      expect(screen.getByText('personalDetails.errors.homeCountryRequired')).toBeInTheDocument();
+      expect(mocks.mockPatch).not.toHaveBeenCalled();
+    });
+
+    it('clears firstName error after fixing and successfully saving', async () => {
+      const { user } = setup();
+      const input = screen.getByLabelText('personalDetails.firstName');
+      await user.clear(input);
+      await user.click(screen.getByRole('button', { name: 'personalDetails.save' }));
+      expect(screen.getByText('personalDetails.errors.firstNameRequired')).toBeInTheDocument();
+
+      await user.type(input, 'Pedro');
+      await user.click(screen.getByRole('button', { name: 'personalDetails.save' }));
+      await waitFor(() => expect(mocks.mockToastSuccess).toHaveBeenCalled());
+      expect(
+        screen.queryByText('personalDetails.errors.firstNameRequired'),
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/src/components/profile/PersonalDetailsSection.tsx
+++ b/apps/web/src/components/profile/PersonalDetailsSection.tsx
@@ -41,6 +41,9 @@ function isValidCalendarDay(day: number, month: number, year: number): boolean {
   return date.getFullYear() === year && date.getMonth() === month - 1 && date.getDate() === day;
 }
 
+const NAME_REGEX = /^[\p{L}\s]+$/u;
+const CURRENT_YEAR = new Date().getFullYear();
+
 export function PersonalDetailsSection({ profile, onRefresh }: PersonalDetailsSectionProps) {
   const { t } = useTranslation('profile');
 
@@ -66,9 +69,6 @@ export function PersonalDetailsSection({ profile, onRefresh }: PersonalDetailsSe
   const [homeCountryError, setHomeCountryError] = useState<string | null>(null);
   const [isSaving, setIsSaving] = useState(false);
 
-  const nameRegex = /^[\p{L}\s]+$/u;
-  const currentYear = new Date().getFullYear();
-
   const isDirty =
     firstName !== profile.firstName ||
     lastName !== profile.lastName ||
@@ -92,7 +92,7 @@ export function PersonalDetailsSection({ profile, onRefresh }: PersonalDetailsSe
       !firstName.trim() ||
       firstName.trim().length < 2 ||
       firstName.trim().length > 100 ||
-      !nameRegex.test(firstName.trim())
+      !NAME_REGEX.test(firstName.trim())
     ) {
       setFirstNameError(t('personalDetails.errors.firstNameRequired'));
       hasError = true;
@@ -104,7 +104,7 @@ export function PersonalDetailsSection({ profile, onRefresh }: PersonalDetailsSe
       !lastName.trim() ||
       lastName.trim().length < 2 ||
       lastName.trim().length > 100 ||
-      !nameRegex.test(lastName.trim())
+      !NAME_REGEX.test(lastName.trim())
     ) {
       setLastNameError(t('personalDetails.errors.lastNameRequired'));
       hasError = true;
@@ -124,7 +124,7 @@ export function PersonalDetailsSection({ profile, onRefresh }: PersonalDetailsSe
       month >= 1 &&
       month <= 12 &&
       year >= 1900 &&
-      year <= currentYear - 15 &&
+      year <= CURRENT_YEAR - 15 &&
       isValidCalendarDay(day, month, year);
 
     if (!dobValid) {
@@ -247,7 +247,7 @@ export function PersonalDetailsSection({ profile, onRefresh }: PersonalDetailsSe
               id="dobYear"
               type="number"
               min={1900}
-              max={currentYear - 15}
+              max={CURRENT_YEAR - 15}
               value={dobYear}
               onChange={(e) => setDobYear(e.target.value)}
               aria-invalid={dobError !== null}

--- a/apps/web/src/components/profile/PersonalDetailsSection.tsx
+++ b/apps/web/src/components/profile/PersonalDetailsSection.tsx
@@ -1,0 +1,391 @@
+'use client';
+
+import { useState, type FormEvent } from 'react';
+import { useTranslation } from 'react-i18next';
+import { isValidPhoneNumber, type CountryCode } from 'libphonenumber-js';
+import { getCountryDataList } from 'countries-list';
+
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Spinner } from '@/components/ui/spinner';
+import { CountryCombobox, getCallingCode } from '@/components/ui/country-combobox';
+import { CityCombobox } from '@/components/ui/city-combobox';
+import { toast } from '@/components/ui/toast';
+import { apiClient } from '@/services/api-client';
+
+export interface PersonalDetailsProfile {
+  firstName: string;
+  lastName: string;
+  dateOfBirth: { day: number; month: number; year: number; yearVisible: boolean };
+  phoneCountryCode: string;
+  phoneLocalNumber: string;
+  birthCountry: string | null;
+  birthCity: string | null;
+  homeCountry: string;
+  homeCity: string | null;
+}
+
+interface PersonalDetailsSectionProps {
+  profile: PersonalDetailsProfile;
+  onRefresh: () => void;
+}
+
+function callingCodeToIso2(callingCode: string): string {
+  const digits = Number(callingCode.replace('+', ''));
+  return getCountryDataList().find((c) => c.phone[0] === digits)?.iso2 ?? 'CO';
+}
+
+function isValidCalendarDay(day: number, month: number, year: number): boolean {
+  const date = new Date(year, month - 1, day);
+  return date.getFullYear() === year && date.getMonth() === month - 1 && date.getDate() === day;
+}
+
+export function PersonalDetailsSection({ profile, onRefresh }: PersonalDetailsSectionProps) {
+  const { t } = useTranslation('profile');
+
+  const [firstName, setFirstName] = useState(profile.firstName);
+  const [lastName, setLastName] = useState(profile.lastName);
+  const [dobDay, setDobDay] = useState(String(profile.dateOfBirth.day));
+  const [dobMonth, setDobMonth] = useState(String(profile.dateOfBirth.month));
+  const [dobYear, setDobYear] = useState(String(profile.dateOfBirth.year));
+  const [yearVisible, setYearVisible] = useState(profile.dateOfBirth.yearVisible);
+  const [phoneCountryIso, setPhoneCountryIso] = useState(
+    callingCodeToIso2(profile.phoneCountryCode),
+  );
+  const [phoneLocalNumber, setPhoneLocalNumber] = useState(profile.phoneLocalNumber);
+  const [birthCountry, setBirthCountry] = useState(profile.birthCountry ?? '');
+  const [birthCity, setBirthCity] = useState(profile.birthCity ?? '');
+  const [homeCountry, setHomeCountry] = useState(profile.homeCountry);
+  const [homeCity, setHomeCity] = useState(profile.homeCity ?? '');
+
+  const [firstNameError, setFirstNameError] = useState<string | null>(null);
+  const [lastNameError, setLastNameError] = useState<string | null>(null);
+  const [dobError, setDobError] = useState<string | null>(null);
+  const [phoneError, setPhoneError] = useState<string | null>(null);
+  const [homeCountryError, setHomeCountryError] = useState<string | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+
+  const nameRegex = /^[\p{L}\s]+$/u;
+  const currentYear = new Date().getFullYear();
+
+  const isDirty =
+    firstName !== profile.firstName ||
+    lastName !== profile.lastName ||
+    Number(dobDay) !== profile.dateOfBirth.day ||
+    Number(dobMonth) !== profile.dateOfBirth.month ||
+    Number(dobYear) !== profile.dateOfBirth.year ||
+    yearVisible !== profile.dateOfBirth.yearVisible ||
+    getCallingCode(phoneCountryIso) !== profile.phoneCountryCode ||
+    phoneLocalNumber !== profile.phoneLocalNumber ||
+    (birthCountry || null) !== profile.birthCountry ||
+    (birthCity.trim() || null) !== profile.birthCity ||
+    homeCountry !== profile.homeCountry ||
+    (homeCity.trim() || null) !== profile.homeCity;
+
+  async function handleSave(e: FormEvent) {
+    e.preventDefault();
+
+    let hasError = false;
+
+    if (
+      !firstName.trim() ||
+      firstName.trim().length < 2 ||
+      firstName.trim().length > 100 ||
+      !nameRegex.test(firstName.trim())
+    ) {
+      setFirstNameError(t('personalDetails.errors.firstNameRequired'));
+      hasError = true;
+    } else {
+      setFirstNameError(null);
+    }
+
+    if (
+      !lastName.trim() ||
+      lastName.trim().length < 2 ||
+      lastName.trim().length > 100 ||
+      !nameRegex.test(lastName.trim())
+    ) {
+      setLastNameError(t('personalDetails.errors.lastNameRequired'));
+      hasError = true;
+    } else {
+      setLastNameError(null);
+    }
+
+    const day = Number(dobDay);
+    const month = Number(dobMonth);
+    const year = Number(dobYear);
+    const dobValid =
+      Number.isInteger(day) &&
+      Number.isInteger(month) &&
+      Number.isInteger(year) &&
+      day >= 1 &&
+      day <= 31 &&
+      month >= 1 &&
+      month <= 12 &&
+      year >= 1900 &&
+      year <= currentYear - 15 &&
+      isValidCalendarDay(day, month, year);
+
+    if (!dobValid) {
+      setDobError(t('personalDetails.errors.invalidDob'));
+      hasError = true;
+    } else {
+      setDobError(null);
+    }
+
+    if (!isValidPhoneNumber(phoneLocalNumber, phoneCountryIso as CountryCode)) {
+      setPhoneError(t('personalDetails.errors.invalidPhone'));
+      hasError = true;
+    } else {
+      setPhoneError(null);
+    }
+
+    if (!homeCountry) {
+      setHomeCountryError(t('personalDetails.errors.homeCountryRequired'));
+      hasError = true;
+    } else {
+      setHomeCountryError(null);
+    }
+
+    if (hasError) return;
+
+    setIsSaving(true);
+    try {
+      await apiClient.patch('/v1/users/me/profile', {
+        firstName: firstName.trim(),
+        lastName: lastName.trim(),
+        dateOfBirth: { day, month, year, yearVisible },
+        phoneCountryCode: getCallingCode(phoneCountryIso),
+        phoneLocalNumber,
+        birthCountry: birthCountry || null,
+        birthCity: birthCity.trim() || null,
+        homeCountry,
+        homeCity: homeCity.trim() || null,
+      });
+      toast.success(t('personalDetails.saveSuccess'));
+      onRefresh();
+    } catch {
+      toast.error(t('personalDetails.saveError'));
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  return (
+    <form onSubmit={handleSave} className="max-w-lg space-y-6">
+      <h2 className="text-xl font-semibold">{t('personalDetails.heading')}</h2>
+
+      <div className="grid grid-cols-2 gap-4">
+        <div className="space-y-1.5">
+          <Label htmlFor="firstName">{t('personalDetails.firstName')}</Label>
+          <Input
+            id="firstName"
+            value={firstName}
+            onChange={(e) => setFirstName(e.target.value)}
+            placeholder={t('personalDetails.firstNamePlaceholder')}
+            aria-invalid={firstNameError !== null}
+            disabled={isSaving}
+          />
+          {firstNameError && <p className="text-sm text-destructive">{firstNameError}</p>}
+          <p className="text-xs text-muted-foreground">{t('personalDetails.firstNameHint')}</p>
+        </div>
+
+        <div className="space-y-1.5">
+          <Label htmlFor="lastName">{t('personalDetails.lastName')}</Label>
+          <Input
+            id="lastName"
+            value={lastName}
+            onChange={(e) => setLastName(e.target.value)}
+            placeholder={t('personalDetails.lastNamePlaceholder')}
+            aria-invalid={lastNameError !== null}
+            disabled={isSaving}
+          />
+          {lastNameError && <p className="text-sm text-destructive">{lastNameError}</p>}
+          <p className="text-xs text-muted-foreground">{t('personalDetails.lastNameHint')}</p>
+        </div>
+      </div>
+
+      <div className="space-y-1.5">
+        <Label id="dob-label">{t('personalDetails.dateOfBirth')}</Label>
+        <div className="grid grid-cols-3 gap-2">
+          <div className="space-y-1">
+            <Label htmlFor="dobDay" className="text-xs text-muted-foreground">
+              {t('personalDetails.day')}
+            </Label>
+            <Input
+              id="dobDay"
+              type="number"
+              min={1}
+              max={31}
+              value={dobDay}
+              onChange={(e) => setDobDay(e.target.value)}
+              aria-invalid={dobError !== null}
+              disabled={isSaving}
+            />
+          </div>
+          <div className="space-y-1">
+            <Label htmlFor="dobMonth" className="text-xs text-muted-foreground">
+              {t('personalDetails.month')}
+            </Label>
+            <Input
+              id="dobMonth"
+              type="number"
+              min={1}
+              max={12}
+              value={dobMonth}
+              onChange={(e) => setDobMonth(e.target.value)}
+              aria-invalid={dobError !== null}
+              disabled={isSaving}
+            />
+          </div>
+          <div className="space-y-1">
+            <Label htmlFor="dobYear" className="text-xs text-muted-foreground">
+              {t('personalDetails.year')}
+            </Label>
+            <Input
+              id="dobYear"
+              type="number"
+              min={1900}
+              max={currentYear - 15}
+              value={dobYear}
+              onChange={(e) => setDobYear(e.target.value)}
+              aria-invalid={dobError !== null}
+              disabled={isSaving}
+            />
+          </div>
+        </div>
+        {dobError && <p className="text-sm text-destructive">{dobError}</p>}
+        <label className="flex cursor-pointer items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            checked={yearVisible}
+            onChange={(e) => setYearVisible(e.target.checked)}
+            disabled={isSaving}
+            className="rounded border-border"
+          />
+          {t('personalDetails.yearVisible')}
+        </label>
+      </div>
+
+      <div className="space-y-1.5">
+        <Label id="phone-label">{t('personalDetails.phone')}</Label>
+        <div className="flex gap-2">
+          <div className="w-40 shrink-0">
+            <Label htmlFor="phoneCountry" className="sr-only">
+              {t('personalDetails.phoneCountry')}
+            </Label>
+            <CountryCombobox
+              value={phoneCountryIso}
+              onChange={setPhoneCountryIso}
+              displayMode="phone"
+              placeholder={t('personalDetails.phoneCountryPlaceholder')}
+              searchPlaceholder={t('personalDetails.phoneCountrySearch')}
+              noResultsText={t('personalDetails.phoneCountryNoResults')}
+              aria-labelledby="phone-label"
+              aria-invalid={phoneError !== null}
+              data-testid="phone-country"
+            />
+          </div>
+          <div className="flex-1">
+            <Label htmlFor="phoneLocalNumber" className="sr-only">
+              {t('personalDetails.phoneNumber')}
+            </Label>
+            <Input
+              id="phoneLocalNumber"
+              type="tel"
+              value={phoneLocalNumber}
+              onChange={(e) => setPhoneLocalNumber(e.target.value)}
+              placeholder={t('personalDetails.phoneNumberPlaceholder')}
+              aria-invalid={phoneError !== null}
+              disabled={isSaving}
+            />
+          </div>
+        </div>
+        {phoneError && <p className="text-sm text-destructive">{phoneError}</p>}
+      </div>
+
+      <div className="space-y-1.5">
+        <Label id="birth-location-label">{t('personalDetails.birthLocationOptional')}</Label>
+        <div className="grid grid-cols-2 gap-2">
+          <div>
+            <Label htmlFor="birthCountry" className="sr-only">
+              {t('personalDetails.birthCountry')}
+            </Label>
+            <CountryCombobox
+              value={birthCountry}
+              onChange={(iso2) => {
+                setBirthCountry(iso2);
+                setBirthCity('');
+              }}
+              displayMode="name"
+              placeholder={t('personalDetails.birthCountryPlaceholder')}
+              searchPlaceholder={t('personalDetails.birthCountrySearch')}
+              noResultsText={t('personalDetails.birthCountryNoResults')}
+              aria-labelledby="birth-location-label"
+              data-testid="birth-country"
+            />
+          </div>
+          <div>
+            <Label htmlFor="birthCity" className="sr-only">
+              {t('personalDetails.birthCity')}
+            </Label>
+            <CityCombobox
+              value={birthCity}
+              onChange={setBirthCity}
+              country={birthCountry}
+              placeholder={t('personalDetails.birthCityPlaceholder')}
+              data-testid="birth-city"
+            />
+          </div>
+        </div>
+      </div>
+
+      <div className="space-y-1.5">
+        <Label id="home-location-label">{t('personalDetails.homeLocation')}</Label>
+        <div className="grid grid-cols-2 gap-2">
+          <div>
+            <Label htmlFor="homeCountry" className="sr-only">
+              {t('personalDetails.homeCountry')}
+            </Label>
+            <CountryCombobox
+              value={homeCountry}
+              onChange={(iso2) => {
+                setHomeCountry(iso2);
+                setHomeCity('');
+              }}
+              displayMode="name"
+              placeholder={t('personalDetails.homeCountryPlaceholder')}
+              searchPlaceholder={t('personalDetails.homeCountrySearch')}
+              noResultsText={t('personalDetails.homeCountryNoResults')}
+              aria-labelledby="home-location-label"
+              aria-invalid={homeCountryError !== null}
+              data-testid="home-country"
+            />
+          </div>
+          <div>
+            <Label htmlFor="homeCity" className="sr-only">
+              {t('personalDetails.homeCity')}
+            </Label>
+            <CityCombobox
+              value={homeCity}
+              onChange={setHomeCity}
+              country={homeCountry}
+              placeholder={t('personalDetails.homeCityPlaceholder')}
+              data-testid="home-city"
+            />
+          </div>
+        </div>
+        {homeCountryError && <p className="text-sm text-destructive">{homeCountryError}</p>}
+      </div>
+
+      <Button type="submit" disabled={isSaving || !isDirty} className="gap-2">
+        {isSaving && <Spinner size="sm" />}
+        {!isSaving && isDirty && (
+          <span data-testid="unsaved-indicator" className="size-2 rounded-full bg-amber-500" />
+        )}
+        {isSaving ? t('personalDetails.saving') : t('personalDetails.save')}
+      </Button>
+    </form>
+  );
+}

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -293,8 +293,8 @@
       "saveSuccess": "Personal details updated",
       "saveError": "Failed to save personal details",
       "errors": {
-        "firstNameRequired": "First name must be 2–100 letters",
-        "lastNameRequired": "Last name must be 2–100 letters",
+        "firstNameRequired": "First name: letters and spaces only, 2–100 characters",
+        "lastNameRequired": "Last name: letters and spaces only, 2–100 characters",
         "invalidDob": "Enter a valid date of birth (min age: 15)",
         "invalidPhone": "Enter a valid phone number",
         "homeCountryRequired": "Home country is required"

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -165,7 +165,9 @@
         "minAge": "You must be at least 16 years old to register",
         "invalidCountryCode": "Enter a 2-letter uppercase country code (e.g. CO)",
         "invalidPhone": "Enter a valid phone number (4–14 digits)",
-        "invalidPhoneCode": "Enter a valid country code (e.g. +57)"
+        "invalidPhoneCode": "Enter a valid country code (e.g. +57)",
+        "invalidName": "Letters and spaces only (2–100 characters), as on your passport",
+        "invalidDob": "Enter a valid date of birth"
       }
     }
   },
@@ -208,6 +210,7 @@
     "statistics": "Statistics",
     "tabs": {
       "basicInfo": "Basic Info",
+      "personalDetails": "Personal Details",
       "preferences": "Preferences",
       "loyaltyPrograms": "Loyalty Programs"
     },
@@ -250,6 +253,53 @@
       },
       "saveError": "Failed to save preferences"
     },
+    "personalDetails": {
+      "heading": "Personal Details",
+      "firstName": "First Name",
+      "firstNamePlaceholder": "JUAN CARLOS",
+      "firstNameHint": "As on your passport or ID",
+      "lastName": "Last Name",
+      "lastNamePlaceholder": "GARCÍA LÓPEZ",
+      "lastNameHint": "As on your passport or ID",
+      "dateOfBirth": "Date of Birth",
+      "day": "Day",
+      "month": "Month",
+      "year": "Year",
+      "yearVisible": "Show birth year on public profile",
+      "phone": "Phone Number",
+      "phoneCountry": "Country Code",
+      "phoneCountryPlaceholder": "Country",
+      "phoneCountrySearch": "Search countries…",
+      "phoneCountryNoResults": "No countries found.",
+      "phoneNumber": "Local Number",
+      "phoneNumberPlaceholder": "e.g. 3001234567",
+      "birthLocation": "Birth Location",
+      "birthLocationOptional": "Birth Location (optional)",
+      "birthCountry": "Birth Country",
+      "birthCountryPlaceholder": "Select country",
+      "birthCountrySearch": "Search countries…",
+      "birthCountryNoResults": "No countries found.",
+      "birthCity": "Birth City",
+      "birthCityPlaceholder": "e.g. Bogotá",
+      "homeLocation": "Home Location",
+      "homeCountry": "Home Country",
+      "homeCountryPlaceholder": "Select country",
+      "homeCountrySearch": "Search countries…",
+      "homeCountryNoResults": "No countries found.",
+      "homeCity": "Home City",
+      "homeCityPlaceholder": "e.g. Medellín",
+      "save": "Save changes",
+      "saving": "Saving...",
+      "saveSuccess": "Personal details updated",
+      "saveError": "Failed to save personal details",
+      "errors": {
+        "firstNameRequired": "First name must be 2–100 letters",
+        "lastNameRequired": "Last name must be 2–100 letters",
+        "invalidDob": "Enter a valid date of birth (min age: 15)",
+        "invalidPhone": "Enter a valid phone number",
+        "homeCountryRequired": "Home country is required"
+      }
+    },
     "loyaltyPrograms": {
       "heading": "Loyalty Programs",
       "empty": "No loyalty programs added yet",
@@ -287,7 +337,9 @@
     "notFound": "Page not found",
     "unauthorized": "You are not authorized to access this resource",
     "networkError": "Network error. Please check your connection.",
-    "sessionExpired": "Your session has expired. Please sign in again."
+    "sessionExpired": "Your session has expired. Please sign in again.",
+    "loadError": "Failed to load data. Please try again.",
+    "retry": "Retry"
   },
   "legal": {
     "privacy": {

--- a/apps/web/src/locales/es.json
+++ b/apps/web/src/locales/es.json
@@ -165,7 +165,9 @@
         "minAge": "Debes tener al menos 16 años para registrarte",
         "invalidCountryCode": "Ingresa un código de país de 2 letras mayúsculas (ej. CO)",
         "invalidPhone": "Ingresa un número de teléfono válido (4–14 dígitos)",
-        "invalidPhoneCode": "Ingresa un código de país válido (ej. +57)"
+        "invalidPhoneCode": "Ingresa un código de país válido (ej. +57)",
+        "invalidName": "Solo letras y espacios (2–100 caracteres), tal como aparece en tu pasaporte",
+        "invalidDob": "Ingresa una fecha de nacimiento válida"
       }
     }
   },
@@ -208,6 +210,7 @@
     "statistics": "Estadísticas",
     "tabs": {
       "basicInfo": "Información Básica",
+      "personalDetails": "Datos Personales",
       "preferences": "Preferencias",
       "loyaltyPrograms": "Programas de Fidelidad"
     },
@@ -250,6 +253,53 @@
       },
       "saveError": "Error al guardar las preferencias"
     },
+    "personalDetails": {
+      "heading": "Datos Personales",
+      "firstName": "Nombre(s)",
+      "firstNamePlaceholder": "JUAN CARLOS",
+      "firstNameHint": "Como aparece en tu pasaporte o documento de identidad",
+      "lastName": "Apellido(s)",
+      "lastNamePlaceholder": "GARCÍA LÓPEZ",
+      "lastNameHint": "Como aparece en tu pasaporte o documento de identidad",
+      "dateOfBirth": "Fecha de Nacimiento",
+      "day": "Día",
+      "month": "Mes",
+      "year": "Año",
+      "yearVisible": "Mostrar año de nacimiento en el perfil público",
+      "phone": "Número de Teléfono",
+      "phoneCountry": "Código de País",
+      "phoneCountryPlaceholder": "País",
+      "phoneCountrySearch": "Buscar países…",
+      "phoneCountryNoResults": "No se encontraron países.",
+      "phoneNumber": "Número Local",
+      "phoneNumberPlaceholder": "ej. 3001234567",
+      "birthLocation": "Lugar de Nacimiento",
+      "birthLocationOptional": "Lugar de Nacimiento (opcional)",
+      "birthCountry": "País de Nacimiento",
+      "birthCountryPlaceholder": "Seleccionar país",
+      "birthCountrySearch": "Buscar países…",
+      "birthCountryNoResults": "No se encontraron países.",
+      "birthCity": "Ciudad de Nacimiento",
+      "birthCityPlaceholder": "ej. Bogotá",
+      "homeLocation": "Lugar de Residencia",
+      "homeCountry": "País de Residencia",
+      "homeCountryPlaceholder": "Seleccionar país",
+      "homeCountrySearch": "Buscar países…",
+      "homeCountryNoResults": "No se encontraron países.",
+      "homeCity": "Ciudad de Residencia",
+      "homeCityPlaceholder": "ej. Medellín",
+      "save": "Guardar cambios",
+      "saving": "Guardando...",
+      "saveSuccess": "Datos personales actualizados",
+      "saveError": "Error al guardar los datos personales",
+      "errors": {
+        "firstNameRequired": "El nombre debe tener entre 2 y 100 letras",
+        "lastNameRequired": "El apellido debe tener entre 2 y 100 letras",
+        "invalidDob": "Ingresa una fecha de nacimiento válida (edad mínima: 15)",
+        "invalidPhone": "Ingresa un número de teléfono válido",
+        "homeCountryRequired": "El país de residencia es obligatorio"
+      }
+    },
     "loyaltyPrograms": {
       "heading": "Programas de Fidelidad",
       "empty": "No hay programas de fidelidad agregados",
@@ -287,7 +337,9 @@
     "notFound": "Página no encontrada",
     "unauthorized": "No estás autorizado para acceder a este recurso",
     "networkError": "Error de red. Por favor verifica tu conexión.",
-    "sessionExpired": "Tu sesión ha expirado. Por favor inicia sesión nuevamente."
+    "sessionExpired": "Tu sesión ha expirado. Por favor inicia sesión nuevamente.",
+    "loadError": "Error al cargar los datos. Por favor intenta de nuevo.",
+    "retry": "Reintentar"
   },
   "legal": {
     "privacy": {

--- a/apps/web/src/locales/es.json
+++ b/apps/web/src/locales/es.json
@@ -293,8 +293,8 @@
       "saveSuccess": "Datos personales actualizados",
       "saveError": "Error al guardar los datos personales",
       "errors": {
-        "firstNameRequired": "El nombre debe tener entre 2 y 100 letras",
-        "lastNameRequired": "El apellido debe tener entre 2 y 100 letras",
+        "firstNameRequired": "El nombre puede contener letras y espacios (2–100 caracteres)",
+        "lastNameRequired": "El apellido puede contener letras y espacios (2–100 caracteres)",
         "invalidDob": "Ingresa una fecha de nacimiento válida (edad mínima: 15)",
         "invalidPhone": "Ingresa un número de teléfono válido",
         "homeCountryRequired": "El país de residencia es obligatorio"


### PR DESCRIPTION
## Summary

Adds a new **Personal Details** tab to the profile page, letting users view and edit their legal name, date of birth, phone number, and birth/home location via `GET/PATCH /v1/users/me/profile`. Also fixes a class of silent failures in onboarding step 2 where invalid names passed through to the API, causing an opaque error on step 3 with no path to recovery.

## Changes

**New: Personal Details tab (`/profile`)**
- New `PersonalDetailsSection` component with all required fields: first/last name, DOB (day/month/year + year-visible toggle), international phone (country code + local number), birth location (country + city, optional), and home location (country + city)
- Dirty-state tracking: save button disabled until a field changes; unsaved indicator shown
- Full client-side validation before PATCH: name format (letters/spaces only), DOB calendar validity + minimum age (15), phone via `libphonenumber-js`, home country required
- `ProfileData` in `profile/page.tsx` extended with `personalDetails`; new `'personal'` tab wired in

**Improved: Onboarding step 2 validation**
- Validation now collects **all errors at once** (`string[]`) instead of stopping at the first; every invalid field is highlighted simultaneously
- Name normalization (trim + collapse internal whitespace) applied before validation and reflected in the input on Next click
- Names validated against `/^[\p{L}\s]+$/u` — numbers and special characters are now caught
- DOB error message split: `dobRequired` ("This field is required") vs `dobInvalid` ("Enter a valid date of birth") — no more misleading "required" message when the date simply doesn't exist

**i18n**
- Added `profile.personalDetails.*` keys (heading, field labels, errors, save/saving/success/error) to both `en.json` and `es.json`
- Added `auth.onboarding.validation.invalidDob` to both locales
- Added `profile.tabs.personalDetails` tab label

## Testing

- 35 new unit tests for `PersonalDetailsSection` (rendering, dirty state, PATCH payload, validation, success/error toasts, spinner)
- 8 new unit tests for onboarding page (multi-error display, name character validation, whitespace normalization, simultaneous firstName+lastName+DOB errors)
- All 556 frontend tests pass; coverage above 90% threshold
- Typecheck and lint clean; i18n validation passes

## Notes

`getCallingCode` is imported from `@/components/ui/country-combobox` — the phone country code stored in the API (`+57` format) is reverse-mapped to ISO2 on load so the `CountryCombobox` can be pre-selected correctly.

Closes #114