### PR TITLE
fix(api): support multiple CORS origins via comma-separated CORS_ORIGIN

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -150,7 +150,7 @@ jobs:
             --add-cloudsql-instances=chamuco-app-mn:us-central1:chamuco-postgres \
             --vpc-connector=chamuco-vpc-connector \
             --vpc-egress=private-ranges-only \
-            --set-env-vars=NODE_ENV=production,CORS_ORIGIN=https://chamucotravel.com \
+            --set-env-vars=^|^NODE_ENV=production|CORS_ORIGIN=https://chamucotravel.com,https://www.chamucotravel.com \
             --set-secrets=FIREBASE_SERVICE_ACCOUNT_JSON=FIREBASE_SERVICE_ACCOUNT_JSON:latest \
             --memory=512Mi \
             --cpu=1 \

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -23,8 +23,8 @@ DATABASE_POOL_MIN=2
 DATABASE_POOL_MAX=10
 
 # CORS
-# Restrict API to this origin in production. Unset locally to allow all origins.
-# CORS_ORIGIN=https://chamucotravel.com
+# Comma-separated list of allowed origins in production. Unset locally to allow all origins.
+# CORS_ORIGIN=https://chamucotravel.com,https://www.chamucotravel.com
 
 # Firebase Admin SDK
 # Paste the full content of the service account JSON as a single-line string.

--- a/apps/api/src/config/environment.schema.spec.ts
+++ b/apps/api/src/config/environment.schema.spec.ts
@@ -30,11 +30,20 @@ describe('environment.schema — validate()', () => {
       );
     });
 
-    it('rejects comma-separated URLs (single origin only)', () => {
+    it('accepts comma-separated https URLs', () => {
       expect(() =>
         validate({
           ...baseEnv,
-          CORS_ORIGIN: 'https://chamucotravel.com,https://staging.chamucotravel.com',
+          CORS_ORIGIN: 'https://chamucotravel.com,https://www.chamucotravel.com',
+        }),
+      ).not.toThrow();
+    });
+
+    it('rejects comma-separated URLs where any lacks protocol', () => {
+      expect(() =>
+        validate({
+          ...baseEnv,
+          CORS_ORIGIN: 'https://chamucotravel.com,www.chamucotravel.com',
         }),
       ).toThrow('Environment validation failed');
     });

--- a/apps/api/src/config/environment.schema.ts
+++ b/apps/api/src/config/environment.schema.ts
@@ -6,7 +6,6 @@ import {
   IsBoolean,
   IsOptional,
   IsString,
-  IsUrl,
   Matches,
   Min,
   Max,
@@ -54,7 +53,10 @@ class EnvironmentVariables {
   FIREBASE_SERVICE_ACCOUNT_JSON!: string;
 
   @IsOptional()
-  @IsUrl({ require_protocol: true, require_tld: true })
+  @IsString()
+  @Matches(/^https:\/\/[^\s,]+(,https:\/\/[^\s,]+)*$/, {
+    message: 'CORS_ORIGIN must be one or more comma-separated https URLs',
+  })
   CORS_ORIGIN?: string;
 }
 

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -7,10 +7,11 @@ import { AppModule } from '@/app.module';
 async function bootstrap(): Promise<void> {
   const app = await NestFactory.create(AppModule);
 
-  // Enable CORS — restrict to configured origin in production.
-  // CORS_ORIGIN must be a single URL. Unset locally to allow all origins.
+  // Enable CORS — restrict to configured origins in production.
+  // CORS_ORIGIN is a comma-separated list of https URLs. Unset locally to allow all origins.
   const corsOrigin = process.env.CORS_ORIGIN;
-  app.enableCors(corsOrigin ? { origin: corsOrigin } : undefined);
+  const origins = corsOrigin ? corsOrigin.split(',').map((o) => o.trim()) : undefined;
+  app.enableCors(origins ? { origin: origins } : undefined);
 
   // Global validation pipe
   app.useGlobalPipes(


### PR DESCRIPTION
## Summary

\`CORS_ORIGIN\` previously accepted only a single URL, blocking \`www.chamucotravel.com\` from reaching the API in production. This fix extends it to accept a comma-separated list of \`https://\` URLs so both apex and \`www\` variants can be allowed simultaneously.

A secondary bug was found in the CI deploy command: the comma inside the \`CORS_ORIGIN\` value was being parsed by \`gcloud\` as an env-var delimiter, which would have caused the deployment to fail. Fixed by switching to the \`^|^\` alternate-delimiter syntax.

## Changes

- **\`environment.schema.ts\`** — replaced \`@IsUrl\` with \`@Matches\` regex validating one or more comma-separated \`https://\` URLs; removed unused \`IsUrl\` import
- **\`main.ts\`** — splits \`CORS_ORIGIN\` by comma before passing to \`enableCors\`, so NestJS receives a proper string array
- **\`environment.schema.spec.ts\`** — updated test that previously asserted comma-separated input was rejected; added case for mixed valid/invalid input
- **\`.env.example\`** — updated comment and example value
- **\`api.yml\`** — fixed \`--set-env-vars\` to use \`^|^\` alternate delimiter, preventing \`gcloud\` from misinterpreting the comma in the \`CORS_ORIGIN\` value

## Breaking Changes

None. Existing single-URL values in \`CORS_ORIGIN\` continue to work unchanged.

## Testing

- Unit tests: \`environment.schema.spec.ts\` — 6/6 passing
- Single URL accepted ✓
- Comma-separated URLs accepted ✓
- URL without protocol rejected ✓
- Mixed valid/invalid rejected ✓

## Notes

To enable both origins in production, set:
\`\`\`
CORS_ORIGIN=https://chamucotravel.com,https://www.chamucotravel.com
\`\`\`

The CI workflow (\`api.yml\`) already has this value set with the corrected delimiter.

Closes #187