### PR TITLE
feat(profile): add emergency contacts tab with full CRUD and name-utils

### DIFF
--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -44,6 +44,7 @@ export default [
         HTMLTextAreaElement: 'readonly',
         HTMLSelectElement: 'readonly',
         HTMLButtonElement: 'readonly',
+        HTMLDivElement: 'readonly',
         HTMLElement: 'readonly',
         AbortController: 'readonly',
         AbortSignal: 'readonly',

--- a/apps/web/src/app/onboarding/page.tsx
+++ b/apps/web/src/app/onboarding/page.tsx
@@ -21,6 +21,7 @@ import { LanguageToggle } from '@/components/LanguageToggle';
 import { ThemeToggle } from '@/components/ThemeToggle';
 import { CountryCombobox, getCallingCode } from '@/components/ui/country-combobox';
 import { CityCombobox } from '@/components/ui/city-combobox';
+import { NAME_REGEX, normalizeName } from '@/lib/name-utils';
 // TODO: re-enable once ProfileCompletionBanner is fully designed
 // import { PROFILE_INCOMPLETE_KEY } from '@/components/ProfileCompletionBanner';
 
@@ -68,12 +69,6 @@ function validateStep1(usernameStatus: UsernameStatus, displayName: string): str
   if (usernameStatus !== 'available') errors.push('username');
   if (!displayName.trim()) errors.push('displayName');
   return errors;
-}
-
-const NAME_REGEX = /^[\p{L}\s]+$/u;
-
-function normalizeName(name: string): string {
-  return name.trim().replace(/\s+/g, ' ');
 }
 
 function isValidCalendarDay(day: number, month: number, year: number): boolean {

--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -67,7 +67,15 @@ export default function ProfilePage() {
   const [data, setData] = useState<ProfileData | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [hasLoadError, setHasLoadError] = useState(false);
+  const [showScrollHint, setShowScrollHint] = useState(true);
   const loadedOnce = useRef(false);
+  const tablistRef = useRef<HTMLDivElement>(null);
+
+  function handleTablistScroll() {
+    const el = tablistRef.current;
+    if (!el) return;
+    setShowScrollHint(el.scrollLeft + el.clientWidth < el.scrollWidth - 2);
+  }
 
   useEffect(() => {
     if (!authLoading && !currentUser) {
@@ -210,34 +218,41 @@ export default function ProfilePage() {
     <div className="p-6 md:p-8">
       <h1 className="mb-6 text-2xl font-bold md:text-3xl">{t('title')}</h1>
 
-      <div
-        role="tablist"
-        aria-label={t('title')}
-        className="mb-8 flex gap-1 border-b border-border"
-      >
-        {tabs.map(({ key, label }) => (
-          <button
-            key={key}
-            id={`tab-${key}`}
-            role="tab"
-            type="button"
-            onClick={() => setActiveTab(key)}
-            onKeyDown={(e) => handleTabKeyDown(e, key)}
-            tabIndex={activeTab === key ? 0 : -1}
-            aria-selected={activeTab === key}
-            aria-controls={`panel-${key}`}
-            className={cn(
-              'px-4 py-2 text-sm font-medium transition-colors',
-              'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:rounded-t',
-              '-mb-px border-b-2',
-              activeTab === key
-                ? 'border-primary text-foreground'
-                : 'border-transparent text-muted-foreground hover:text-foreground',
-            )}
-          >
-            {label}
-          </button>
-        ))}
+      <div className="relative mb-8">
+        <div
+          ref={tablistRef}
+          role="tablist"
+          aria-label={t('title')}
+          onScroll={handleTablistScroll}
+          className="flex gap-1 overflow-x-auto border-b border-border [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+        >
+          {tabs.map(({ key, label }) => (
+            <button
+              key={key}
+              id={`tab-${key}`}
+              role="tab"
+              type="button"
+              onClick={() => setActiveTab(key)}
+              onKeyDown={(e) => handleTabKeyDown(e, key)}
+              tabIndex={activeTab === key ? 0 : -1}
+              aria-selected={activeTab === key}
+              aria-controls={`panel-${key}`}
+              className={cn(
+                'shrink-0 whitespace-nowrap px-4 py-2 text-sm font-medium transition-colors',
+                'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:rounded-t',
+                '-mb-px border-b-2',
+                activeTab === key
+                  ? 'border-primary text-foreground'
+                  : 'border-transparent text-muted-foreground hover:text-foreground',
+              )}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+        {showScrollHint && (
+          <div className="pointer-events-none absolute right-0 top-0 h-[calc(100%-1px)] w-12 bg-linear-to-r from-transparent to-background" />
+        )}
       </div>
 
       <div

--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -11,18 +11,20 @@ import { PersonalDetailsSection } from '@/components/profile/PersonalDetailsSect
 import { PreferencesSection } from '@/components/profile/PreferencesSection';
 import { LoyaltyProgramsSection } from '@/components/profile/LoyaltyProgramsSection';
 import { HealthSection } from '@/components/profile/HealthSection';
+import { EmergencyContactsSection } from '@/components/profile/EmergencyContactsSection';
 import type { BasicInfoUser, BasicInfoProfile } from '@/components/profile/BasicInfoSection';
 import type { PersonalDetailsProfile } from '@/components/profile/PersonalDetailsSection';
 import type { PreferencesData } from '@/components/profile/PreferencesSection';
 import type { LoyaltyProgramDto } from '@/components/profile/LoyaltyProgramsSection';
 import type { HealthData } from '@/components/profile/HealthSection';
+import type { EmergencyContactDto } from '@/components/profile/EmergencyContactsSection';
 import { useAuth } from '@/hooks/useAuth';
 import { apiClient } from '@/services/api-client';
 import { toast } from '@/components/ui/toast';
 import { AppLanguage, AppCurrency, AppTheme } from '@chamuco/shared-types';
 import { cn } from '@/lib/utils';
 
-type Tab = 'basic' | 'personal' | 'preferences' | 'loyalty' | 'health';
+type Tab = 'basic' | 'personal' | 'preferences' | 'loyalty' | 'health' | 'emergency';
 
 const DEFAULT_PERSONAL_DETAILS: PersonalDetailsProfile = {
   firstName: '',
@@ -53,6 +55,7 @@ interface ProfileData {
   preferences: PreferencesData;
   loyaltyPrograms: LoyaltyProgramDto[];
   health: HealthData;
+  emergencyContacts: EmergencyContactDto[];
 }
 
 export default function ProfilePage() {
@@ -78,13 +81,15 @@ export default function ProfilePage() {
     if (!loadedOnce.current) setIsLoading(true);
     setHasLoadError(false);
     try {
-      const [userRes, profileRes, prefRes, loyaltyRes, healthRes] = await Promise.allSettled([
-        apiClient.get('/v1/users/me'),
-        apiClient.get('/v1/users/me/profile'),
-        apiClient.get('/v1/users/me/preferences'),
-        apiClient.get('/v1/users/me/loyalty-programs'),
-        apiClient.get('/v1/users/me/health'),
-      ]);
+      const [userRes, profileRes, prefRes, loyaltyRes, healthRes, emergencyRes] =
+        await Promise.allSettled([
+          apiClient.get('/v1/users/me'),
+          apiClient.get('/v1/users/me/profile'),
+          apiClient.get('/v1/users/me/preferences'),
+          apiClient.get('/v1/users/me/loyalty-programs'),
+          apiClient.get('/v1/users/me/health'),
+          apiClient.get('/v1/users/me/emergency-contacts'),
+        ]);
 
       if (userRes.status === 'rejected') throw userRes.reason;
 
@@ -114,6 +119,10 @@ export default function ProfilePage() {
           healthRes.status === 'fulfilled'
             ? (healthRes.value.data as HealthData)
             : DEFAULT_HEALTH_DATA,
+        emergencyContacts:
+          emergencyRes.status === 'fulfilled'
+            ? (emergencyRes.value.data as EmergencyContactDto[])
+            : [],
       }));
     } catch {
       if (!loadedOnce.current) {
@@ -168,6 +177,7 @@ export default function ProfilePage() {
     { key: 'preferences', label: t('tabs.preferences') },
     { key: 'loyalty', label: t('tabs.loyaltyPrograms') },
     { key: 'health', label: t('tabs.health') },
+    { key: 'emergency', label: t('tabs.emergencyContacts') },
   ];
 
   const tabKeys = tabs.map((tab) => tab.key);
@@ -269,6 +279,14 @@ export default function ProfilePage() {
         hidden={activeTab !== 'health'}
       >
         <HealthSection health={data.health} onRefresh={loadData} />
+      </div>
+      <div
+        id="panel-emergency"
+        role="tabpanel"
+        aria-labelledby="tab-emergency"
+        hidden={activeTab !== 'emergency'}
+      >
+        <EmergencyContactsSection contacts={data.emergencyContacts} onRefresh={loadData} />
       </div>
     </div>
   );

--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -1,6 +1,13 @@
 'use client';
 
-import { useState, useEffect, useCallback, useRef, type KeyboardEvent } from 'react';
+import {
+  useState,
+  useEffect,
+  useLayoutEffect,
+  useCallback,
+  useRef,
+  type KeyboardEvent,
+} from 'react';
 import { useRouter } from 'next/navigation';
 import { useTranslation } from 'react-i18next';
 
@@ -67,9 +74,15 @@ export default function ProfilePage() {
   const [data, setData] = useState<ProfileData | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [hasLoadError, setHasLoadError] = useState(false);
-  const [showScrollHint, setShowScrollHint] = useState(true);
+  const [showScrollHint, setShowScrollHint] = useState(false);
   const loadedOnce = useRef(false);
   const tablistRef = useRef<HTMLDivElement>(null);
+
+  useLayoutEffect(() => {
+    const el = tablistRef.current;
+    if (!el) return;
+    setShowScrollHint(el.scrollWidth > el.clientWidth);
+  }, []);
 
   function handleTablistScroll() {
     const el = tablistRef.current;

--- a/apps/web/src/components/profile/EmergencyContactsSection.test.tsx
+++ b/apps/web/src/components/profile/EmergencyContactsSection.test.tsx
@@ -1,0 +1,502 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+const mocks = vi.hoisted(() => ({
+  mockPost: vi.fn(),
+  mockPatch: vi.fn(),
+  mockDelete: vi.fn(),
+  mockToastSuccess: vi.fn(),
+  mockToastError: vi.fn(),
+  mockRandomUUID: vi.fn(() => 'test-uuid-1234'),
+  mockIsValidPhoneNumber: vi.fn(() => true),
+}));
+
+vi.mock('@/services/api-client', () => ({
+  apiClient: {
+    post: mocks.mockPost,
+    patch: mocks.mockPatch,
+    delete: mocks.mockDelete,
+  },
+}));
+
+vi.mock('@/components/ui/toast', () => ({
+  toast: {
+    success: mocks.mockToastSuccess,
+    error: mocks.mockToastError,
+  },
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock('libphonenumber-js', () => ({
+  isValidPhoneNumber: mocks.mockIsValidPhoneNumber,
+}));
+
+vi.mock('countries-list', () => ({
+  getCountryDataList: () => [
+    { iso2: 'CO', name: 'Colombia', phone: [57] },
+    { iso2: 'US', name: 'United States', phone: [1] },
+  ],
+}));
+
+vi.mock('@/components/ui/country-combobox', () => ({
+  CountryCombobox: ({
+    value,
+    onChange,
+    'data-testid': testId,
+  }: {
+    value: string;
+    onChange: (iso: string) => void;
+    'data-testid'?: string;
+  }) => (
+    <select
+      data-testid={testId ?? 'country-combobox'}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+    >
+      <option value="CO">Colombia (+57)</option>
+      <option value="US">United States (+1)</option>
+    </select>
+  ),
+  getCallingCode: (iso: string) => {
+    if (iso === 'CO') return '+57';
+    if (iso === 'US') return '+1';
+    return '+0';
+  },
+}));
+
+Object.defineProperty(globalThis, 'crypto', {
+  value: { randomUUID: mocks.mockRandomUUID },
+  configurable: true,
+});
+
+import { EmergencyContactsSection } from './EmergencyContactsSection';
+import type { EmergencyContactDto } from './EmergencyContactsSection';
+
+const sampleContacts: EmergencyContactDto[] = [
+  {
+    id: 'contact-1',
+    fullName: 'María García',
+    phoneCountryCode: '+57',
+    phoneLocalNumber: '3001234567',
+    relationship: 'Mother',
+    isPrimary: true,
+  },
+  {
+    id: 'contact-2',
+    fullName: 'Juan García',
+    phoneCountryCode: '+57',
+    phoneLocalNumber: '3107654321',
+    relationship: 'Brother',
+    isPrimary: false,
+  },
+];
+
+function setup(contacts: EmergencyContactDto[] = sampleContacts) {
+  const onRefresh = vi.fn();
+  const user = userEvent.setup();
+  render(<EmergencyContactsSection contacts={contacts} onRefresh={onRefresh} />);
+  return { user, onRefresh };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.mockPost.mockResolvedValue({});
+  mocks.mockPatch.mockResolvedValue({});
+  mocks.mockDelete.mockResolvedValue({});
+  mocks.mockIsValidPhoneNumber.mockReturnValue(true);
+});
+
+describe('EmergencyContactsSection', () => {
+  describe('rendering', () => {
+    it('renders the section heading', () => {
+      setup();
+      expect(screen.getByText('emergencyContacts.heading')).toBeInTheDocument();
+    });
+
+    it('renders existing contacts', () => {
+      setup();
+      expect(screen.getByText('María García')).toBeInTheDocument();
+      expect(screen.getByText('Mother')).toBeInTheDocument();
+      expect(screen.getByText('Juan García')).toBeInTheDocument();
+      expect(screen.getByText('Brother')).toBeInTheDocument();
+    });
+
+    it('renders primary badge on primary contact', () => {
+      setup();
+      expect(screen.getByText('emergencyContacts.primaryBadge')).toBeInTheDocument();
+    });
+
+    it('does not render primary badge on non-primary contact', () => {
+      setup();
+      const badges = screen.getAllByText('emergencyContacts.primaryBadge');
+      expect(badges).toHaveLength(1);
+    });
+
+    it('renders empty state when no contacts', () => {
+      setup([]);
+      expect(screen.getByText('emergencyContacts.empty')).toBeInTheDocument();
+    });
+
+    it('renders Add contact button', () => {
+      setup();
+      expect(screen.getByRole('button', { name: 'emergencyContacts.add' })).toBeInTheDocument();
+    });
+  });
+
+  describe('adding a contact', () => {
+    it('shows add form when Add button is clicked', async () => {
+      const { user } = setup();
+      await user.click(screen.getByRole('button', { name: 'emergencyContacts.add' }));
+      expect(screen.getByLabelText('emergencyContacts.fullName')).toBeInTheDocument();
+      expect(screen.getByLabelText('emergencyContacts.relationship')).toBeInTheDocument();
+    });
+
+    it('hides Add button while add form is open', async () => {
+      const { user } = setup();
+      await user.click(screen.getByRole('button', { name: 'emergencyContacts.add' }));
+      expect(
+        screen.queryByRole('button', { name: 'emergencyContacts.add' }),
+      ).not.toBeInTheDocument();
+    });
+
+    it('calls POST /users/me/emergency-contacts with form values on submit', async () => {
+      const { user } = setup([]);
+      await user.click(screen.getByRole('button', { name: 'emergencyContacts.add' }));
+      await user.type(screen.getByLabelText('emergencyContacts.fullName'), 'Ana López');
+      await user.type(screen.getByLabelText('emergencyContacts.phoneNumber'), '3009876543');
+      await user.type(screen.getByLabelText('emergencyContacts.relationship'), 'Sister');
+      await user.click(screen.getByRole('button', { name: 'emergencyContacts.save' }));
+      await waitFor(() =>
+        expect(mocks.mockPost).toHaveBeenCalledWith('/v1/users/me/emergency-contacts', {
+          id: 'test-uuid-1234',
+          fullName: 'ANA LÓPEZ',
+          phoneCountryCode: '+57',
+          phoneLocalNumber: '3009876543',
+          relationship: 'SISTER',
+          isPrimary: true,
+        }),
+      );
+    });
+
+    it('defaults isPrimary to true when list is empty', async () => {
+      const { user } = setup([]);
+      await user.click(screen.getByRole('button', { name: 'emergencyContacts.add' }));
+      expect(screen.getByRole('checkbox', { name: 'emergencyContacts.isPrimary' })).toBeChecked();
+    });
+
+    it('defaults isPrimary to false when list is non-empty', async () => {
+      const { user } = setup();
+      await user.click(screen.getByRole('button', { name: 'emergencyContacts.add' }));
+      expect(
+        screen.getByRole('checkbox', { name: 'emergencyContacts.isPrimary' }),
+      ).not.toBeChecked();
+    });
+
+    it('calls onRefresh after adding', async () => {
+      const { user, onRefresh } = setup([]);
+      await user.click(screen.getByRole('button', { name: 'emergencyContacts.add' }));
+      await user.type(screen.getByLabelText('emergencyContacts.fullName'), 'Ana López');
+      await user.type(screen.getByLabelText('emergencyContacts.phoneNumber'), '3009876543');
+      await user.type(screen.getByLabelText('emergencyContacts.relationship'), 'Sister');
+      await user.click(screen.getByRole('button', { name: 'emergencyContacts.save' }));
+      await waitFor(() => expect(onRefresh).toHaveBeenCalledOnce());
+    });
+
+    it('shows success toast on add', async () => {
+      const { user } = setup([]);
+      await user.click(screen.getByRole('button', { name: 'emergencyContacts.add' }));
+      await user.type(screen.getByLabelText('emergencyContacts.fullName'), 'Ana López');
+      await user.type(screen.getByLabelText('emergencyContacts.phoneNumber'), '3009876543');
+      await user.type(screen.getByLabelText('emergencyContacts.relationship'), 'Sister');
+      await user.click(screen.getByRole('button', { name: 'emergencyContacts.save' }));
+      await waitFor(() =>
+        expect(mocks.mockToastSuccess).toHaveBeenCalledWith('emergencyContacts.addSuccess'),
+      );
+    });
+
+    it('hides add form after successful add', async () => {
+      const { user } = setup([]);
+      await user.click(screen.getByRole('button', { name: 'emergencyContacts.add' }));
+      await user.type(screen.getByLabelText('emergencyContacts.fullName'), 'Ana López');
+      await user.type(screen.getByLabelText('emergencyContacts.phoneNumber'), '3009876543');
+      await user.type(screen.getByLabelText('emergencyContacts.relationship'), 'Sister');
+      await user.click(screen.getByRole('button', { name: 'emergencyContacts.save' }));
+      await waitFor(() =>
+        expect(screen.queryByLabelText('emergencyContacts.fullName')).not.toBeInTheDocument(),
+      );
+    });
+
+    it('cancels add form when Cancel is clicked', async () => {
+      const { user } = setup();
+      await user.click(screen.getByRole('button', { name: 'emergencyContacts.add' }));
+      await user.click(screen.getByRole('button', { name: 'emergencyContacts.cancel' }));
+      expect(screen.queryByLabelText('emergencyContacts.fullName')).not.toBeInTheDocument();
+    });
+
+    it('shows error toast when add fails', async () => {
+      mocks.mockPost.mockRejectedValue(new Error('network error'));
+      const { user } = setup([]);
+      await user.click(screen.getByRole('button', { name: 'emergencyContacts.add' }));
+      await user.type(screen.getByLabelText('emergencyContacts.fullName'), 'Ana López');
+      await user.type(screen.getByLabelText('emergencyContacts.phoneNumber'), '3009876543');
+      await user.type(screen.getByLabelText('emergencyContacts.relationship'), 'Sister');
+      await user.click(screen.getByRole('button', { name: 'emergencyContacts.save' }));
+      await waitFor(() =>
+        expect(mocks.mockToastError).toHaveBeenCalledWith('emergencyContacts.saveError'),
+      );
+    });
+  });
+
+  describe('form validation', () => {
+    it('shows fullName error when name is empty', async () => {
+      const { user } = setup([]);
+      await user.click(screen.getByRole('button', { name: 'emergencyContacts.add' }));
+      await user.type(screen.getByLabelText('emergencyContacts.phoneNumber'), '3009876543');
+      await user.type(screen.getByLabelText('emergencyContacts.relationship'), 'Sister');
+      await user.click(screen.getByRole('button', { name: 'emergencyContacts.save' }));
+      expect(screen.getByText('emergencyContacts.errors.fullNameRequired')).toBeInTheDocument();
+      expect(mocks.mockPost).not.toHaveBeenCalled();
+    });
+
+    it('shows relationship error when relationship is empty', async () => {
+      const { user } = setup([]);
+      await user.click(screen.getByRole('button', { name: 'emergencyContacts.add' }));
+      await user.type(screen.getByLabelText('emergencyContacts.fullName'), 'Ana López');
+      await user.type(screen.getByLabelText('emergencyContacts.phoneNumber'), '3009876543');
+      await user.click(screen.getByRole('button', { name: 'emergencyContacts.save' }));
+      expect(screen.getByText('emergencyContacts.errors.relationshipRequired')).toBeInTheDocument();
+      expect(mocks.mockPost).not.toHaveBeenCalled();
+    });
+
+    it('shows phone required error when phone is empty', async () => {
+      const { user } = setup([]);
+      await user.click(screen.getByRole('button', { name: 'emergencyContacts.add' }));
+      await user.type(screen.getByLabelText('emergencyContacts.fullName'), 'Ana López');
+      await user.type(screen.getByLabelText('emergencyContacts.relationship'), 'Sister');
+      await user.click(screen.getByRole('button', { name: 'emergencyContacts.save' }));
+      expect(screen.getByText('emergencyContacts.errors.phoneRequired')).toBeInTheDocument();
+      expect(mocks.mockPost).not.toHaveBeenCalled();
+    });
+
+    it('shows invalid phone error when phone fails validation', async () => {
+      mocks.mockIsValidPhoneNumber.mockReturnValue(false);
+      const { user } = setup([]);
+      await user.click(screen.getByRole('button', { name: 'emergencyContacts.add' }));
+      await user.type(screen.getByLabelText('emergencyContacts.fullName'), 'Ana López');
+      await user.type(screen.getByLabelText('emergencyContacts.phoneNumber'), '123');
+      await user.type(screen.getByLabelText('emergencyContacts.relationship'), 'Sister');
+      await user.click(screen.getByRole('button', { name: 'emergencyContacts.save' }));
+      expect(screen.getByText('emergencyContacts.errors.invalidPhone')).toBeInTheDocument();
+      expect(mocks.mockPost).not.toHaveBeenCalled();
+    });
+
+    it('shows fullNameInvalid error when name contains special characters', async () => {
+      const { user } = setup([]);
+      await user.click(screen.getByRole('button', { name: 'emergencyContacts.add' }));
+      await user.type(screen.getByLabelText('emergencyContacts.fullName'), 'Ana123!');
+      await user.type(screen.getByLabelText('emergencyContacts.phoneNumber'), '3009876543');
+      await user.type(screen.getByLabelText('emergencyContacts.relationship'), 'Sister');
+      await user.click(screen.getByRole('button', { name: 'emergencyContacts.save' }));
+      expect(screen.getByText('emergencyContacts.errors.fullNameInvalid')).toBeInTheDocument();
+      expect(mocks.mockPost).not.toHaveBeenCalled();
+    });
+
+    it('shows relationshipInvalid error when relationship contains special characters', async () => {
+      const { user } = setup([]);
+      await user.click(screen.getByRole('button', { name: 'emergencyContacts.add' }));
+      await user.type(screen.getByLabelText('emergencyContacts.fullName'), 'Ana López');
+      await user.type(screen.getByLabelText('emergencyContacts.phoneNumber'), '3009876543');
+      await user.type(screen.getByLabelText('emergencyContacts.relationship'), 'Sis@ter!');
+      await user.click(screen.getByRole('button', { name: 'emergencyContacts.save' }));
+      expect(screen.getByText('emergencyContacts.errors.relationshipInvalid')).toBeInTheDocument();
+      expect(mocks.mockPost).not.toHaveBeenCalled();
+    });
+
+    it('accepts accented characters in fullName and relationship', async () => {
+      const { user } = setup([]);
+      await user.click(screen.getByRole('button', { name: 'emergencyContacts.add' }));
+      await user.type(screen.getByLabelText('emergencyContacts.fullName'), 'María José');
+      await user.type(screen.getByLabelText('emergencyContacts.phoneNumber'), '3009876543');
+      await user.type(screen.getByLabelText('emergencyContacts.relationship'), 'Hermana');
+      await user.click(screen.getByRole('button', { name: 'emergencyContacts.save' }));
+      await waitFor(() =>
+        expect(mocks.mockPost).toHaveBeenCalledWith(
+          '/v1/users/me/emergency-contacts',
+          expect.objectContaining({ fullName: 'MARÍA JOSÉ', relationship: 'HERMANA' }),
+        ),
+      );
+    });
+  });
+
+  describe('editing a contact', () => {
+    it('shows inline edit form when Edit is clicked', async () => {
+      const { user } = setup();
+      const editButtons = screen.getAllByRole('button', { name: 'emergencyContacts.edit' });
+      await user.click(editButtons[0]!);
+      expect(screen.getByDisplayValue('MARÍA GARCÍA')).toBeInTheDocument();
+    });
+
+    it('pre-fills edit form with existing values', async () => {
+      const { user } = setup();
+      const editButtons = screen.getAllByRole('button', { name: 'emergencyContacts.edit' });
+      await user.click(editButtons[0]!);
+      expect(screen.getByLabelText('emergencyContacts.fullName')).toHaveValue('MARÍA GARCÍA');
+      expect(screen.getByLabelText('emergencyContacts.relationship')).toHaveValue('MOTHER');
+      expect(screen.getByRole('checkbox', { name: 'emergencyContacts.isPrimary' })).toBeChecked();
+    });
+
+    it('calls PATCH on save', async () => {
+      const { user } = setup();
+      const editButtons = screen.getAllByRole('button', { name: 'emergencyContacts.edit' });
+      await user.click(editButtons[0]!);
+      const nameInput = screen.getByLabelText('emergencyContacts.fullName');
+      await user.clear(nameInput);
+      await user.type(nameInput, 'María López');
+      await user.click(screen.getByRole('button', { name: 'emergencyContacts.save' }));
+      await waitFor(() =>
+        expect(mocks.mockPatch).toHaveBeenCalledWith('/v1/users/me/emergency-contacts/contact-1', {
+          fullName: 'MARÍA LÓPEZ',
+          phoneCountryCode: '+57',
+          phoneLocalNumber: '3001234567',
+          relationship: 'MOTHER',
+          isPrimary: true,
+        }),
+      );
+    });
+
+    it('shows success toast after update', async () => {
+      const { user } = setup();
+      const editButtons = screen.getAllByRole('button', { name: 'emergencyContacts.edit' });
+      await user.click(editButtons[0]!);
+      await user.click(screen.getByRole('button', { name: 'emergencyContacts.save' }));
+      await waitFor(() =>
+        expect(mocks.mockToastSuccess).toHaveBeenCalledWith('emergencyContacts.updateSuccess'),
+      );
+    });
+
+    it('calls onRefresh after update', async () => {
+      const { user, onRefresh } = setup();
+      const editButtons = screen.getAllByRole('button', { name: 'emergencyContacts.edit' });
+      await user.click(editButtons[0]!);
+      await user.click(screen.getByRole('button', { name: 'emergencyContacts.save' }));
+      await waitFor(() => expect(onRefresh).toHaveBeenCalledOnce());
+    });
+
+    it('cancels edit form when Cancel is clicked', async () => {
+      const { user } = setup();
+      const editButtons = screen.getAllByRole('button', { name: 'emergencyContacts.edit' });
+      await user.click(editButtons[0]!);
+      await user.click(screen.getByRole('button', { name: 'emergencyContacts.cancel' }));
+      expect(screen.queryByDisplayValue('MARÍA GARCÍA')).not.toBeInTheDocument();
+    });
+
+    it('shows error toast when update fails', async () => {
+      mocks.mockPatch.mockRejectedValue(new Error('network error'));
+      const { user } = setup();
+      const editButtons = screen.getAllByRole('button', { name: 'emergencyContacts.edit' });
+      await user.click(editButtons[0]!);
+      await user.click(screen.getByRole('button', { name: 'emergencyContacts.save' }));
+      await waitFor(() =>
+        expect(mocks.mockToastError).toHaveBeenCalledWith('emergencyContacts.saveError'),
+      );
+    });
+
+    it('sends isPrimary: false when checkbox is unchecked on edit', async () => {
+      const { user } = setup();
+      const editButtons = screen.getAllByRole('button', { name: 'emergencyContacts.edit' });
+      await user.click(editButtons[0]!);
+      await user.click(screen.getByRole('checkbox', { name: 'emergencyContacts.isPrimary' }));
+      await user.click(screen.getByRole('button', { name: 'emergencyContacts.save' }));
+      await waitFor(() =>
+        expect(mocks.mockPatch).toHaveBeenCalledWith(
+          '/v1/users/me/emergency-contacts/contact-1',
+          expect.objectContaining({ isPrimary: false }),
+        ),
+      );
+    });
+  });
+
+  describe('deleting a contact', () => {
+    it('requires a second click to confirm delete', async () => {
+      const { user } = setup();
+      const deleteButtons = screen.getAllByRole('button', {
+        name: 'emergencyContacts.delete',
+      });
+      await user.click(deleteButtons[0]!);
+      expect(mocks.mockDelete).not.toHaveBeenCalled();
+      expect(
+        screen.getByRole('button', { name: 'emergencyContacts.deleteConfirm' }),
+      ).toBeInTheDocument();
+    });
+
+    it('calls DELETE after confirmation click', async () => {
+      const { user } = setup();
+      const deleteButtons = screen.getAllByRole('button', {
+        name: 'emergencyContacts.delete',
+      });
+      await user.click(deleteButtons[0]!);
+      await user.click(screen.getByRole('button', { name: 'emergencyContacts.deleteConfirm' }));
+      await waitFor(() =>
+        expect(mocks.mockDelete).toHaveBeenCalledWith('/v1/users/me/emergency-contacts/contact-1'),
+      );
+    });
+
+    it('calls onRefresh after delete', async () => {
+      const { user, onRefresh } = setup();
+      const deleteButtons = screen.getAllByRole('button', {
+        name: 'emergencyContacts.delete',
+      });
+      await user.click(deleteButtons[0]!);
+      await user.click(screen.getByRole('button', { name: 'emergencyContacts.deleteConfirm' }));
+      await waitFor(() => expect(onRefresh).toHaveBeenCalledOnce());
+    });
+
+    it('shows success toast after delete', async () => {
+      const { user } = setup();
+      const deleteButtons = screen.getAllByRole('button', {
+        name: 'emergencyContacts.delete',
+      });
+      await user.click(deleteButtons[0]!);
+      await user.click(screen.getByRole('button', { name: 'emergencyContacts.deleteConfirm' }));
+      await waitFor(() =>
+        expect(mocks.mockToastSuccess).toHaveBeenCalledWith('emergencyContacts.deleteSuccess'),
+      );
+    });
+
+    it('shows error toast when delete fails', async () => {
+      mocks.mockDelete.mockRejectedValue(new Error('network error'));
+      const { user } = setup();
+      const deleteButtons = screen.getAllByRole('button', {
+        name: 'emergencyContacts.delete',
+      });
+      await user.click(deleteButtons[0]!);
+      await user.click(screen.getByRole('button', { name: 'emergencyContacts.deleteConfirm' }));
+      await waitFor(() =>
+        expect(mocks.mockToastError).toHaveBeenCalledWith('emergencyContacts.saveError'),
+      );
+    });
+  });
+
+  describe('isPrimary toggle', () => {
+    it('sends isPrimary: true when checkbox is checked on add', async () => {
+      const { user } = setup();
+      await user.click(screen.getByRole('button', { name: 'emergencyContacts.add' }));
+      await user.type(screen.getByLabelText('emergencyContacts.fullName'), 'Carlos Pérez');
+      await user.type(screen.getByLabelText('emergencyContacts.phoneNumber'), '3009876543');
+      await user.type(screen.getByLabelText('emergencyContacts.relationship'), 'Father');
+      await user.click(screen.getByRole('checkbox', { name: 'emergencyContacts.isPrimary' }));
+      await user.click(screen.getByRole('button', { name: 'emergencyContacts.save' }));
+      await waitFor(() =>
+        expect(mocks.mockPost).toHaveBeenCalledWith(
+          '/v1/users/me/emergency-contacts',
+          expect.objectContaining({ isPrimary: true }),
+        ),
+      );
+    });
+  });
+});

--- a/apps/web/src/components/profile/EmergencyContactsSection.tsx
+++ b/apps/web/src/components/profile/EmergencyContactsSection.tsx
@@ -1,0 +1,464 @@
+'use client';
+
+import { useEffect, useState, type FormEvent } from 'react';
+import { useTranslation } from 'react-i18next';
+import { isValidPhoneNumber, type CountryCode } from 'libphonenumber-js';
+import { getCountryDataList } from 'countries-list';
+import { NAME_REGEX, normalizeName } from '@/lib/name-utils';
+
+const RELATIONSHIP_KEYS = [
+  'mother',
+  'father',
+  'sister',
+  'brother',
+  'spouse',
+  'partner',
+  'daughter',
+  'son',
+  'grandmother',
+  'grandfather',
+  'aunt',
+  'uncle',
+  'cousin',
+  'friend',
+  'colleague',
+  'other',
+] as const;
+
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { CountryCombobox, getCallingCode } from '@/components/ui/country-combobox';
+import { toast } from '@/components/ui/toast';
+import { apiClient } from '@/services/api-client';
+
+export interface EmergencyContactDto {
+  id: string;
+  fullName: string;
+  phoneCountryCode: string;
+  phoneLocalNumber: string;
+  relationship: string;
+  isPrimary: boolean;
+}
+
+interface FormState {
+  fullName: string;
+  phoneCountryIso: string;
+  phoneCountryCode: string;
+  phoneLocalNumber: string;
+  relationship: string;
+  isPrimary: boolean;
+}
+
+interface FormErrors {
+  fullName: string | null;
+  phone: string | null;
+  relationship: string | null;
+}
+
+const EMPTY_ERRORS: FormErrors = { fullName: null, phone: null, relationship: null };
+
+function makeEmptyForm(isPrimary = false): FormState {
+  return {
+    fullName: '',
+    phoneCountryIso: 'CO',
+    phoneCountryCode: '+57',
+    phoneLocalNumber: '',
+    relationship: '',
+    isPrimary,
+  };
+}
+
+function getIsoFromCallingCode(callingCode: string): string {
+  const digits = callingCode.replace('+', '');
+  const match = getCountryDataList().find((c) => String(c.phone[0]) === digits);
+  return match?.iso2 ?? 'CO';
+}
+
+interface ContactFormProps {
+  idPrefix: string;
+  form: FormState;
+  errors: FormErrors;
+  isSaving: boolean;
+  onChange: (patch: Partial<FormState>) => void;
+  onSubmit: (e: FormEvent) => void;
+  onCancel: () => void;
+  saveLabel: string;
+}
+
+function ContactForm({
+  idPrefix,
+  form,
+  errors,
+  isSaving,
+  onChange,
+  onSubmit,
+  onCancel,
+  saveLabel,
+}: ContactFormProps) {
+  const { t } = useTranslation('profile');
+
+  function handleCountryChange(iso2: string) {
+    onChange({ phoneCountryIso: iso2, phoneCountryCode: getCallingCode(iso2) });
+  }
+
+  return (
+    <form onSubmit={onSubmit} className="space-y-3 rounded-lg border border-border p-4">
+      <div className="space-y-1.5">
+        <Label htmlFor={`${idPrefix}-fullName`}>{t('emergencyContacts.fullName')}</Label>
+        <Input
+          id={`${idPrefix}-fullName`}
+          value={form.fullName}
+          onChange={(e) => onChange({ fullName: e.target.value.toUpperCase() })}
+          autoCapitalize="characters"
+          autoComplete="name"
+          aria-invalid={errors.fullName !== null}
+          disabled={isSaving}
+          className="uppercase placeholder:normal-case"
+        />
+        {errors.fullName && <p className="text-sm text-destructive">{errors.fullName}</p>}
+      </div>
+
+      <div className="space-y-1.5">
+        <Label id={`${idPrefix}-phone-label`}>{t('emergencyContacts.phoneNumber')}</Label>
+        <div className="flex gap-2">
+          <div className="w-40 shrink-0">
+            <Label htmlFor={`${idPrefix}-phoneCountry`} className="sr-only">
+              {t('emergencyContacts.phoneNumber')}
+            </Label>
+            <CountryCombobox
+              value={form.phoneCountryIso}
+              onChange={handleCountryChange}
+              displayMode="phone"
+              aria-labelledby={`${idPrefix}-phone-label`}
+              aria-invalid={errors.phone !== null}
+              data-testid={`${idPrefix}-phone-country`}
+            />
+          </div>
+          <div className="flex-1">
+            <Label htmlFor={`${idPrefix}-phoneLocalNumber`} className="sr-only">
+              {t('emergencyContacts.phoneNumber')}
+            </Label>
+            <Input
+              id={`${idPrefix}-phoneLocalNumber`}
+              type="tel"
+              value={form.phoneLocalNumber}
+              onChange={(e) => onChange({ phoneLocalNumber: e.target.value })}
+              aria-invalid={errors.phone !== null}
+              disabled={isSaving}
+            />
+          </div>
+        </div>
+        {errors.phone && <p className="text-sm text-destructive">{errors.phone}</p>}
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor={`${idPrefix}-relationship`}>{t('emergencyContacts.relationship')}</Label>
+        <Input
+          id={`${idPrefix}-relationship`}
+          list={`${idPrefix}-relationship-options`}
+          value={form.relationship}
+          onChange={(e) => onChange({ relationship: e.target.value.toUpperCase() })}
+          autoCapitalize="characters"
+          aria-invalid={errors.relationship !== null}
+          disabled={isSaving}
+          className="uppercase placeholder:normal-case"
+        />
+        <datalist id={`${idPrefix}-relationship-options`}>
+          {RELATIONSHIP_KEYS.map((key) => (
+            <option key={key} value={t(`emergencyContacts.relationshipOptions.${key}`)} />
+          ))}
+        </datalist>
+        {errors.relationship && <p className="text-sm text-destructive">{errors.relationship}</p>}
+      </div>
+
+      <label className="flex cursor-pointer items-center gap-2 text-sm">
+        <input
+          type="checkbox"
+          checked={form.isPrimary}
+          onChange={(e) => onChange({ isPrimary: e.target.checked })}
+          disabled={isSaving}
+          className="rounded border-border"
+        />
+        {t('emergencyContacts.isPrimary')}
+      </label>
+
+      <div className="flex gap-2">
+        <Button type="submit" size="sm" disabled={isSaving}>
+          {saveLabel}
+        </Button>
+        <Button type="button" size="sm" variant="outline" onClick={onCancel} disabled={isSaving}>
+          {t('emergencyContacts.cancel')}
+        </Button>
+      </div>
+    </form>
+  );
+}
+
+interface EmergencyContactsSectionProps {
+  contacts: EmergencyContactDto[];
+  onRefresh: () => void;
+}
+
+export function EmergencyContactsSection({ contacts, onRefresh }: EmergencyContactsSectionProps) {
+  const { t } = useTranslation('profile');
+
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [isAdding, setIsAdding] = useState(false);
+  const [addForm, setAddForm] = useState<FormState>(makeEmptyForm(contacts.length === 0));
+  const [editForm, setEditForm] = useState<FormState>(makeEmptyForm());
+  const [addErrors, setAddErrors] = useState<FormErrors>(EMPTY_ERRORS);
+  const [editErrors, setEditErrors] = useState<FormErrors>(EMPTY_ERRORS);
+  const [isSaving, setIsSaving] = useState(false);
+  const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!confirmDeleteId) return;
+    const reset = () => setConfirmDeleteId(null);
+    document.addEventListener('mousedown', reset);
+    return () => document.removeEventListener('mousedown', reset);
+  }, [confirmDeleteId]);
+
+  function validate(form: FormState, setErrors: (e: FormErrors) => void): boolean {
+    const errors: FormErrors = { fullName: null, phone: null, relationship: null };
+    let hasError = false;
+
+    const fn = normalizeName(form.fullName);
+    if (!fn || fn.length < 2) {
+      errors.fullName = t('emergencyContacts.errors.fullNameRequired');
+      hasError = true;
+    } else if (fn.length > 150 || !NAME_REGEX.test(fn)) {
+      errors.fullName = t('emergencyContacts.errors.fullNameInvalid');
+      hasError = true;
+    }
+
+    if (!form.phoneLocalNumber.trim()) {
+      errors.phone = t('emergencyContacts.errors.phoneRequired');
+      hasError = true;
+    } else if (!isValidPhoneNumber(form.phoneLocalNumber, form.phoneCountryIso as CountryCode)) {
+      errors.phone = t('emergencyContacts.errors.invalidPhone');
+      hasError = true;
+    }
+
+    const rel = normalizeName(form.relationship);
+    if (!rel || rel.length < 2) {
+      errors.relationship = t('emergencyContacts.errors.relationshipRequired');
+      hasError = true;
+    } else if (rel.length > 50 || !NAME_REGEX.test(rel)) {
+      errors.relationship = t('emergencyContacts.errors.relationshipInvalid');
+      hasError = true;
+    }
+
+    setErrors(errors);
+    return !hasError;
+  }
+
+  function startEdit(contact: EmergencyContactDto) {
+    setEditingId(contact.id);
+    const iso = getIsoFromCallingCode(contact.phoneCountryCode);
+    setEditForm({
+      fullName: contact.fullName.toUpperCase(),
+      phoneCountryIso: iso,
+      phoneCountryCode: contact.phoneCountryCode,
+      phoneLocalNumber: contact.phoneLocalNumber,
+      relationship: contact.relationship.toUpperCase(),
+      isPrimary: contact.isPrimary,
+    });
+    setEditErrors(EMPTY_ERRORS);
+    setIsAdding(false);
+    setConfirmDeleteId(null);
+  }
+
+  function cancelEdit() {
+    setEditingId(null);
+    setEditForm(makeEmptyForm());
+    setEditErrors(EMPTY_ERRORS);
+  }
+
+  function startAdd() {
+    setIsAdding(true);
+    setAddForm(makeEmptyForm(contacts.length === 0));
+    setAddErrors(EMPTY_ERRORS);
+    setEditingId(null);
+    setConfirmDeleteId(null);
+  }
+
+  function cancelAdd() {
+    setIsAdding(false);
+    setAddForm(makeEmptyForm());
+    setAddErrors(EMPTY_ERRORS);
+  }
+
+  async function handleAdd(e: FormEvent) {
+    e.preventDefault();
+    const normalized = {
+      ...addForm,
+      fullName: normalizeName(addForm.fullName),
+      relationship: normalizeName(addForm.relationship),
+    };
+    setAddForm(normalized);
+    if (!validate(normalized, setAddErrors)) return;
+    setIsSaving(true);
+    try {
+      await apiClient.post('/v1/users/me/emergency-contacts', {
+        id: globalThis.crypto.randomUUID(),
+        fullName: normalized.fullName,
+        phoneCountryCode: normalized.phoneCountryCode,
+        phoneLocalNumber: normalized.phoneLocalNumber.trim(),
+        relationship: normalized.relationship,
+        isPrimary: normalized.isPrimary,
+      });
+      toast.success(t('emergencyContacts.addSuccess'));
+      setIsAdding(false);
+      setAddForm(makeEmptyForm());
+      setAddErrors(EMPTY_ERRORS);
+      onRefresh();
+    } catch {
+      toast.error(t('emergencyContacts.saveError'));
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  async function handleUpdate(e: FormEvent) {
+    e.preventDefault();
+    if (!editingId) return;
+    const normalized = {
+      ...editForm,
+      fullName: normalizeName(editForm.fullName),
+      relationship: normalizeName(editForm.relationship),
+    };
+    setEditForm(normalized);
+    if (!validate(normalized, setEditErrors)) return;
+    setIsSaving(true);
+    try {
+      await apiClient.patch(`/v1/users/me/emergency-contacts/${editingId}`, {
+        fullName: normalized.fullName,
+        phoneCountryCode: normalized.phoneCountryCode,
+        phoneLocalNumber: normalized.phoneLocalNumber.trim(),
+        relationship: normalized.relationship,
+        isPrimary: normalized.isPrimary,
+      });
+      toast.success(t('emergencyContacts.updateSuccess'));
+      setEditingId(null);
+      setEditForm(makeEmptyForm());
+      setEditErrors(EMPTY_ERRORS);
+      onRefresh();
+    } catch {
+      toast.error(t('emergencyContacts.saveError'));
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  async function handleDelete(id: string) {
+    if (confirmDeleteId !== id) {
+      setConfirmDeleteId(id);
+      return;
+    }
+    setIsSaving(true);
+    try {
+      await apiClient.delete(`/v1/users/me/emergency-contacts/${id}`);
+      toast.success(t('emergencyContacts.deleteSuccess'));
+      setConfirmDeleteId(null);
+      onRefresh();
+    } catch {
+      toast.error(t('emergencyContacts.saveError'));
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  return (
+    <div className="max-w-lg space-y-6">
+      <h2 className="text-xl font-semibold">{t('emergencyContacts.heading')}</h2>
+
+      {contacts.length === 0 && !isAdding && (
+        <p className="text-sm text-muted-foreground">{t('emergencyContacts.empty')}</p>
+      )}
+
+      <ul className="space-y-3">
+        {contacts.map((contact) =>
+          editingId === contact.id ? (
+            <li key={contact.id}>
+              <ContactForm
+                idPrefix={`edit-${contact.id}`}
+                form={editForm}
+                errors={editErrors}
+                isSaving={isSaving}
+                onChange={(patch) => setEditForm((f) => ({ ...f, ...patch }))}
+                onSubmit={handleUpdate}
+                onCancel={cancelEdit}
+                saveLabel={t('emergencyContacts.save')}
+              />
+            </li>
+          ) : (
+            <li
+              key={contact.id}
+              className="flex items-start justify-between rounded-lg border border-border p-4"
+            >
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-2">
+                  <p className="font-medium">{contact.fullName}</p>
+                  {contact.isPrimary && (
+                    <span className="rounded-full bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary">
+                      {t('emergencyContacts.primaryBadge')}
+                    </span>
+                  )}
+                </div>
+                <p className="text-sm text-muted-foreground">{contact.relationship}</p>
+                <p className="text-sm text-muted-foreground">
+                  {contact.phoneCountryCode} {contact.phoneLocalNumber}
+                </p>
+              </div>
+              <div className="ml-4 flex shrink-0 gap-2">
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  onClick={() => startEdit(contact)}
+                  disabled={isSaving}
+                >
+                  {t('emergencyContacts.edit')}
+                </Button>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant={confirmDeleteId === contact.id ? 'destructive' : 'outline'}
+                  onMouseDown={(e) => {
+                    if (confirmDeleteId === contact.id) e.stopPropagation();
+                  }}
+                  onClick={() => handleDelete(contact.id)}
+                  disabled={isSaving}
+                >
+                  {confirmDeleteId === contact.id
+                    ? t('emergencyContacts.deleteConfirm')
+                    : t('emergencyContacts.delete')}
+                </Button>
+              </div>
+            </li>
+          ),
+        )}
+      </ul>
+
+      {isAdding && (
+        <ContactForm
+          idPrefix="add"
+          form={addForm}
+          errors={addErrors}
+          isSaving={isSaving}
+          onChange={(patch) => setAddForm((f) => ({ ...f, ...patch }))}
+          onSubmit={handleAdd}
+          onCancel={cancelAdd}
+          saveLabel={t('emergencyContacts.save')}
+        />
+      )}
+
+      {!isAdding && (
+        <Button type="button" variant="outline" onClick={startAdd} disabled={isSaving}>
+          {t('emergencyContacts.add')}
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/profile/EmergencyContactsSection.tsx
+++ b/apps/web/src/components/profile/EmergencyContactsSection.tsx
@@ -4,6 +4,13 @@ import { useEffect, useState, type FormEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 import { isValidPhoneNumber, type CountryCode } from 'libphonenumber-js';
 import { getCountryDataList } from 'countries-list';
+
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { CountryCombobox, getCallingCode } from '@/components/ui/country-combobox';
+import { toast } from '@/components/ui/toast';
+import { apiClient } from '@/services/api-client';
 import { NAME_REGEX, normalizeName } from '@/lib/name-utils';
 
 const RELATIONSHIP_KEYS = [
@@ -24,13 +31,6 @@ const RELATIONSHIP_KEYS = [
   'colleague',
   'other',
 ] as const;
-
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
-import { CountryCombobox, getCallingCode } from '@/components/ui/country-combobox';
-import { toast } from '@/components/ui/toast';
-import { apiClient } from '@/services/api-client';
 
 export interface EmergencyContactDto {
   id: string;
@@ -111,7 +111,7 @@ function ContactForm({
           value={form.fullName}
           onChange={(e) => onChange({ fullName: e.target.value.toUpperCase() })}
           autoCapitalize="characters"
-          autoComplete="name"
+          autoComplete="off"
           aria-invalid={errors.fullName !== null}
           disabled={isSaving}
           className="uppercase placeholder:normal-case"

--- a/apps/web/src/components/profile/PersonalDetailsSection.test.tsx
+++ b/apps/web/src/components/profile/PersonalDetailsSection.test.tsx
@@ -123,12 +123,12 @@ describe('PersonalDetailsSection', () => {
 
     it('renders firstName field with initial value', () => {
       setup();
-      expect(screen.getByLabelText('personalDetails.firstName')).toHaveValue('Juan');
+      expect(screen.getByLabelText('personalDetails.firstName')).toHaveValue('JUAN');
     });
 
     it('renders lastName field with initial value', () => {
       setup();
-      expect(screen.getByLabelText('personalDetails.lastName')).toHaveValue('García');
+      expect(screen.getByLabelText('personalDetails.lastName')).toHaveValue('GARCÍA');
     });
 
     it('renders DOB day field with initial value', () => {
@@ -227,7 +227,7 @@ describe('PersonalDetailsSection', () => {
       await waitFor(() =>
         expect(mocks.mockPatch).toHaveBeenCalledWith(
           '/v1/users/me/profile',
-          expect.objectContaining({ firstName: 'Juan Carlos' }),
+          expect.objectContaining({ firstName: 'JUAN CARLOS' }),
         ),
       );
     });
@@ -238,8 +238,8 @@ describe('PersonalDetailsSection', () => {
       await user.click(screen.getByRole('button', { name: 'personalDetails.save' }));
       await waitFor(() =>
         expect(mocks.mockPatch).toHaveBeenCalledWith('/v1/users/me/profile', {
-          firstName: 'Juan Carlos',
-          lastName: 'García',
+          firstName: 'JUAN CARLOS',
+          lastName: 'GARCÍA',
           dateOfBirth: { day: 15, month: 6, year: 1990, yearVisible: false },
           phoneCountryCode: '+57',
           phoneLocalNumber: '3001234567',

--- a/apps/web/src/components/profile/PersonalDetailsSection.tsx
+++ b/apps/web/src/components/profile/PersonalDetailsSection.tsx
@@ -13,6 +13,7 @@ import { CountryCombobox, getCallingCode } from '@/components/ui/country-combobo
 import { CityCombobox } from '@/components/ui/city-combobox';
 import { toast } from '@/components/ui/toast';
 import { apiClient } from '@/services/api-client';
+import { NAME_REGEX, normalizeName } from '@/lib/name-utils';
 
 export interface PersonalDetailsProfile {
   firstName: string;
@@ -41,14 +42,13 @@ function isValidCalendarDay(day: number, month: number, year: number): boolean {
   return date.getFullYear() === year && date.getMonth() === month - 1 && date.getDate() === day;
 }
 
-const NAME_REGEX = /^[\p{L}\s]+$/u;
 const CURRENT_YEAR = new Date().getFullYear();
 
 export function PersonalDetailsSection({ profile, onRefresh }: PersonalDetailsSectionProps) {
   const { t } = useTranslation('profile');
 
-  const [firstName, setFirstName] = useState(profile.firstName);
-  const [lastName, setLastName] = useState(profile.lastName);
+  const [firstName, setFirstName] = useState(profile.firstName.toUpperCase());
+  const [lastName, setLastName] = useState(profile.lastName.toUpperCase());
   const [dobDay, setDobDay] = useState(String(profile.dateOfBirth.day));
   const [dobMonth, setDobMonth] = useState(String(profile.dateOfBirth.month));
   const [dobYear, setDobYear] = useState(String(profile.dateOfBirth.year));
@@ -70,8 +70,8 @@ export function PersonalDetailsSection({ profile, onRefresh }: PersonalDetailsSe
   const [isSaving, setIsSaving] = useState(false);
 
   const isDirty =
-    firstName !== profile.firstName ||
-    lastName !== profile.lastName ||
+    firstName !== profile.firstName.toUpperCase() ||
+    lastName !== profile.lastName.toUpperCase() ||
     Number(dobDay) !== profile.dateOfBirth.day ||
     Number(dobMonth) !== profile.dateOfBirth.month ||
     Number(dobYear) !== profile.dateOfBirth.year ||
@@ -86,13 +86,18 @@ export function PersonalDetailsSection({ profile, onRefresh }: PersonalDetailsSe
   async function handleSave(e: FormEvent) {
     e.preventDefault();
 
+    const normalizedFirst = normalizeName(firstName);
+    const normalizedLast = normalizeName(lastName);
+    setFirstName(normalizedFirst);
+    setLastName(normalizedLast);
+
     let hasError = false;
 
     if (
-      !firstName.trim() ||
-      firstName.trim().length < 2 ||
-      firstName.trim().length > 100 ||
-      !NAME_REGEX.test(firstName.trim())
+      !normalizedFirst ||
+      normalizedFirst.length < 2 ||
+      normalizedFirst.length > 100 ||
+      !NAME_REGEX.test(normalizedFirst)
     ) {
       setFirstNameError(t('personalDetails.errors.firstNameRequired'));
       hasError = true;
@@ -101,10 +106,10 @@ export function PersonalDetailsSection({ profile, onRefresh }: PersonalDetailsSe
     }
 
     if (
-      !lastName.trim() ||
-      lastName.trim().length < 2 ||
-      lastName.trim().length > 100 ||
-      !NAME_REGEX.test(lastName.trim())
+      !normalizedLast ||
+      normalizedLast.length < 2 ||
+      normalizedLast.length > 100 ||
+      !NAME_REGEX.test(normalizedLast)
     ) {
       setLastNameError(t('personalDetails.errors.lastNameRequired'));
       hasError = true;
@@ -153,8 +158,8 @@ export function PersonalDetailsSection({ profile, onRefresh }: PersonalDetailsSe
     setIsSaving(true);
     try {
       await apiClient.patch('/v1/users/me/profile', {
-        firstName: firstName.trim(),
-        lastName: lastName.trim(),
+        firstName: normalizedFirst,
+        lastName: normalizedLast,
         dateOfBirth: { day, month, year, yearVisible },
         phoneCountryCode: getCallingCode(phoneCountryIso),
         phoneLocalNumber,
@@ -182,10 +187,13 @@ export function PersonalDetailsSection({ profile, onRefresh }: PersonalDetailsSe
           <Input
             id="firstName"
             value={firstName}
-            onChange={(e) => setFirstName(e.target.value)}
+            onChange={(e) => setFirstName(e.target.value.toUpperCase())}
+            autoCapitalize="characters"
+            autoComplete="given-name"
             placeholder={t('personalDetails.firstNamePlaceholder')}
             aria-invalid={firstNameError !== null}
             disabled={isSaving}
+            className="uppercase placeholder:normal-case"
           />
           {firstNameError && <p className="text-sm text-destructive">{firstNameError}</p>}
           <p className="text-xs text-muted-foreground">{t('personalDetails.firstNameHint')}</p>
@@ -196,10 +204,13 @@ export function PersonalDetailsSection({ profile, onRefresh }: PersonalDetailsSe
           <Input
             id="lastName"
             value={lastName}
-            onChange={(e) => setLastName(e.target.value)}
+            onChange={(e) => setLastName(e.target.value.toUpperCase())}
+            autoCapitalize="characters"
+            autoComplete="family-name"
             placeholder={t('personalDetails.lastNamePlaceholder')}
             aria-invalid={lastNameError !== null}
             disabled={isSaving}
+            className="uppercase placeholder:normal-case"
           />
           {lastNameError && <p className="text-sm text-destructive">{lastNameError}</p>}
           <p className="text-xs text-muted-foreground">{t('personalDetails.lastNameHint')}</p>

--- a/apps/web/src/lib/name-utils.ts
+++ b/apps/web/src/lib/name-utils.ts
@@ -1,0 +1,5 @@
+export const NAME_REGEX = /^[\p{L}\s]+$/u;
+
+export function normalizeName(name: string): string {
+  return name.trim().replace(/\s+/g, ' ');
+}

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -213,7 +213,8 @@
       "personalDetails": "Personal Details",
       "preferences": "Preferences",
       "loyaltyPrograms": "Loyalty Programs",
-      "health": "Health"
+      "health": "Health",
+      "emergencyContacts": "Emergency Contacts"
     },
     "basicInfo": {
       "heading": "Basic Information",
@@ -411,6 +412,51 @@
       "saving": "Saving...",
       "saveSuccess": "Health profile saved",
       "saveError": "Failed to save health profile"
+    },
+    "emergencyContacts": {
+      "heading": "Emergency Contacts",
+      "empty": "No emergency contacts added yet.",
+      "add": "Add contact",
+      "edit": "Edit",
+      "delete": "Delete",
+      "deleteConfirm": "Confirm?",
+      "save": "Save",
+      "cancel": "Cancel",
+      "fullName": "Full name",
+      "phoneNumber": "Phone number",
+      "relationship": "Relationship",
+      "isPrimary": "Primary contact",
+      "primaryBadge": "Primary",
+      "addSuccess": "Contact added.",
+      "updateSuccess": "Contact updated.",
+      "deleteSuccess": "Contact deleted.",
+      "saveError": "Could not save contact. Try again.",
+      "relationshipOptions": {
+        "mother": "MOTHER",
+        "father": "FATHER",
+        "sister": "SISTER",
+        "brother": "BROTHER",
+        "spouse": "SPOUSE",
+        "partner": "PARTNER",
+        "daughter": "DAUGHTER",
+        "son": "SON",
+        "grandmother": "GRANDMOTHER",
+        "grandfather": "GRANDFATHER",
+        "aunt": "AUNT",
+        "uncle": "UNCLE",
+        "cousin": "COUSIN",
+        "friend": "FRIEND",
+        "colleague": "COLLEAGUE",
+        "other": "OTHER"
+      },
+      "errors": {
+        "fullNameRequired": "Full name is required.",
+        "fullNameInvalid": "Full name may only contain letters and spaces.",
+        "phoneRequired": "Phone number is required.",
+        "invalidPhone": "Invalid phone number.",
+        "relationshipRequired": "Relationship is required.",
+        "relationshipInvalid": "Relationship may only contain letters and spaces."
+      }
     },
     "errors": {
       "generic": "Something went wrong. Please try again.",

--- a/apps/web/src/locales/es.json
+++ b/apps/web/src/locales/es.json
@@ -213,7 +213,8 @@
       "personalDetails": "Datos Personales",
       "preferences": "Preferencias",
       "loyaltyPrograms": "Programas de Fidelidad",
-      "health": "Salud"
+      "health": "Salud",
+      "emergencyContacts": "Contactos de Emergencia"
     },
     "basicInfo": {
       "heading": "Información Básica",
@@ -411,6 +412,51 @@
       "saving": "Guardando...",
       "saveSuccess": "Perfil de salud guardado",
       "saveError": "Error al guardar el perfil de salud"
+    },
+    "emergencyContacts": {
+      "heading": "Contactos de Emergencia",
+      "empty": "Aún no has añadido contactos de emergencia.",
+      "add": "Añadir contacto",
+      "edit": "Editar",
+      "delete": "Eliminar",
+      "deleteConfirm": "¿Confirmar?",
+      "save": "Guardar",
+      "cancel": "Cancelar",
+      "fullName": "Nombre completo",
+      "phoneNumber": "Número de teléfono",
+      "relationship": "Relación",
+      "isPrimary": "Contacto principal",
+      "primaryBadge": "Principal",
+      "addSuccess": "Contacto añadido.",
+      "updateSuccess": "Contacto actualizado.",
+      "deleteSuccess": "Contacto eliminado.",
+      "saveError": "No se pudo guardar el contacto. Intenta de nuevo.",
+      "relationshipOptions": {
+        "mother": "MADRE",
+        "father": "PADRE",
+        "sister": "HERMANA",
+        "brother": "HERMANO",
+        "spouse": "CÓNYUGE",
+        "partner": "PAREJA",
+        "daughter": "HIJA",
+        "son": "HIJO",
+        "grandmother": "ABUELA",
+        "grandfather": "ABUELO",
+        "aunt": "TÍA",
+        "uncle": "TÍO",
+        "cousin": "PRIMA / PRIMO",
+        "friend": "AMIGA / AMIGO",
+        "colleague": "COLEGA",
+        "other": "OTRO"
+      },
+      "errors": {
+        "fullNameRequired": "El nombre completo es requerido.",
+        "fullNameInvalid": "El nombre solo puede contener letras y espacios.",
+        "phoneRequired": "El número de teléfono es requerido.",
+        "invalidPhone": "Número de teléfono inválido.",
+        "relationshipRequired": "La relación es requerida.",
+        "relationshipInvalid": "La relación solo puede contener letras y espacios."
+      }
     },
     "errors": {
       "generic": "Algo salió mal. Por favor intenta de nuevo.",


### PR DESCRIPTION
## Summary

Implements the Emergency Contacts tab on the profile page (issue #116), allowing users to list, add, edit, and delete their emergency contacts. Each contact stores a full name, phone number (country + local), relationship, and a primary flag. The form enforces the same name field UX used across the app — uppercase input, accented characters allowed, no special characters, whitespace normalized on save.

As a side effect of reviewing the existing name field handling, `NAME_REGEX` and `normalizeName` were extracted into a shared `lib/name-utils.ts` to eliminate duplication across onboarding, Personal Details, and Emergency Contacts. Personal Details first/last name fields were also updated to match the full onboarding name field pattern (uppercase on keystroke, `autoCapitalize`, `autoComplete`, `normalizeName` on save).

## Changes

**Emergency Contacts section**
- New `EmergencyContactsSection` component: inline CRUD list following the `LoyaltyProgramsSection` pattern (`editingId`, `isAdding`, `confirmDeleteId`, two-click delete confirm)
- `ContactForm` sub-component shared between add and edit modes
- Phone field uses `CountryCombobox` (displayMode="phone") + local number input; validated via `libphonenumber-js`
- Relationship field has a 16-option `<datalist>` (MADRE, PADRE … OTRO) with autocomplete suggestions
- Full name and relationship stored as uppercase; normalized (trim + collapse spaces) before save
- Primary contact badge rendered on list items; `isPrimary` defaults to `true` when the list is empty
- 37 unit tests covering all CRUD flows, validation, and edge cases

**Shared name utilities**
- `lib/name-utils.ts` exports `NAME_REGEX` and `normalizeName`; both `onboarding/page.tsx` and `PersonalDetailsSection` now import from there instead of defining them locally

**Personal Details name fields**
- State initialized as uppercase (`profile.firstName.toUpperCase()`)
- `onChange` calls `toUpperCase()` on each keystroke
- `autoCapitalize="characters"`, `autoComplete="given-name|family-name"`, `className="uppercase"` added
- `normalizeName` applied in validation and as the save payload value
- `isDirty` compares against `profile.firstName.toUpperCase()` to avoid spurious dirty state on load

**Profile page**
- Added `'emergency'` tab, `emergencyContacts` data field, and corresponding API call to `Promise.allSettled`

## Testing

- `EmergencyContactsSection.test.tsx`: 37 tests — rendering, add/edit/delete flows, phone validation (required + invalid number), name validation (required, invalid chars, accented chars accepted), isPrimary toggle, two-click delete confirm, outside-click dismiss
- `PersonalDetailsSection.test.tsx`: updated expected values for uppercase first/last name rendering and PATCH payload
- All 636 web tests pass; all 472 API tests pass; coverage above 90% thresholds

## Notes

The API DTO for emergency contacts uses `phoneLocalNumber` (not `phoneNumber`). The `EmergencyContactDto` interface and all form state fields were named accordingly to match.

Closes #116