### PR TITLE
fix(ci): replace ^|^ delimiter with --env-vars-file to fix gcloud deploy

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -142,6 +142,7 @@ jobs:
 
       - name: Deploy to Cloud Run
         run: |
+          printf 'NODE_ENV: production\nCORS_ORIGIN: "https://chamucotravel.com,https://www.chamucotravel.com"\n' > /tmp/env-vars.yaml
           gcloud run deploy ${{ env.SERVICE_NAME }} \
             --image=${{ env.ARTIFACT_REGISTRY }}/api:${{ github.sha }} \
             --region=${{ env.GCP_REGION }} \
@@ -150,7 +151,7 @@ jobs:
             --add-cloudsql-instances=chamuco-app-mn:us-central1:chamuco-postgres \
             --vpc-connector=chamuco-vpc-connector \
             --vpc-egress=private-ranges-only \
-            --set-env-vars=^|^NODE_ENV=production|CORS_ORIGIN=https://chamucotravel.com,https://www.chamucotravel.com \
+            --env-vars-file=/tmp/env-vars.yaml \
             --set-secrets=FIREBASE_SERVICE_ACCOUNT_JSON=FIREBASE_SERVICE_ACCOUNT_JSON:latest \
             --memory=512Mi \
             --cpu=1 \


### PR DESCRIPTION
## Summary

PR #188 introduced `^|^` as an alternate delimiter for `--set-env-vars` to pass a comma-containing `CORS_ORIGIN` value. Bash interprets the `|` as a pipe operator, causing the deploy step to exit with code 127 before gcloud is even called.

## Fix

Write env vars to a temp YAML file via `printf` and pass it to gcloud via `--env-vars-file`. This sidesteps all shell special-character issues cleanly.

## Changes

- **`api.yml`** — adds `printf` to write `/tmp/env-vars.yaml` with `NODE_ENV` and `CORS_ORIGIN`; replaces `--set-env-vars=^|^...` with `--env-vars-file=/tmp/env-vars.yaml`

## Testing

No unit tests — CI workflow change. The fix removes a shell construct that is verifiably broken (confirmed by the failed run). The `--env-vars-file` flag is documented gcloud behavior for values with special characters.

Closes #189