### PR TITLE
feat(profile): add nationalities & travel documents tab

### DIFF
--- a/apps/api/src/database/migrations/0008_numerous_spot.sql
+++ b/apps/api/src/database/migrations/0008_numerous_spot.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "user_nationalities" ADD CONSTRAINT "national_id_number_format" CHECK ("user_nationalities"."national_id_number" IS NULL OR "user_nationalities"."national_id_number" ~ '^[A-Z0-9-]+$');
+ALTER TABLE "user_nationalities" ADD CONSTRAINT "passport_number_format" CHECK ("user_nationalities"."passport_number" IS NULL OR "user_nationalities"."passport_number" ~ '^[A-Z0-9-]+$');

--- a/apps/api/src/database/migrations/meta/0008_snapshot.json
+++ b/apps/api/src/database/migrations/meta/0008_snapshot.json
@@ -1,0 +1,722 @@
+{
+  "id": "8b1464e8-903e-424a-aef8-94b3af5fcc25",
+  "prevId": "95f954ec-c8c7-4196-8d9e-314ef8796e45",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_provider": {
+          "name": "auth_provider",
+          "type": "auth_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "firebase_uid": {
+          "name": "firebase_uid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "platform_role": {
+          "name": "platform_role",
+          "type": "platform_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'USER'"
+        },
+        "profile_visibility": {
+          "name": "profile_visibility",
+          "type": "profile_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PRIVATE'"
+        },
+        "agency_id": {
+          "name": "agency_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        },
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": ["username"]
+        },
+        "users_firebase_uid_unique": {
+          "name": "users_firebase_uid_unique",
+          "nullsNotDistinct": false,
+          "columns": ["firebase_uid"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "users_username_format": {
+          "name": "users_username_format",
+          "value": "\"users\".\"username\" ~ '^[a-z0-9_-]{3,30}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_preferences": {
+      "name": "user_preferences",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "app_language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ES'"
+        },
+        "currency": {
+          "name": "currency",
+          "type": "app_currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'COP'"
+        },
+        "theme": {
+          "name": "theme",
+          "type": "app_theme",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'SYSTEM'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_preferences_user_id_users_id_fk": {
+          "name": "user_preferences_user_id_users_id_fk",
+          "tableFrom": "user_preferences",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_profiles": {
+      "name": "user_profiles",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_of_birth": {
+          "name": "date_of_birth",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "birth_country": {
+          "name": "birth_country",
+          "type": "char(2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "birth_city": {
+          "name": "birth_city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "home_country": {
+          "name": "home_country",
+          "type": "char(2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "home_city": {
+          "name": "home_city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone_country_code": {
+          "name": "phone_country_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone_local_number": {
+          "name": "phone_local_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bio": {
+          "name": "bio",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dietary_preference": {
+          "name": "dietary_preference",
+          "type": "dietary_preference",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'OMNIVORE'"
+        },
+        "dietary_notes": {
+          "name": "dietary_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "general_medical_notes": {
+          "name": "general_medical_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "food_allergies": {
+          "name": "food_allergies",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "phobias": {
+          "name": "phobias",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "physical_limitations": {
+          "name": "physical_limitations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "medical_conditions": {
+          "name": "medical_conditions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "emergency_contacts": {
+          "name": "emergency_contacts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "loyalty_programs": {
+          "name": "loyalty_programs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_profiles_user_id_users_id_fk": {
+          "name": "user_profiles_user_id_users_id_fk",
+          "tableFrom": "user_profiles",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_nationalities": {
+      "name": "user_nationalities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country_code": {
+          "name": "country_code",
+          "type": "char(2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "national_id_number": {
+          "name": "national_id_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "passport_number": {
+          "name": "passport_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "passport_issue_date": {
+          "name": "passport_issue_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "passport_expiry_date": {
+          "name": "passport_expiry_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "passport_status": {
+          "name": "passport_status",
+          "type": "passport_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_nationalities_user_id_idx": {
+          "name": "user_nationalities_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_nationalities_one_primary_per_user": {
+          "name": "user_nationalities_one_primary_per_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"user_nationalities\".\"is_primary\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_nationalities_user_id_users_id_fk": {
+          "name": "user_nationalities_user_id_users_id_fk",
+          "tableFrom": "user_nationalities",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_nationalities_user_id_country_code_unique": {
+          "name": "user_nationalities_user_id_country_code_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id", "country_code"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "passport_data_consistency": {
+          "name": "passport_data_consistency",
+          "value": "(\"user_nationalities\".\"passport_status\" = 'OMITTED'\n        AND \"user_nationalities\".\"passport_number\" IS NULL\n        AND \"user_nationalities\".\"passport_issue_date\" IS NULL\n        AND \"user_nationalities\".\"passport_expiry_date\" IS NULL)\n      OR\n      (\"user_nationalities\".\"passport_status\" <> 'OMITTED'\n        AND \"user_nationalities\".\"passport_number\" IS NOT NULL\n        AND \"user_nationalities\".\"passport_issue_date\" IS NOT NULL\n        AND \"user_nationalities\".\"passport_expiry_date\" IS NOT NULL)"
+        },
+        "national_id_number_format": {
+          "name": "national_id_number_format",
+          "value": "\"user_nationalities\".\"national_id_number\" IS NULL OR \"user_nationalities\".\"national_id_number\" ~ '^[A-Z0-9-]+$'"
+        },
+        "passport_number_format": {
+          "name": "passport_number_format",
+          "value": "\"user_nationalities\".\"passport_number\" IS NULL OR \"user_nationalities\".\"passport_number\" ~ '^[A-Z0-9-]+$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.support_admin_audit_log": {
+      "name": "support_admin_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "admin_user_id": {
+          "name": "admin_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_table": {
+          "name": "target_table",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "before_state": {
+          "name": "before_state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "after_state": {
+          "name": "after_state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "performed_at": {
+          "name": "performed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "support_admin_audit_log_admin_user_id_idx": {
+          "name": "support_admin_audit_log_admin_user_id_idx",
+          "columns": [
+            {
+              "expression": "admin_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "support_admin_audit_log_performed_at_idx": {
+          "name": "support_admin_audit_log_performed_at_idx",
+          "columns": [
+            {
+              "expression": "performed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "support_admin_audit_log_admin_user_id_users_id_fk": {
+          "name": "support_admin_audit_log_admin_user_id_users_id_fk",
+          "tableFrom": "support_admin_audit_log",
+          "tableTo": "users",
+          "columnsFrom": ["admin_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.auth_provider": {
+      "name": "auth_provider",
+      "schema": "public",
+      "values": ["GOOGLE", "FACEBOOK"]
+    },
+    "public.platform_role": {
+      "name": "platform_role",
+      "schema": "public",
+      "values": ["USER", "SUPPORT_ADMIN"]
+    },
+    "public.profile_visibility": {
+      "name": "profile_visibility",
+      "schema": "public",
+      "values": ["PRIVATE", "CONNECTIONS_ONLY", "MEMBERS_ONLY", "PUBLIC"]
+    },
+    "public.app_currency": {
+      "name": "app_currency",
+      "schema": "public",
+      "values": ["COP", "USD"]
+    },
+    "public.app_language": {
+      "name": "app_language",
+      "schema": "public",
+      "values": ["ES", "EN"]
+    },
+    "public.app_theme": {
+      "name": "app_theme",
+      "schema": "public",
+      "values": ["LIGHT", "DARK", "SYSTEM"]
+    },
+    "public.dietary_preference": {
+      "name": "dietary_preference",
+      "schema": "public",
+      "values": ["OMNIVORE", "VEGETARIAN", "VEGAN", "PESCATARIAN", "GLUTEN_FREE", "OTHER"]
+    },
+    "public.food_allergen": {
+      "name": "food_allergen",
+      "schema": "public",
+      "values": [
+        "GLUTEN",
+        "CRUSTACEANS",
+        "EGGS",
+        "FISH",
+        "PEANUTS",
+        "SOYBEANS",
+        "MILK",
+        "TREE_NUTS",
+        "CELERY",
+        "MUSTARD",
+        "SESAME",
+        "SULPHITES",
+        "LUPIN",
+        "MOLLUSCS",
+        "OTHER"
+      ]
+    },
+    "public.medical_condition_type": {
+      "name": "medical_condition_type",
+      "schema": "public",
+      "values": [
+        "DIABETES",
+        "EPILEPSY",
+        "SEVERE_ALLERGY_EPIPEN",
+        "ASTHMA",
+        "HEART_CONDITION",
+        "HYPERTENSION",
+        "BLOOD_CLOTTING_DISORDER",
+        "IMMUNODEFICIENCY",
+        "MENTAL_HEALTH_CONDITION",
+        "OTHER"
+      ]
+    },
+    "public.phobia_type": {
+      "name": "phobia_type",
+      "schema": "public",
+      "values": [
+        "HEIGHTS",
+        "ENCLOSED_SPACES",
+        "FLYING",
+        "DEEP_WATER",
+        "OPEN_WATER",
+        "ANIMALS",
+        "INSECTS",
+        "SNAKES",
+        "SPIDERS",
+        "DARKNESS",
+        "CROWDS",
+        "MOTION_SICKNESS",
+        "OTHER"
+      ]
+    },
+    "public.physical_limitation_type": {
+      "name": "physical_limitation_type",
+      "schema": "public",
+      "values": [
+        "WHEELCHAIR_USER",
+        "REDUCED_MOBILITY",
+        "CANNOT_USE_STAIRS",
+        "HEARING_IMPAIRMENT",
+        "VISUAL_IMPAIRMENT",
+        "REQUIRES_OXYGEN",
+        "REQUIRES_CPAP",
+        "CHRONIC_PAIN",
+        "JOINT_CONDITION",
+        "CARDIAC_CONDITION",
+        "RESPIRATORY_CONDITION",
+        "PREGNANCY",
+        "OTHER"
+      ]
+    },
+    "public.passport_status": {
+      "name": "passport_status",
+      "schema": "public",
+      "values": ["OMITTED", "ACTIVE", "EXPIRING_SOON", "EXPIRED"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/src/database/migrations/meta/_journal.json
+++ b/apps/api/src/database/migrations/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1776653280008,
       "tag": "0007_fast_carlie_cooper",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1776869616730,
+      "tag": "0008_numerous_spot",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/modules/users/dto/nationality.dto.spec.ts
+++ b/apps/api/src/modules/users/dto/nationality.dto.spec.ts
@@ -42,6 +42,24 @@ describe('CreateNationalityDto', () => {
     expect(errors.some((e) => e.property === 'nationalIdNumber')).toBe(true);
   });
 
+  it('rejects nationalIdNumber with lowercase letters', async () => {
+    const dto = plainToInstance(CreateNationalityDto, { ...validBase, nationalIdNumber: 'abc123' });
+    const errors = await validate(dto);
+    expect(errors.some((e) => e.property === 'nationalIdNumber')).toBe(true);
+  });
+
+  it('rejects nationalIdNumber with spaces', async () => {
+    const dto = plainToInstance(CreateNationalityDto, { ...validBase, nationalIdNumber: 'AB 123' });
+    const errors = await validate(dto);
+    expect(errors.some((e) => e.property === 'nationalIdNumber')).toBe(true);
+  });
+
+  it('accepts nationalIdNumber with hyphens', async () => {
+    const dto = plainToInstance(CreateNationalityDto, { ...validBase, nationalIdNumber: 'AB-123' });
+    const errors = await validate(dto);
+    expect(errors.some((e) => e.property === 'nationalIdNumber')).toBe(false);
+  });
+
   it('rejects countryCode with more than 2 letters', async () => {
     const dto = plainToInstance(CreateNationalityDto, { ...validBase, countryCode: 'COL' });
     const errors = await validate(dto);
@@ -144,6 +162,36 @@ describe('CreateNationalityDto', () => {
       const errors = await validate(dto);
       expect(errors.some((e) => e.property === 'passportNumber')).toBe(true);
     });
+
+    it('rejects passportNumber with lowercase letters', async () => {
+      const dto = plainToInstance(CreateNationalityDto, {
+        ...validBase,
+        ...validPassport,
+        passportNumber: 'ab123456',
+      });
+      const errors = await validate(dto);
+      expect(errors.some((e) => e.property === 'passportNumber')).toBe(true);
+    });
+
+    it('rejects passportNumber with spaces', async () => {
+      const dto = plainToInstance(CreateNationalityDto, {
+        ...validBase,
+        ...validPassport,
+        passportNumber: 'AB 123456',
+      });
+      const errors = await validate(dto);
+      expect(errors.some((e) => e.property === 'passportNumber')).toBe(true);
+    });
+
+    it('accepts passportNumber with hyphens', async () => {
+      const dto = plainToInstance(CreateNationalityDto, {
+        ...validBase,
+        ...validPassport,
+        passportNumber: 'AB-123456',
+      });
+      const errors = await validate(dto);
+      expect(errors.some((e) => e.property === 'passportNumber')).toBe(false);
+    });
   });
 });
 
@@ -184,6 +232,24 @@ describe('UpdateNationalityDto', () => {
     expect(errors.some((e) => e.property === 'nationalIdNumber')).toBe(true);
   });
 
+  it('rejects nationalIdNumber with lowercase letters', async () => {
+    const dto = plainToInstance(UpdateNationalityDto, { nationalIdNumber: 'abc123' });
+    const errors = await validate(dto);
+    expect(errors.some((e) => e.property === 'nationalIdNumber')).toBe(true);
+  });
+
+  it('rejects nationalIdNumber with spaces', async () => {
+    const dto = plainToInstance(UpdateNationalityDto, { nationalIdNumber: 'AB 123' });
+    const errors = await validate(dto);
+    expect(errors.some((e) => e.property === 'nationalIdNumber')).toBe(true);
+  });
+
+  it('accepts nationalIdNumber with hyphens', async () => {
+    const dto = plainToInstance(UpdateNationalityDto, { nationalIdNumber: 'AB-123' });
+    const errors = await validate(dto);
+    expect(errors.some((e) => e.property === 'nationalIdNumber')).toBe(false);
+  });
+
   describe('passport data consistency', () => {
     it('requires all three passport fields when only one is provided', async () => {
       const dto = plainToInstance(UpdateNationalityDto, { passportNumber: 'AB123456' });
@@ -202,6 +268,33 @@ describe('UpdateNationalityDto', () => {
       const dto = plainToInstance(UpdateNationalityDto, { isPrimary: false });
       const errors = await validate(dto);
       expect(errors).toHaveLength(0);
+    });
+
+    it('rejects passportNumber with lowercase letters', async () => {
+      const dto = plainToInstance(UpdateNationalityDto, {
+        ...validPassport,
+        passportNumber: 'ab123456',
+      });
+      const errors = await validate(dto);
+      expect(errors.some((e) => e.property === 'passportNumber')).toBe(true);
+    });
+
+    it('rejects passportNumber with spaces', async () => {
+      const dto = plainToInstance(UpdateNationalityDto, {
+        ...validPassport,
+        passportNumber: 'AB 123456',
+      });
+      const errors = await validate(dto);
+      expect(errors.some((e) => e.property === 'passportNumber')).toBe(true);
+    });
+
+    it('accepts passportNumber with hyphens', async () => {
+      const dto = plainToInstance(UpdateNationalityDto, {
+        ...validPassport,
+        passportNumber: 'AB-123456',
+      });
+      const errors = await validate(dto);
+      expect(errors.some((e) => e.property === 'passportNumber')).toBe(false);
     });
   });
 });

--- a/apps/api/src/modules/users/dto/nationality.dto.ts
+++ b/apps/api/src/modules/users/dto/nationality.dto.ts
@@ -77,24 +77,32 @@ export class CreateNationalityDto {
 
   @ApiProperty({
     example: '12345678',
-    description: 'National ID / Cédula / DNI. Omit or set null to leave empty.',
+    description:
+      'National ID / Cédula / DNI. Omit or set null to leave empty. Only uppercase letters, numbers, and hyphens allowed.',
     nullable: true,
     required: false,
   })
   @IsOptional()
   @IsString()
   @IsNotEmpty({ message: 'nationalIdNumber must not be an empty string' })
+  @Matches(/^[A-Z0-9-]+$/, {
+    message: 'nationalIdNumber must contain only uppercase letters, numbers, and hyphens',
+  })
   nationalIdNumber?: string | null;
 
   @ApiProperty({
     example: 'AB123456',
-    description: 'Passport document number. Required when any passport field is provided.',
+    description:
+      'Passport document number. Required when any passport field is provided. Only uppercase letters, numbers, and hyphens allowed.',
     required: false,
   })
   @ValidateIf(anyPassportFieldPresent)
   @IsDefined({ message: 'passportNumber is required when any passport field is provided' })
   @IsString()
   @IsNotEmpty({ message: 'passportNumber must not be an empty string' })
+  @Matches(/^[A-Z0-9-]+$/, {
+    message: 'passportNumber must contain only uppercase letters, numbers, and hyphens',
+  })
   passportNumber?: string;
 
   @ApiProperty({
@@ -131,24 +139,32 @@ export class UpdateNationalityDto {
 
   @ApiProperty({
     example: '12345678',
-    description: 'National ID / Cédula / DNI. Omit to leave unchanged.',
+    description:
+      'National ID / Cédula / DNI. Omit to leave unchanged. Only uppercase letters, numbers, and hyphens allowed.',
     nullable: true,
     required: false,
   })
   @IsOptional()
   @IsString()
   @IsNotEmpty({ message: 'nationalIdNumber must not be an empty string' })
+  @Matches(/^[A-Z0-9-]+$/, {
+    message: 'nationalIdNumber must contain only uppercase letters, numbers, and hyphens',
+  })
   nationalIdNumber?: string | null;
 
   @ApiProperty({
     example: 'AB123456',
-    description: 'Passport document number. Required when any passport field is provided.',
+    description:
+      'Passport document number. Required when any passport field is provided. Only uppercase letters, numbers, and hyphens allowed.',
     required: false,
   })
   @ValidateIf(anyPassportFieldPresent)
   @IsDefined({ message: 'passportNumber is required when any passport field is provided' })
   @IsString()
   @IsNotEmpty({ message: 'passportNumber must not be an empty string' })
+  @Matches(/^[A-Z0-9-]+$/, {
+    message: 'passportNumber must contain only uppercase letters, numbers, and hyphens',
+  })
   passportNumber?: string;
 
   @ApiProperty({

--- a/apps/api/src/modules/users/schema/user-nationalities.schema.ts
+++ b/apps/api/src/modules/users/schema/user-nationalities.schema.ts
@@ -58,5 +58,13 @@ export const userNationalities = pgTable(
         AND ${table.passportIssueDate} IS NOT NULL
         AND ${table.passportExpiryDate} IS NOT NULL)`,
     ),
+    check(
+      'national_id_number_format',
+      sql`${table.nationalIdNumber} IS NULL OR ${table.nationalIdNumber} ~ '^[A-Z0-9-]+$'`,
+    ),
+    check(
+      'passport_number_format',
+      sql`${table.passportNumber} IS NULL OR ${table.passportNumber} ~ '^[A-Z0-9-]+$'`,
+    ),
   ],
 );

--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -19,19 +19,28 @@ import { PreferencesSection } from '@/components/profile/PreferencesSection';
 import { LoyaltyProgramsSection } from '@/components/profile/LoyaltyProgramsSection';
 import { HealthSection } from '@/components/profile/HealthSection';
 import { EmergencyContactsSection } from '@/components/profile/EmergencyContactsSection';
+import { NationalitiesSection } from '@/components/profile/NationalitiesSection';
 import type { BasicInfoUser, BasicInfoProfile } from '@/components/profile/BasicInfoSection';
 import type { PersonalDetailsProfile } from '@/components/profile/PersonalDetailsSection';
 import type { PreferencesData } from '@/components/profile/PreferencesSection';
 import type { LoyaltyProgramDto } from '@/components/profile/LoyaltyProgramsSection';
 import type { HealthData } from '@/components/profile/HealthSection';
 import type { EmergencyContactDto } from '@/components/profile/EmergencyContactsSection';
+import type { NationalityDto } from '@/components/profile/NationalitiesSection';
 import { useAuth } from '@/hooks/useAuth';
 import { apiClient } from '@/services/api-client';
 import { toast } from '@/components/ui/toast';
 import { AppLanguage, AppCurrency, AppTheme } from '@chamuco/shared-types';
 import { cn } from '@/lib/utils';
 
-type Tab = 'basic' | 'personal' | 'preferences' | 'loyalty' | 'health' | 'emergency';
+type Tab =
+  | 'basic'
+  | 'personal'
+  | 'nationalities'
+  | 'preferences'
+  | 'loyalty'
+  | 'health'
+  | 'emergency';
 
 const DEFAULT_PERSONAL_DETAILS: PersonalDetailsProfile = {
   firstName: '',
@@ -63,6 +72,7 @@ interface ProfileData {
   loyaltyPrograms: LoyaltyProgramDto[];
   health: HealthData;
   emergencyContacts: EmergencyContactDto[];
+  nationalities: NationalityDto[];
 }
 
 export default function ProfilePage() {
@@ -102,7 +112,7 @@ export default function ProfilePage() {
     if (!loadedOnce.current) setIsLoading(true);
     setHasLoadError(false);
     try {
-      const [userRes, profileRes, prefRes, loyaltyRes, healthRes, emergencyRes] =
+      const [userRes, profileRes, prefRes, loyaltyRes, healthRes, emergencyRes, nationalitiesRes] =
         await Promise.allSettled([
           apiClient.get('/v1/users/me'),
           apiClient.get('/v1/users/me/profile'),
@@ -110,6 +120,7 @@ export default function ProfilePage() {
           apiClient.get('/v1/users/me/loyalty-programs'),
           apiClient.get('/v1/users/me/health'),
           apiClient.get('/v1/users/me/emergency-contacts'),
+          apiClient.get('/v1/users/me/nationalities'),
         ]);
 
       if (userRes.status === 'rejected') throw userRes.reason;
@@ -143,6 +154,10 @@ export default function ProfilePage() {
         emergencyContacts:
           emergencyRes.status === 'fulfilled'
             ? (emergencyRes.value.data as EmergencyContactDto[])
+            : [],
+        nationalities:
+          nationalitiesRes.status === 'fulfilled'
+            ? (nationalitiesRes.value.data as NationalityDto[])
             : [],
       }));
     } catch {
@@ -195,6 +210,7 @@ export default function ProfilePage() {
   const tabs: { key: Tab; label: string }[] = [
     { key: 'basic', label: t('tabs.basicInfo') },
     { key: 'personal', label: t('tabs.personalDetails') },
+    { key: 'nationalities', label: t('tabs.nationalities') },
     { key: 'preferences', label: t('tabs.preferences') },
     { key: 'loyalty', label: t('tabs.loyaltyPrograms') },
     { key: 'health', label: t('tabs.health') },
@@ -283,6 +299,14 @@ export default function ProfilePage() {
         hidden={activeTab !== 'personal'}
       >
         <PersonalDetailsSection profile={data.personalDetails} onRefresh={loadData} />
+      </div>
+      <div
+        id="panel-nationalities"
+        role="tabpanel"
+        aria-labelledby="tab-nationalities"
+        hidden={activeTab !== 'nationalities'}
+      >
+        <NationalitiesSection data={data.nationalities} onRefresh={loadData} />
       </div>
       <div
         id="panel-preferences"

--- a/apps/web/src/components/profile/NationalitiesSection.test.tsx
+++ b/apps/web/src/components/profile/NationalitiesSection.test.tsx
@@ -1,0 +1,555 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { PassportStatus } from '@chamuco/shared-types';
+
+const mocks = vi.hoisted(() => ({
+  mockPost: vi.fn(),
+  mockPatch: vi.fn(),
+  mockDelete: vi.fn(),
+  mockToastSuccess: vi.fn(),
+  mockToastError: vi.fn(),
+}));
+
+vi.mock('@/services/api-client', () => ({
+  apiClient: {
+    post: mocks.mockPost,
+    patch: mocks.mockPatch,
+    delete: mocks.mockDelete,
+  },
+}));
+
+vi.mock('@/components/ui/toast', () => ({
+  toast: {
+    success: mocks.mockToastSuccess,
+    error: mocks.mockToastError,
+  },
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock('countries-list', () => ({
+  getCountryDataList: () => [
+    { iso2: 'CO', name: 'Colombia', phone: [57] },
+    { iso2: 'US', name: 'United States', phone: [1] },
+    { iso2: 'MX', name: 'Mexico', phone: [52] },
+  ],
+  getEmojiFlag: (iso2: string) => `[${iso2}]`,
+}));
+
+vi.mock('@/components/ui/country-combobox', () => ({
+  CountryCombobox: ({
+    value,
+    onChange,
+    'data-testid': testId,
+  }: {
+    value: string;
+    onChange: (iso: string) => void;
+    'data-testid'?: string;
+  }) => (
+    <select
+      data-testid={testId ?? 'country-combobox'}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+    >
+      <option value="">Select country</option>
+      <option value="CO">Colombia</option>
+      <option value="US">United States</option>
+      <option value="MX">Mexico</option>
+    </select>
+  ),
+}));
+
+import { NationalitiesSection } from './NationalitiesSection';
+import type { NationalityDto } from './NationalitiesSection';
+
+const sampleNationalities: NationalityDto[] = [
+  {
+    id: 'nat-1',
+    countryCode: 'CO',
+    isPrimary: true,
+    nationalIdNumber: '1234567890',
+    passportNumber: 'AB123456',
+    passportIssueDate: '2020-01-15',
+    passportExpiryDate: '2030-01-15',
+    passportStatus: PassportStatus.ACTIVE,
+  },
+  {
+    id: 'nat-2',
+    countryCode: 'US',
+    isPrimary: false,
+    nationalIdNumber: null,
+    passportNumber: null,
+    passportIssueDate: null,
+    passportExpiryDate: null,
+    passportStatus: PassportStatus.OMITTED,
+  },
+];
+
+function setup(nationalities: NationalityDto[] = sampleNationalities) {
+  const onRefresh = vi.fn();
+  const user = userEvent.setup();
+  render(<NationalitiesSection data={nationalities} onRefresh={onRefresh} />);
+  return { user, onRefresh };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.mockPost.mockResolvedValue({});
+  mocks.mockPatch.mockResolvedValue({});
+  mocks.mockDelete.mockResolvedValue({});
+});
+
+describe('NationalitiesSection', () => {
+  describe('rendering', () => {
+    it('renders the section heading', () => {
+      setup();
+      expect(screen.getByText('nationalities.heading')).toBeInTheDocument();
+    });
+
+    it('renders existing nationalities', () => {
+      setup();
+      expect(screen.getByText('Colombia')).toBeInTheDocument();
+      expect(screen.getByText('United States')).toBeInTheDocument();
+    });
+
+    it('renders national ID when present', () => {
+      setup();
+      expect(screen.getByText('1234567890')).toBeInTheDocument();
+    });
+
+    it('renders passport number when present', () => {
+      setup();
+      expect(screen.getByText('AB123456')).toBeInTheDocument();
+    });
+
+    it('does not render passport number when null', () => {
+      setup();
+      const items = screen.queryAllByText(/^[A-Z]{2}\d{6}$/);
+      expect(items).toHaveLength(1);
+    });
+
+    it('renders primary badge on primary nationality', () => {
+      setup();
+      expect(screen.getByText('nationalities.primaryBadge')).toBeInTheDocument();
+    });
+
+    it('renders only one primary badge', () => {
+      setup();
+      const badges = screen.getAllByText('nationalities.primaryBadge');
+      expect(badges).toHaveLength(1);
+    });
+
+    it('renders passport status badge for each entry', () => {
+      setup();
+      expect(screen.getByText('nationalities.passportStatus.ACTIVE')).toBeInTheDocument();
+      expect(screen.getByText('nationalities.passportStatus.OMITTED')).toBeInTheDocument();
+    });
+
+    it('renders EXPIRING_SOON status badge', () => {
+      const data: NationalityDto[] = [
+        { ...sampleNationalities[0]!, passportStatus: PassportStatus.EXPIRING_SOON },
+      ];
+      setup(data);
+      expect(screen.getByText('nationalities.passportStatus.EXPIRING_SOON')).toBeInTheDocument();
+    });
+
+    it('renders EXPIRED status badge', () => {
+      const data: NationalityDto[] = [
+        { ...sampleNationalities[0]!, passportStatus: PassportStatus.EXPIRED },
+      ];
+      setup(data);
+      expect(screen.getByText('nationalities.passportStatus.EXPIRED')).toBeInTheDocument();
+    });
+
+    it('renders empty state when no nationalities', () => {
+      setup([]);
+      expect(screen.getByText('nationalities.empty')).toBeInTheDocument();
+    });
+
+    it('renders Add button', () => {
+      setup();
+      expect(screen.getByRole('button', { name: 'nationalities.add' })).toBeInTheDocument();
+    });
+  });
+
+  describe('adding a nationality', () => {
+    it('shows add form when Add button is clicked', async () => {
+      const { user } = setup();
+      await user.click(screen.getByRole('button', { name: 'nationalities.add' }));
+      expect(screen.getByLabelText('nationalities.nationalIdNumber')).toBeInTheDocument();
+    });
+
+    it('hides Add button while add form is open', async () => {
+      const { user } = setup();
+      await user.click(screen.getByRole('button', { name: 'nationalities.add' }));
+      expect(screen.queryByRole('button', { name: 'nationalities.add' })).not.toBeInTheDocument();
+    });
+
+    it('calls POST with correct payload on submit', async () => {
+      const { user } = setup([]);
+      await user.click(screen.getByRole('button', { name: 'nationalities.add' }));
+      await user.selectOptions(screen.getByTestId('add-country'), 'CO');
+      await user.type(screen.getByLabelText('nationalities.nationalIdNumber'), '9876543210');
+      await user.click(screen.getByRole('button', { name: 'nationalities.save' }));
+      await waitFor(() =>
+        expect(mocks.mockPost).toHaveBeenCalledWith('/v1/users/me/nationalities', {
+          countryCode: 'CO',
+          nationalIdNumber: '9876543210',
+          passportNumber: null,
+          passportIssueDate: null,
+          passportExpiryDate: null,
+          isPrimary: true,
+        }),
+      );
+    });
+
+    it('calls POST with passport fields when all three provided', async () => {
+      const { user } = setup([]);
+      await user.click(screen.getByRole('button', { name: 'nationalities.add' }));
+      await user.selectOptions(screen.getByTestId('add-country'), 'CO');
+      await user.type(screen.getByLabelText('nationalities.passportNumber'), 'AB123456');
+      await user.type(screen.getByLabelText('nationalities.passportExpiryDate'), '2030-01-15');
+      await user.type(screen.getByLabelText('nationalities.passportIssueDate'), '2020-01-15');
+      await user.click(screen.getByRole('button', { name: 'nationalities.save' }));
+      await waitFor(() =>
+        expect(mocks.mockPost).toHaveBeenCalledWith(
+          '/v1/users/me/nationalities',
+          expect.objectContaining({
+            passportNumber: 'AB123456',
+            passportIssueDate: '2020-01-15',
+            passportExpiryDate: '2030-01-15',
+          }),
+        ),
+      );
+    });
+
+    it('auto-fills expiry date to issue date + 10 years when expiry is empty', async () => {
+      const { user } = setup([]);
+      await user.click(screen.getByRole('button', { name: 'nationalities.add' }));
+      await user.type(screen.getByLabelText('nationalities.passportIssueDate'), '2020-01-15');
+      expect(screen.getByLabelText('nationalities.passportExpiryDate')).toHaveValue('2030-01-15');
+    });
+
+    it('does not overwrite expiry date when already set', async () => {
+      const { user } = setup([]);
+      await user.click(screen.getByRole('button', { name: 'nationalities.add' }));
+      await user.type(screen.getByLabelText('nationalities.passportExpiryDate'), '2025-06-01');
+      await user.type(screen.getByLabelText('nationalities.passportIssueDate'), '2020-01-15');
+      expect(screen.getByLabelText('nationalities.passportExpiryDate')).toHaveValue('2025-06-01');
+    });
+
+    it('defaults isPrimary to true when list is empty', async () => {
+      const { user } = setup([]);
+      await user.click(screen.getByRole('button', { name: 'nationalities.add' }));
+      expect(screen.getByRole('checkbox', { name: 'nationalities.primaryBadge' })).toBeChecked();
+    });
+
+    it('defaults isPrimary to false when list is non-empty', async () => {
+      const { user } = setup();
+      await user.click(screen.getByRole('button', { name: 'nationalities.add' }));
+      expect(
+        screen.getByRole('checkbox', { name: 'nationalities.primaryBadge' }),
+      ).not.toBeChecked();
+    });
+
+    it('calls onRefresh after adding', async () => {
+      const { user, onRefresh } = setup([]);
+      await user.click(screen.getByRole('button', { name: 'nationalities.add' }));
+      await user.selectOptions(screen.getByTestId('add-country'), 'CO');
+      await user.click(screen.getByRole('button', { name: 'nationalities.save' }));
+      await waitFor(() => expect(onRefresh).toHaveBeenCalledOnce());
+    });
+
+    it('shows success toast on add', async () => {
+      const { user } = setup([]);
+      await user.click(screen.getByRole('button', { name: 'nationalities.add' }));
+      await user.selectOptions(screen.getByTestId('add-country'), 'CO');
+      await user.click(screen.getByRole('button', { name: 'nationalities.save' }));
+      await waitFor(() =>
+        expect(mocks.mockToastSuccess).toHaveBeenCalledWith('nationalities.addSuccess'),
+      );
+    });
+
+    it('hides add form after successful add', async () => {
+      const { user } = setup([]);
+      await user.click(screen.getByRole('button', { name: 'nationalities.add' }));
+      await user.selectOptions(screen.getByTestId('add-country'), 'CO');
+      await user.click(screen.getByRole('button', { name: 'nationalities.save' }));
+      await waitFor(() =>
+        expect(screen.queryByLabelText('nationalities.nationalIdNumber')).not.toBeInTheDocument(),
+      );
+    });
+
+    it('cancels add form when Cancel is clicked', async () => {
+      const { user } = setup();
+      await user.click(screen.getByRole('button', { name: 'nationalities.add' }));
+      await user.click(screen.getByRole('button', { name: 'nationalities.cancel' }));
+      expect(screen.queryByLabelText('nationalities.nationalIdNumber')).not.toBeInTheDocument();
+    });
+
+    it('shows error toast when add fails', async () => {
+      mocks.mockPost.mockRejectedValue(new Error('network error'));
+      const { user } = setup([]);
+      await user.click(screen.getByRole('button', { name: 'nationalities.add' }));
+      await user.selectOptions(screen.getByTestId('add-country'), 'CO');
+      await user.click(screen.getByRole('button', { name: 'nationalities.save' }));
+      await waitFor(() =>
+        expect(mocks.mockToastError).toHaveBeenCalledWith('nationalities.saveError'),
+      );
+    });
+  });
+
+  describe('form validation', () => {
+    it('shows nationalIdFormat error when national ID has spaces', async () => {
+      const { user } = setup([]);
+      await user.click(screen.getByRole('button', { name: 'nationalities.add' }));
+      await user.selectOptions(screen.getByTestId('add-country'), 'CO');
+      await user.type(screen.getByLabelText('nationalities.nationalIdNumber'), 'AB 123');
+      await user.click(screen.getByRole('button', { name: 'nationalities.save' }));
+      expect(screen.getByText('nationalities.errors.nationalIdFormat')).toBeInTheDocument();
+      expect(mocks.mockPost).not.toHaveBeenCalled();
+    });
+
+    it('auto-uppercases national ID input', async () => {
+      const { user } = setup([]);
+      await user.click(screen.getByRole('button', { name: 'nationalities.add' }));
+      await user.type(screen.getByLabelText('nationalities.nationalIdNumber'), 'ab-123');
+      expect(screen.getByLabelText('nationalities.nationalIdNumber')).toHaveValue('AB-123');
+    });
+
+    it('accepts national ID with hyphens', async () => {
+      const { user } = setup([]);
+      await user.click(screen.getByRole('button', { name: 'nationalities.add' }));
+      await user.selectOptions(screen.getByTestId('add-country'), 'CO');
+      await user.type(screen.getByLabelText('nationalities.nationalIdNumber'), 'AB-123');
+      await user.click(screen.getByRole('button', { name: 'nationalities.save' }));
+      await waitFor(() => expect(mocks.mockPost).toHaveBeenCalledOnce());
+    });
+
+    it('shows countryRequired error when no country selected', async () => {
+      const { user } = setup([]);
+      await user.click(screen.getByRole('button', { name: 'nationalities.add' }));
+      await user.click(screen.getByRole('button', { name: 'nationalities.save' }));
+      expect(screen.getByText('nationalities.errors.countryRequired')).toBeInTheDocument();
+      expect(mocks.mockPost).not.toHaveBeenCalled();
+    });
+
+    it('shows passportIncomplete error when only passport number provided', async () => {
+      const { user } = setup([]);
+      await user.click(screen.getByRole('button', { name: 'nationalities.add' }));
+      await user.selectOptions(screen.getByTestId('add-country'), 'CO');
+      await user.type(screen.getByLabelText('nationalities.passportNumber'), 'AB123456');
+      await user.click(screen.getByRole('button', { name: 'nationalities.save' }));
+      expect(screen.getByText('nationalities.errors.passportIncomplete')).toBeInTheDocument();
+      expect(mocks.mockPost).not.toHaveBeenCalled();
+    });
+
+    it('shows passportIncomplete error when only issue date provided', async () => {
+      const { user } = setup([]);
+      await user.click(screen.getByRole('button', { name: 'nationalities.add' }));
+      await user.selectOptions(screen.getByTestId('add-country'), 'CO');
+      await user.type(screen.getByLabelText('nationalities.passportIssueDate'), '2020-01-15');
+      await user.click(screen.getByRole('button', { name: 'nationalities.save' }));
+      expect(screen.getByText('nationalities.errors.passportIncomplete')).toBeInTheDocument();
+      expect(mocks.mockPost).not.toHaveBeenCalled();
+    });
+
+    it('shows expiryBeforeIssue error when expiry <= issue date', async () => {
+      const { user } = setup([]);
+      await user.click(screen.getByRole('button', { name: 'nationalities.add' }));
+      await user.selectOptions(screen.getByTestId('add-country'), 'CO');
+      await user.type(screen.getByLabelText('nationalities.passportNumber'), 'AB123456');
+      await user.type(screen.getByLabelText('nationalities.passportExpiryDate'), '2020-01-01');
+      await user.type(screen.getByLabelText('nationalities.passportIssueDate'), '2020-06-01');
+      await user.click(screen.getByRole('button', { name: 'nationalities.save' }));
+      expect(screen.getByText('nationalities.errors.expiryBeforeIssue')).toBeInTheDocument();
+      expect(mocks.mockPost).not.toHaveBeenCalled();
+    });
+
+    it('auto-uppercases passport number input', async () => {
+      const { user } = setup([]);
+      await user.click(screen.getByRole('button', { name: 'nationalities.add' }));
+      await user.selectOptions(screen.getByTestId('add-country'), 'CO');
+      await user.type(screen.getByLabelText('nationalities.passportNumber'), 'ab-123456');
+      expect(screen.getByLabelText('nationalities.passportNumber')).toHaveValue('AB-123456');
+    });
+
+    it('shows passportFormat error when passport number has spaces', async () => {
+      const { user } = setup([]);
+      await user.click(screen.getByRole('button', { name: 'nationalities.add' }));
+      await user.selectOptions(screen.getByTestId('add-country'), 'CO');
+      await user.type(screen.getByLabelText('nationalities.passportNumber'), 'AB 123456');
+      await user.type(screen.getByLabelText('nationalities.passportExpiryDate'), '2030-01-15');
+      await user.type(screen.getByLabelText('nationalities.passportIssueDate'), '2020-01-15');
+      await user.click(screen.getByRole('button', { name: 'nationalities.save' }));
+      expect(screen.getByText('nationalities.errors.passportFormat')).toBeInTheDocument();
+      expect(mocks.mockPost).not.toHaveBeenCalled();
+    });
+
+    it('accepts passport number with hyphens', async () => {
+      const { user } = setup([]);
+      await user.click(screen.getByRole('button', { name: 'nationalities.add' }));
+      await user.selectOptions(screen.getByTestId('add-country'), 'CO');
+      await user.type(screen.getByLabelText('nationalities.passportNumber'), 'AB-123456');
+      await user.type(screen.getByLabelText('nationalities.passportExpiryDate'), '2030-01-15');
+      await user.type(screen.getByLabelText('nationalities.passportIssueDate'), '2020-01-15');
+      await user.click(screen.getByRole('button', { name: 'nationalities.save' }));
+      await waitFor(() =>
+        expect(mocks.mockPost).toHaveBeenCalledWith(
+          '/v1/users/me/nationalities',
+          expect.objectContaining({ passportNumber: 'AB-123456' }),
+        ),
+      );
+    });
+
+    it('accepts nationality with no passport fields', async () => {
+      const { user } = setup([]);
+      await user.click(screen.getByRole('button', { name: 'nationalities.add' }));
+      await user.selectOptions(screen.getByTestId('add-country'), 'CO');
+      await user.click(screen.getByRole('button', { name: 'nationalities.save' }));
+      await waitFor(() => expect(mocks.mockPost).toHaveBeenCalledOnce());
+    });
+  });
+
+  describe('editing a nationality', () => {
+    it('shows inline edit form when Edit is clicked', async () => {
+      const { user } = setup();
+      const editButtons = screen.getAllByRole('button', { name: 'nationalities.edit' });
+      await user.click(editButtons[0]!);
+      expect(screen.getByLabelText('nationalities.nationalIdNumber')).toBeInTheDocument();
+    });
+
+    it('pre-fills edit form with existing values', async () => {
+      const { user } = setup();
+      const editButtons = screen.getAllByRole('button', { name: 'nationalities.edit' });
+      await user.click(editButtons[0]!);
+      expect(screen.getByLabelText('nationalities.nationalIdNumber')).toHaveValue('1234567890');
+      expect(screen.getByLabelText('nationalities.passportNumber')).toHaveValue('AB123456');
+      expect(screen.getByRole('checkbox', { name: 'nationalities.primaryBadge' })).toBeChecked();
+    });
+
+    it('calls PATCH on save', async () => {
+      const { user } = setup();
+      const editButtons = screen.getAllByRole('button', { name: 'nationalities.edit' });
+      await user.click(editButtons[0]!);
+      const idInput = screen.getByLabelText('nationalities.nationalIdNumber');
+      await user.clear(idInput);
+      await user.type(idInput, '0000000000');
+      await user.click(screen.getByRole('button', { name: 'nationalities.save' }));
+      await waitFor(() =>
+        expect(mocks.mockPatch).toHaveBeenCalledWith('/v1/users/me/nationalities/nat-1', {
+          countryCode: 'CO',
+          nationalIdNumber: '0000000000',
+          passportNumber: 'AB123456',
+          passportIssueDate: '2020-01-15',
+          passportExpiryDate: '2030-01-15',
+          isPrimary: true,
+        }),
+      );
+    });
+
+    it('shows success toast after update', async () => {
+      const { user } = setup();
+      const editButtons = screen.getAllByRole('button', { name: 'nationalities.edit' });
+      await user.click(editButtons[0]!);
+      await user.click(screen.getByRole('button', { name: 'nationalities.save' }));
+      await waitFor(() =>
+        expect(mocks.mockToastSuccess).toHaveBeenCalledWith('nationalities.updateSuccess'),
+      );
+    });
+
+    it('calls onRefresh after update', async () => {
+      const { user, onRefresh } = setup();
+      const editButtons = screen.getAllByRole('button', { name: 'nationalities.edit' });
+      await user.click(editButtons[0]!);
+      await user.click(screen.getByRole('button', { name: 'nationalities.save' }));
+      await waitFor(() => expect(onRefresh).toHaveBeenCalledOnce());
+    });
+
+    it('cancels edit form when Cancel is clicked', async () => {
+      const { user } = setup();
+      const editButtons = screen.getAllByRole('button', { name: 'nationalities.edit' });
+      await user.click(editButtons[0]!);
+      await user.click(screen.getByRole('button', { name: 'nationalities.cancel' }));
+      expect(screen.queryByLabelText('nationalities.nationalIdNumber')).not.toBeInTheDocument();
+    });
+
+    it('shows error toast when update fails', async () => {
+      mocks.mockPatch.mockRejectedValue(new Error('network error'));
+      const { user } = setup();
+      const editButtons = screen.getAllByRole('button', { name: 'nationalities.edit' });
+      await user.click(editButtons[0]!);
+      await user.click(screen.getByRole('button', { name: 'nationalities.save' }));
+      await waitFor(() =>
+        expect(mocks.mockToastError).toHaveBeenCalledWith('nationalities.saveError'),
+      );
+    });
+  });
+
+  describe('deleting a nationality', () => {
+    it('requires a second click to confirm delete', async () => {
+      const { user } = setup();
+      const deleteButtons = screen.getAllByRole('button', { name: 'nationalities.delete' });
+      await user.click(deleteButtons[0]!);
+      expect(mocks.mockDelete).not.toHaveBeenCalled();
+      expect(
+        screen.getByRole('button', { name: 'nationalities.deleteConfirm' }),
+      ).toBeInTheDocument();
+    });
+
+    it('calls DELETE after confirmation click', async () => {
+      const { user } = setup();
+      const deleteButtons = screen.getAllByRole('button', { name: 'nationalities.delete' });
+      await user.click(deleteButtons[0]!);
+      await user.click(screen.getByRole('button', { name: 'nationalities.deleteConfirm' }));
+      await waitFor(() =>
+        expect(mocks.mockDelete).toHaveBeenCalledWith('/v1/users/me/nationalities/nat-1'),
+      );
+    });
+
+    it('calls onRefresh after delete', async () => {
+      const { user, onRefresh } = setup();
+      const deleteButtons = screen.getAllByRole('button', { name: 'nationalities.delete' });
+      await user.click(deleteButtons[0]!);
+      await user.click(screen.getByRole('button', { name: 'nationalities.deleteConfirm' }));
+      await waitFor(() => expect(onRefresh).toHaveBeenCalledOnce());
+    });
+
+    it('shows success toast after delete', async () => {
+      const { user } = setup();
+      const deleteButtons = screen.getAllByRole('button', { name: 'nationalities.delete' });
+      await user.click(deleteButtons[0]!);
+      await user.click(screen.getByRole('button', { name: 'nationalities.deleteConfirm' }));
+      await waitFor(() =>
+        expect(mocks.mockToastSuccess).toHaveBeenCalledWith('nationalities.deleteSuccess'),
+      );
+    });
+
+    it('shows deletePrimaryError toast on 400 response', async () => {
+      const error = { response: { status: 400 } };
+      mocks.mockDelete.mockRejectedValue(error);
+      const { user } = setup();
+      const deleteButtons = screen.getAllByRole('button', { name: 'nationalities.delete' });
+      await user.click(deleteButtons[0]!);
+      await user.click(screen.getByRole('button', { name: 'nationalities.deleteConfirm' }));
+      await waitFor(() =>
+        expect(mocks.mockToastError).toHaveBeenCalledWith('nationalities.deletePrimaryError'),
+      );
+    });
+
+    it('shows generic deleteError toast on non-400 error', async () => {
+      mocks.mockDelete.mockRejectedValue(new Error('network error'));
+      const { user } = setup();
+      const deleteButtons = screen.getAllByRole('button', { name: 'nationalities.delete' });
+      await user.click(deleteButtons[0]!);
+      await user.click(screen.getByRole('button', { name: 'nationalities.deleteConfirm' }));
+      await waitFor(() =>
+        expect(mocks.mockToastError).toHaveBeenCalledWith('nationalities.deleteError'),
+      );
+    });
+  });
+});

--- a/apps/web/src/components/profile/NationalitiesSection.test.tsx
+++ b/apps/web/src/components/profile/NationalitiesSection.test.tsx
@@ -447,7 +447,6 @@ describe('NationalitiesSection', () => {
       await user.click(screen.getByRole('button', { name: 'nationalities.save' }));
       await waitFor(() =>
         expect(mocks.mockPatch).toHaveBeenCalledWith('/v1/users/me/nationalities/nat-1', {
-          countryCode: 'CO',
           nationalIdNumber: '0000000000',
           passportNumber: 'AB123456',
           passportIssueDate: '2020-01-15',

--- a/apps/web/src/components/profile/NationalitiesSection.test.tsx
+++ b/apps/web/src/components/profile/NationalitiesSection.test.tsx
@@ -126,10 +126,15 @@ describe('NationalitiesSection', () => {
       expect(screen.getByText('AB123456')).toBeInTheDocument();
     });
 
-    it('does not render passport number when null', () => {
+    it('renders passport expiry date alongside passport number', () => {
       setup();
-      const items = screen.queryAllByText(/^[A-Z]{2}\d{6}$/);
-      expect(items).toHaveLength(1);
+      expect(screen.getByText('· 2030-01-15')).toBeInTheDocument();
+    });
+
+    it('does not render passport number for nationality with null passportNumber', () => {
+      const data: NationalityDto[] = [{ ...sampleNationalities[1]! }]; // US, passportNumber: null
+      setup(data);
+      expect(screen.queryByText('AB123456')).not.toBeInTheDocument();
     });
 
     it('renders primary badge on primary nationality', () => {

--- a/apps/web/src/components/profile/NationalitiesSection.test.tsx
+++ b/apps/web/src/components/profile/NationalitiesSection.test.tsx
@@ -428,6 +428,14 @@ describe('NationalitiesSection', () => {
       expect(screen.getByLabelText('nationalities.nationalIdNumber')).toBeInTheDocument();
     });
 
+    it('shows country as read-only text, not a combobox, in edit mode', async () => {
+      const { user } = setup();
+      const editButtons = screen.getAllByRole('button', { name: 'nationalities.edit' });
+      await user.click(editButtons[0]!);
+      expect(screen.queryByTestId('edit-nat-1-country')).not.toBeInTheDocument();
+      expect(screen.getByText('Colombia')).toBeInTheDocument();
+    });
+
     it('pre-fills edit form with existing values', async () => {
       const { user } = setup();
       const editButtons = screen.getAllByRole('button', { name: 'nationalities.edit' });

--- a/apps/web/src/components/profile/NationalitiesSection.tsx
+++ b/apps/web/src/components/profile/NationalitiesSection.tsx
@@ -87,6 +87,7 @@ interface NationalityFormProps {
   form: FormState;
   errors: FormErrors;
   isSaving: boolean;
+  readOnlyCountry?: boolean;
   onChange: (patch: Partial<FormState>) => void;
   onSubmit: (e: FormEvent) => void;
   onCancel: () => void;
@@ -98,6 +99,7 @@ function NationalityForm({
   form,
   errors,
   isSaving,
+  readOnlyCountry = false,
   onChange,
   onSubmit,
   onCancel,
@@ -113,18 +115,27 @@ function NationalityForm({
     <form onSubmit={onSubmit} className="space-y-4 rounded-lg border border-border p-4">
       <div className="space-y-1.5">
         <Label id={`${idPrefix}-country-label`}>{t('nationalities.countryCode')}</Label>
-        <CountryCombobox
-          value={form.countryCode}
-          onChange={(iso2) => onChange({ countryCode: iso2 })}
-          displayMode="name"
-          placeholder={t('nationalities.countryPlaceholder')}
-          searchPlaceholder={t('nationalities.countrySearch')}
-          noResultsText={t('nationalities.countryNoResults')}
-          aria-labelledby={`${idPrefix}-country-label`}
-          aria-invalid={errors.countryCode !== null}
-          data-testid={`${idPrefix}-country`}
-        />
-        {errors.countryCode && <p className="text-sm text-destructive">{errors.countryCode}</p>}
+        {readOnlyCountry ? (
+          <p className="flex items-center gap-2 rounded-md border border-border bg-muted/50 px-3 py-2 text-sm">
+            <span aria-hidden="true">{getEmojiFlag(form.countryCode as TCountryCode)}</span>
+            {getCountryName(form.countryCode)}
+          </p>
+        ) : (
+          <>
+            <CountryCombobox
+              value={form.countryCode}
+              onChange={(iso2) => onChange({ countryCode: iso2 })}
+              displayMode="name"
+              placeholder={t('nationalities.countryPlaceholder')}
+              searchPlaceholder={t('nationalities.countrySearch')}
+              noResultsText={t('nationalities.countryNoResults')}
+              aria-labelledby={`${idPrefix}-country-label`}
+              aria-invalid={errors.countryCode !== null}
+              data-testid={`${idPrefix}-country`}
+            />
+            {errors.countryCode && <p className="text-sm text-destructive">{errors.countryCode}</p>}
+          </>
+        )}
       </div>
 
       <div className="space-y-1.5">
@@ -156,6 +167,7 @@ function NationalityForm({
             value={form.passportNumber}
             onChange={(e) => onChange({ passportNumber: e.target.value.toUpperCase() })}
             autoCapitalize="characters"
+            placeholder={t('nationalities.passportPlaceholder')}
             autoComplete="off"
             disabled={isSaving}
             aria-invalid={
@@ -320,7 +332,6 @@ export function NationalitiesSection({ data, onRefresh }: NationalitiesSectionPr
       form.passportNumber.trim() && form.passportIssueDate && form.passportExpiryDate,
     );
     return {
-      countryCode: form.countryCode,
       nationalIdNumber: form.nationalIdNumber.trim() || null,
       passportNumber: hasPassport ? form.passportNumber.trim() : null,
       passportIssueDate: hasPassport ? form.passportIssueDate : null,
@@ -362,7 +373,10 @@ export function NationalitiesSection({ data, onRefresh }: NationalitiesSectionPr
     if (!validate(addForm, setAddErrors)) return;
     setIsSaving(true);
     try {
-      await apiClient.post('/v1/users/me/nationalities', formToPayload(addForm));
+      await apiClient.post('/v1/users/me/nationalities', {
+        countryCode: addForm.countryCode,
+        ...formToPayload(addForm),
+      });
       toast.success(t('nationalities.addSuccess'));
       setIsAdding(false);
       setAddForm(makeEmptyForm());
@@ -442,6 +456,7 @@ export function NationalitiesSection({ data, onRefresh }: NationalitiesSectionPr
                 form={editForm}
                 errors={editErrors}
                 isSaving={isSaving}
+                readOnlyCountry
                 onChange={(patch) => setEditForm((f) => ({ ...f, ...patch }))}
                 onSubmit={handleUpdate}
                 onCancel={cancelEdit}

--- a/apps/web/src/components/profile/NationalitiesSection.tsx
+++ b/apps/web/src/components/profile/NationalitiesSection.tsx
@@ -1,0 +1,537 @@
+'use client';
+
+import { useEffect, useState, type FormEvent } from 'react';
+import { useTranslation } from 'react-i18next';
+import { getCountryDataList, getEmojiFlag, type TCountryCode } from 'countries-list';
+import { GlobeIcon, IdentificationCardIcon } from '@phosphor-icons/react';
+import { PassportStatus } from '@chamuco/shared-types';
+
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { CountryCombobox } from '@/components/ui/country-combobox';
+import { toast } from '@/components/ui/toast';
+import { apiClient } from '@/services/api-client';
+import { cn } from '@/lib/utils';
+
+export interface NationalityDto {
+  id: string;
+  countryCode: string;
+  isPrimary: boolean;
+  nationalIdNumber: string | null;
+  passportNumber: string | null;
+  passportIssueDate: string | null;
+  passportExpiryDate: string | null;
+  passportStatus: PassportStatus;
+}
+
+interface FormState {
+  countryCode: string;
+  nationalIdNumber: string;
+  passportNumber: string;
+  passportIssueDate: string;
+  passportExpiryDate: string;
+  isPrimary: boolean;
+}
+
+interface FormErrors {
+  countryCode: string | null;
+  nationalId: string | null;
+  passport: string | null;
+  passportNumber: string | null;
+  passportDates: string | null;
+}
+
+const EMPTY_ERRORS: FormErrors = {
+  countryCode: null,
+  nationalId: null,
+  passport: null,
+  passportNumber: null,
+  passportDates: null,
+};
+const ID_FORMAT_REGEX = /^[A-Z0-9-]+$/;
+
+function makeEmptyForm(isPrimary = false): FormState {
+  return {
+    countryCode: '',
+    nationalIdNumber: '',
+    passportNumber: '',
+    passportIssueDate: '',
+    passportExpiryDate: '',
+    isPrimary,
+  };
+}
+
+function getCountryName(iso2: string): string {
+  const match = getCountryDataList().find((c) => c.iso2 === iso2);
+  return match?.name ?? iso2;
+}
+
+function passportStatusBadgeClass(status: PassportStatus): string {
+  switch (status) {
+    case PassportStatus.ACTIVE:
+      return 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200';
+    case PassportStatus.EXPIRING_SOON:
+      return 'bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-200';
+    case PassportStatus.EXPIRED:
+      return 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200';
+    case PassportStatus.OMITTED:
+    default:
+      return 'bg-muted text-muted-foreground';
+  }
+}
+
+interface NationalityFormProps {
+  idPrefix: string;
+  form: FormState;
+  errors: FormErrors;
+  isSaving: boolean;
+  onChange: (patch: Partial<FormState>) => void;
+  onSubmit: (e: FormEvent) => void;
+  onCancel: () => void;
+  saveLabel: string;
+}
+
+function NationalityForm({
+  idPrefix,
+  form,
+  errors,
+  isSaving,
+  onChange,
+  onSubmit,
+  onCancel,
+  saveLabel,
+}: NationalityFormProps) {
+  const { t } = useTranslation('profile');
+
+  const passportFilled = Boolean(
+    form.passportNumber || form.passportIssueDate || form.passportExpiryDate,
+  );
+
+  return (
+    <form onSubmit={onSubmit} className="space-y-4 rounded-lg border border-border p-4">
+      <div className="space-y-1.5">
+        <Label id={`${idPrefix}-country-label`}>{t('nationalities.countryCode')}</Label>
+        <CountryCombobox
+          value={form.countryCode}
+          onChange={(iso2) => onChange({ countryCode: iso2 })}
+          displayMode="name"
+          placeholder={t('nationalities.countryPlaceholder')}
+          searchPlaceholder={t('nationalities.countrySearch')}
+          noResultsText={t('nationalities.countryNoResults')}
+          aria-labelledby={`${idPrefix}-country-label`}
+          aria-invalid={errors.countryCode !== null}
+          data-testid={`${idPrefix}-country`}
+        />
+        {errors.countryCode && <p className="text-sm text-destructive">{errors.countryCode}</p>}
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor={`${idPrefix}-nationalIdNumber`}>
+          {t('nationalities.nationalIdNumber')}
+        </Label>
+        <Input
+          id={`${idPrefix}-nationalIdNumber`}
+          value={form.nationalIdNumber}
+          onChange={(e) => onChange({ nationalIdNumber: e.target.value.toUpperCase() })}
+          autoCapitalize="characters"
+          placeholder={t('nationalities.nationalIdPlaceholder')}
+          autoComplete="off"
+          disabled={isSaving}
+          aria-invalid={errors.nationalId !== null}
+        />
+        {errors.nationalId && <p className="text-sm text-destructive">{errors.nationalId}</p>}
+      </div>
+
+      <fieldset className="space-y-3 rounded-md border border-border p-3">
+        <legend className="px-1 text-sm font-medium text-muted-foreground">
+          {t('nationalities.passportSection')}
+        </legend>
+
+        <div className="space-y-1.5">
+          <Label htmlFor={`${idPrefix}-passportNumber`}>{t('nationalities.passportNumber')}</Label>
+          <Input
+            id={`${idPrefix}-passportNumber`}
+            value={form.passportNumber}
+            onChange={(e) => onChange({ passportNumber: e.target.value.toUpperCase() })}
+            autoCapitalize="characters"
+            autoComplete="off"
+            disabled={isSaving}
+            aria-invalid={
+              (errors.passport !== null || errors.passportNumber !== null) && passportFilled
+            }
+          />
+        </div>
+
+        <div className="grid grid-cols-2 gap-3">
+          <div className="space-y-1.5">
+            <Label htmlFor={`${idPrefix}-passportIssueDate`}>
+              {t('nationalities.passportIssueDate')}
+            </Label>
+            <Input
+              id={`${idPrefix}-passportIssueDate`}
+              type="date"
+              value={form.passportIssueDate}
+              onChange={(e) => {
+                const issueDate = e.target.value;
+                const patch: Partial<FormState> = { passportIssueDate: issueDate };
+                if (issueDate.length === 10 && !form.passportExpiryDate) {
+                  const [year, month, day] = issueDate.split('-');
+                  patch.passportExpiryDate = `${parseInt(year!) + 10}-${month}-${day}`;
+                }
+                onChange(patch);
+              }}
+              disabled={isSaving}
+              aria-invalid={
+                (errors.passport !== null || errors.passportDates !== null) && passportFilled
+              }
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor={`${idPrefix}-passportExpiryDate`}>
+              {t('nationalities.passportExpiryDate')}
+            </Label>
+            <Input
+              id={`${idPrefix}-passportExpiryDate`}
+              type="date"
+              value={form.passportExpiryDate}
+              onChange={(e) => onChange({ passportExpiryDate: e.target.value })}
+              disabled={isSaving}
+              aria-invalid={
+                (errors.passport !== null || errors.passportDates !== null) && passportFilled
+              }
+            />
+          </div>
+        </div>
+
+        {(errors.passport ?? errors.passportNumber ?? errors.passportDates) && (
+          <p className="text-sm text-destructive">
+            {errors.passport ?? errors.passportNumber ?? errors.passportDates}
+          </p>
+        )}
+      </fieldset>
+
+      <label className="flex cursor-pointer items-center gap-2 text-sm">
+        <input
+          type="checkbox"
+          checked={form.isPrimary}
+          onChange={(e) => onChange({ isPrimary: e.target.checked })}
+          disabled={isSaving}
+          className="rounded border-border"
+        />
+        {t('nationalities.primaryBadge')}
+      </label>
+
+      <div className="flex gap-2">
+        <Button type="submit" size="sm" disabled={isSaving}>
+          {saveLabel}
+        </Button>
+        <Button type="button" size="sm" variant="outline" onClick={onCancel} disabled={isSaving}>
+          {t('nationalities.cancel')}
+        </Button>
+      </div>
+    </form>
+  );
+}
+
+interface NationalitiesSectionProps {
+  data: NationalityDto[];
+  onRefresh: () => void;
+}
+
+export function NationalitiesSection({ data, onRefresh }: NationalitiesSectionProps) {
+  const { t } = useTranslation('profile');
+
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [isAdding, setIsAdding] = useState(false);
+  const [addForm, setAddForm] = useState<FormState>(makeEmptyForm(data.length === 0));
+  const [editForm, setEditForm] = useState<FormState>(makeEmptyForm());
+  const [addErrors, setAddErrors] = useState<FormErrors>(EMPTY_ERRORS);
+  const [editErrors, setEditErrors] = useState<FormErrors>(EMPTY_ERRORS);
+  const [isSaving, setIsSaving] = useState(false);
+  const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!confirmDeleteId) return;
+    const reset = () => setConfirmDeleteId(null);
+    document.addEventListener('mousedown', reset);
+    return () => document.removeEventListener('mousedown', reset);
+  }, [confirmDeleteId]);
+
+  function validate(form: FormState, setErrors: (e: FormErrors) => void): boolean {
+    const errors: FormErrors = {
+      countryCode: null,
+      nationalId: null,
+      passport: null,
+      passportNumber: null,
+      passportDates: null,
+    };
+    let hasError = false;
+
+    if (!form.countryCode) {
+      errors.countryCode = t('nationalities.errors.countryRequired');
+      hasError = true;
+    }
+
+    const trimmedNationalId = form.nationalIdNumber.trim();
+    if (trimmedNationalId !== '' && !ID_FORMAT_REGEX.test(trimmedNationalId)) {
+      errors.nationalId = t('nationalities.errors.nationalIdFormat');
+      hasError = true;
+    }
+
+    const hasPassportNumber = form.passportNumber.trim() !== '';
+    const hasIssueDate = form.passportIssueDate !== '';
+    const hasExpiryDate = form.passportExpiryDate !== '';
+    const passportFieldCount = [hasPassportNumber, hasIssueDate, hasExpiryDate].filter(
+      Boolean,
+    ).length;
+
+    if (passportFieldCount > 0 && passportFieldCount < 3) {
+      errors.passport = t('nationalities.errors.passportIncomplete');
+      hasError = true;
+    } else if (passportFieldCount === 3) {
+      if (!ID_FORMAT_REGEX.test(form.passportNumber.trim())) {
+        errors.passportNumber = t('nationalities.errors.passportFormat');
+        hasError = true;
+      } else if (form.passportExpiryDate <= form.passportIssueDate) {
+        errors.passportDates = t('nationalities.errors.expiryBeforeIssue');
+        hasError = true;
+      }
+    }
+
+    setErrors(errors);
+    return !hasError;
+  }
+
+  function dtoToForm(nat: NationalityDto): FormState {
+    return {
+      countryCode: nat.countryCode,
+      nationalIdNumber: nat.nationalIdNumber ?? '',
+      passportNumber: nat.passportNumber ?? '',
+      passportIssueDate: nat.passportIssueDate ?? '',
+      passportExpiryDate: nat.passportExpiryDate ?? '',
+      isPrimary: nat.isPrimary,
+    };
+  }
+
+  function formToPayload(form: FormState) {
+    const hasPassport =
+      form.passportNumber.trim() && form.passportIssueDate && form.passportExpiryDate;
+    return {
+      countryCode: form.countryCode,
+      nationalIdNumber: form.nationalIdNumber.trim() || null,
+      passportNumber: hasPassport ? form.passportNumber.trim() : null,
+      passportIssueDate: hasPassport ? form.passportIssueDate : null,
+      passportExpiryDate: hasPassport ? form.passportExpiryDate : null,
+      isPrimary: form.isPrimary,
+    };
+  }
+
+  function startEdit(nat: NationalityDto) {
+    setEditingId(nat.id);
+    setEditForm(dtoToForm(nat));
+    setEditErrors(EMPTY_ERRORS);
+    setIsAdding(false);
+    setConfirmDeleteId(null);
+  }
+
+  function cancelEdit() {
+    setEditingId(null);
+    setEditForm(makeEmptyForm());
+    setEditErrors(EMPTY_ERRORS);
+  }
+
+  function startAdd() {
+    setIsAdding(true);
+    setAddForm(makeEmptyForm(data.length === 0));
+    setAddErrors(EMPTY_ERRORS);
+    setEditingId(null);
+    setConfirmDeleteId(null);
+  }
+
+  function cancelAdd() {
+    setIsAdding(false);
+    setAddForm(makeEmptyForm());
+    setAddErrors(EMPTY_ERRORS);
+  }
+
+  async function handleAdd(e: FormEvent) {
+    e.preventDefault();
+    if (!validate(addForm, setAddErrors)) return;
+    setIsSaving(true);
+    try {
+      await apiClient.post('/v1/users/me/nationalities', formToPayload(addForm));
+      toast.success(t('nationalities.addSuccess'));
+      setIsAdding(false);
+      setAddForm(makeEmptyForm());
+      setAddErrors(EMPTY_ERRORS);
+      onRefresh();
+    } catch {
+      toast.error(t('nationalities.saveError'));
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  async function handleUpdate(e: FormEvent) {
+    e.preventDefault();
+    if (!editingId) return;
+    if (!validate(editForm, setEditErrors)) return;
+    setIsSaving(true);
+    try {
+      await apiClient.patch(`/v1/users/me/nationalities/${editingId}`, formToPayload(editForm));
+      toast.success(t('nationalities.updateSuccess'));
+      setEditingId(null);
+      setEditForm(makeEmptyForm());
+      setEditErrors(EMPTY_ERRORS);
+      onRefresh();
+    } catch {
+      toast.error(t('nationalities.saveError'));
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  async function handleDelete(id: string) {
+    if (confirmDeleteId !== id) {
+      setConfirmDeleteId(id);
+      return;
+    }
+    setIsSaving(true);
+    try {
+      await apiClient.delete(`/v1/users/me/nationalities/${id}`);
+      toast.success(t('nationalities.deleteSuccess'));
+      setConfirmDeleteId(null);
+      onRefresh();
+    } catch (err: unknown) {
+      const status =
+        err &&
+        typeof err === 'object' &&
+        'response' in err &&
+        err.response &&
+        typeof err.response === 'object' &&
+        'status' in err.response
+          ? (err.response as { status: number }).status
+          : null;
+      if (status === 400) {
+        toast.error(t('nationalities.deletePrimaryError'));
+      } else {
+        toast.error(t('nationalities.deleteError'));
+      }
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  return (
+    <div className="max-w-lg space-y-6">
+      <h2 className="text-xl font-semibold">{t('nationalities.heading')}</h2>
+
+      {data.length === 0 && !isAdding && (
+        <p className="text-sm text-muted-foreground">{t('nationalities.empty')}</p>
+      )}
+
+      <ul className="space-y-3">
+        {data.map((nat) =>
+          editingId === nat.id ? (
+            <li key={nat.id}>
+              <NationalityForm
+                idPrefix={`edit-${nat.id}`}
+                form={editForm}
+                errors={editErrors}
+                isSaving={isSaving}
+                onChange={(patch) => setEditForm((f) => ({ ...f, ...patch }))}
+                onSubmit={handleUpdate}
+                onCancel={cancelEdit}
+                saveLabel={t('nationalities.save')}
+              />
+            </li>
+          ) : (
+            <li
+              key={nat.id}
+              className="flex items-start justify-between rounded-lg border border-border p-4"
+            >
+              <div className="min-w-0 flex-1">
+                <div className="flex flex-wrap items-center gap-2">
+                  <span className="text-lg leading-none" aria-hidden="true">
+                    {getEmojiFlag(nat.countryCode as TCountryCode)}
+                  </span>
+                  <p className="font-medium">{getCountryName(nat.countryCode)}</p>
+                  {nat.isPrimary && (
+                    <span className="rounded-full bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary">
+                      {t('nationalities.primaryBadge')}
+                    </span>
+                  )}
+                  <span
+                    className={cn(
+                      'rounded-full px-2 py-0.5 text-xs font-medium',
+                      passportStatusBadgeClass(nat.passportStatus),
+                    )}
+                  >
+                    {t(`nationalities.passportStatus.${nat.passportStatus}`)}
+                  </span>
+                </div>
+                {nat.nationalIdNumber && (
+                  <p className="mt-1 flex items-center gap-1.5 text-sm text-muted-foreground">
+                    <IdentificationCardIcon size={20} aria-hidden="true" />
+                    {nat.nationalIdNumber}
+                  </p>
+                )}
+                {nat.passportNumber && (
+                  <p className="mt-0.5 flex items-center gap-1.5 text-sm text-muted-foreground">
+                    <GlobeIcon size={20} aria-hidden="true" />
+                    {nat.passportNumber}
+                  </p>
+                )}
+              </div>
+              <div className="ml-4 flex shrink-0 gap-2">
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  onClick={() => startEdit(nat)}
+                  disabled={isSaving}
+                >
+                  {t('nationalities.edit')}
+                </Button>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant={confirmDeleteId === nat.id ? 'destructive' : 'outline'}
+                  onMouseDown={(e) => {
+                    if (confirmDeleteId === nat.id) e.stopPropagation();
+                  }}
+                  onClick={() => handleDelete(nat.id)}
+                  disabled={isSaving}
+                >
+                  {confirmDeleteId === nat.id
+                    ? t('nationalities.deleteConfirm')
+                    : t('nationalities.delete')}
+                </Button>
+              </div>
+            </li>
+          ),
+        )}
+      </ul>
+
+      {isAdding && (
+        <NationalityForm
+          idPrefix="add"
+          form={addForm}
+          errors={addErrors}
+          isSaving={isSaving}
+          onChange={(patch) => setAddForm((f) => ({ ...f, ...patch }))}
+          onSubmit={handleAdd}
+          onCancel={cancelAdd}
+          saveLabel={t('nationalities.save')}
+        />
+      )}
+
+      {!isAdding && (
+        <Button type="button" variant="outline" onClick={startAdd} disabled={isSaving}>
+          {t('nationalities.add')}
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/profile/NationalitiesSection.tsx
+++ b/apps/web/src/components/profile/NationalitiesSection.tsx
@@ -62,9 +62,10 @@ function makeEmptyForm(isPrimary = false): FormState {
   };
 }
 
+const countryList = getCountryDataList();
+
 function getCountryName(iso2: string): string {
-  const match = getCountryDataList().find((c) => c.iso2 === iso2);
-  return match?.name ?? iso2;
+  return countryList.find((c) => c.iso2 === iso2)?.name ?? iso2;
 }
 
 function passportStatusBadgeClass(status: PassportStatus): string {
@@ -315,8 +316,9 @@ export function NationalitiesSection({ data, onRefresh }: NationalitiesSectionPr
   }
 
   function formToPayload(form: FormState) {
-    const hasPassport =
-      form.passportNumber.trim() && form.passportIssueDate && form.passportExpiryDate;
+    const hasPassport = Boolean(
+      form.passportNumber.trim() && form.passportIssueDate && form.passportExpiryDate,
+    );
     return {
       countryCode: form.countryCode,
       nationalIdNumber: form.nationalIdNumber.trim() || null,
@@ -481,6 +483,9 @@ export function NationalitiesSection({ data, onRefresh }: NationalitiesSectionPr
                   <p className="mt-0.5 flex items-center gap-1.5 text-sm text-muted-foreground">
                     <GlobeIcon size={20} aria-hidden="true" />
                     {nat.passportNumber}
+                    {nat.passportExpiryDate && (
+                      <span className="text-muted-foreground/60">· {nat.passportExpiryDate}</span>
+                    )}
                   </p>
                 )}
               </div>

--- a/apps/web/src/components/ui/command.tsx
+++ b/apps/web/src/components/ui/command.tsx
@@ -72,7 +72,7 @@ function CommandGroupSection({
   return (
     <CommandGroup
       className={cn(
-        'overflow-hidden p-1 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground',
+        'overflow-hidden p-1 **:[[cmdk-group-heading]]:px-2 **:[[cmdk-group-heading]]:py-1.5 **:[[cmdk-group-heading]]:text-xs **:[[cmdk-group-heading]]:font-medium **:[[cmdk-group-heading]]:text-muted-foreground',
         className,
       )}
       {...props}

--- a/apps/web/src/components/ui/dialog.tsx
+++ b/apps/web/src/components/ui/dialog.tsx
@@ -19,7 +19,7 @@ function DialogBackdrop({
     <DialogPrimitive.Backdrop
       className={cn(
         'fixed inset-0 z-50 bg-black/50 backdrop-blur-sm',
-        'data-[starting-style]:opacity-0 data-[ending-style]:opacity-0 transition-opacity duration-200',
+        'data-starting-style:opacity-0 data-ending-style:opacity-0 transition-opacity duration-200',
         className,
       )}
       {...props}
@@ -39,8 +39,8 @@ function DialogPopup({
         className={cn(
           'fixed left-1/2 top-1/2 z-50 w-full max-w-lg -translate-x-1/2 -translate-y-1/2',
           'rounded-xl bg-card p-6 shadow-xl ring-1 ring-foreground/10',
-          'data-[starting-style]:opacity-0 data-[starting-style]:scale-95',
-          'data-[ending-style]:opacity-0 data-[ending-style]:scale-95',
+          'data-starting-style:opacity-0 data-starting-style:scale-95',
+          'data-ending-style:opacity-0 data-ending-style:scale-95',
           'transition-all duration-200',
           className,
         )}

--- a/apps/web/src/components/ui/menu.tsx
+++ b/apps/web/src/components/ui/menu.tsx
@@ -18,8 +18,8 @@ function MenuPopup({
         <MenuPrimitive.Popup
           className={cn(
             'z-50 min-w-48 rounded-xl bg-popover p-1 text-popover-foreground shadow-lg ring-1 ring-foreground/10',
-            'data-[starting-style]:opacity-0 data-[starting-style]:scale-95 data-[starting-style]:translate-y-1',
-            'data-[ending-style]:opacity-0 data-[ending-style]:scale-95 data-[ending-style]:translate-y-1',
+            'data-starting-style:opacity-0 data-starting-style:scale-95 data-starting-style:translate-y-1',
+            'data-ending-style:opacity-0 data-ending-style:scale-95 data-ending-style:translate-y-1',
             'transition-all duration-150 origin-top-right',
             className,
           )}
@@ -39,7 +39,7 @@ function MenuItem({
       className={cn(
         'flex cursor-pointer select-none items-center gap-2 rounded-lg px-3 py-2 text-sm outline-none',
         'hover:bg-muted focus-visible:bg-muted',
-        'data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+        'data-disabled:pointer-events-none data-disabled:opacity-50',
         className,
       )}
       {...props}

--- a/apps/web/src/components/ui/toast.tsx
+++ b/apps/web/src/components/ui/toast.tsx
@@ -81,7 +81,7 @@ function Toaster() {
   return (
     <ToastPrimitive.Viewport
       className={cn(
-        'fixed bottom-0 right-0 z-[100] flex max-h-screen w-full flex-col gap-2 p-4 md:max-w-sm',
+        'fixed bottom-0 right-0 z-100 flex max-h-screen w-full flex-col gap-2 p-4 md:max-w-sm',
         'pb-safe-bottom',
       )}
     >
@@ -91,8 +91,8 @@ function Toaster() {
           toast={toast}
           className={cn(
             toastVariants({ type: toast.type as keyof typeof typeIconMap }),
-            'data-[starting-style]:translate-y-2 data-[starting-style]:opacity-0',
-            'data-[ending-style]:translate-y-2 data-[ending-style]:opacity-0',
+            'data-starting-style:translate-y-2 data-starting-style:opacity-0',
+            'data-ending-style:translate-y-2 data-ending-style:opacity-0',
             'transition-all duration-200',
           )}
         >

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -214,7 +214,8 @@
       "preferences": "Preferences",
       "loyaltyPrograms": "Loyalty Programs",
       "health": "Health",
-      "emergencyContacts": "Emergency Contacts"
+      "emergencyContacts": "Emergency Contacts",
+      "nationalities": "Nationalities & Documents"
     },
     "basicInfo": {
       "heading": "Basic Information",
@@ -456,6 +457,46 @@
         "invalidPhone": "Invalid phone number.",
         "relationshipRequired": "Relationship is required.",
         "relationshipInvalid": "Relationship may only contain letters and spaces."
+      }
+    },
+    "nationalities": {
+      "heading": "Nationalities & Travel Documents",
+      "empty": "No nationalities added yet.",
+      "add": "Add nationality",
+      "edit": "Edit",
+      "delete": "Delete",
+      "deleteConfirm": "Confirm?",
+      "save": "Save",
+      "cancel": "Cancel",
+      "primaryBadge": "Primary",
+      "countryCode": "Country",
+      "countryPlaceholder": "Select country",
+      "countrySearch": "Search countries…",
+      "countryNoResults": "No countries found.",
+      "nationalIdNumber": "National ID",
+      "nationalIdPlaceholder": "e.g. 1234567890",
+      "passportSection": "Passport (optional)",
+      "passportNumber": "Passport number",
+      "passportIssueDate": "Issue date",
+      "passportExpiryDate": "Expiry date",
+      "passportStatus": {
+        "OMITTED": "No passport",
+        "ACTIVE": "Active",
+        "EXPIRING_SOON": "Expiring soon",
+        "EXPIRED": "Expired"
+      },
+      "addSuccess": "Nationality added.",
+      "updateSuccess": "Nationality updated.",
+      "deleteSuccess": "Nationality removed.",
+      "saveError": "Could not save. Please try again.",
+      "deleteError": "Could not delete. Please try again.",
+      "deletePrimaryError": "Cannot delete the primary nationality while others exist.",
+      "errors": {
+        "countryRequired": "Select a country.",
+        "nationalIdFormat": "National ID may only contain uppercase letters, numbers, and hyphens.",
+        "passportIncomplete": "Provide all three passport fields or leave them all empty.",
+        "passportFormat": "Passport number may only contain uppercase letters, numbers, and hyphens.",
+        "expiryBeforeIssue": "Expiry date must be after issue date."
       }
     },
     "errors": {

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -477,6 +477,7 @@
       "nationalIdPlaceholder": "e.g. 1234567890",
       "passportSection": "Passport (optional)",
       "passportNumber": "Passport number",
+      "passportPlaceholder": "e.g. AB1234567",
       "passportIssueDate": "Issue date",
       "passportExpiryDate": "Expiry date",
       "passportStatus": {

--- a/apps/web/src/locales/es.json
+++ b/apps/web/src/locales/es.json
@@ -477,6 +477,7 @@
       "nationalIdPlaceholder": "ej. 1234567890",
       "passportSection": "Pasaporte (opcional)",
       "passportNumber": "Número de pasaporte",
+      "passportPlaceholder": "ej. AB1234567",
       "passportIssueDate": "Fecha de expedición",
       "passportExpiryDate": "Fecha de vencimiento",
       "passportStatus": {

--- a/apps/web/src/locales/es.json
+++ b/apps/web/src/locales/es.json
@@ -214,7 +214,8 @@
       "preferences": "Preferencias",
       "loyaltyPrograms": "Programas de Fidelidad",
       "health": "Salud",
-      "emergencyContacts": "Contactos de Emergencia"
+      "emergencyContacts": "Contactos de Emergencia",
+      "nationalities": "Nacionalidades y Documentos"
     },
     "basicInfo": {
       "heading": "Información Básica",
@@ -456,6 +457,46 @@
         "invalidPhone": "Número de teléfono inválido.",
         "relationshipRequired": "La relación es requerida.",
         "relationshipInvalid": "La relación solo puede contener letras y espacios."
+      }
+    },
+    "nationalities": {
+      "heading": "Nacionalidades y Documentos de Viaje",
+      "empty": "Aún no has añadido nacionalidades.",
+      "add": "Añadir nacionalidad",
+      "edit": "Editar",
+      "delete": "Eliminar",
+      "deleteConfirm": "¿Confirmar?",
+      "save": "Guardar",
+      "cancel": "Cancelar",
+      "primaryBadge": "Principal",
+      "countryCode": "País",
+      "countryPlaceholder": "Seleccionar país",
+      "countrySearch": "Buscar países…",
+      "countryNoResults": "No se encontraron países.",
+      "nationalIdNumber": "Documento de identidad",
+      "nationalIdPlaceholder": "ej. 1234567890",
+      "passportSection": "Pasaporte (opcional)",
+      "passportNumber": "Número de pasaporte",
+      "passportIssueDate": "Fecha de expedición",
+      "passportExpiryDate": "Fecha de vencimiento",
+      "passportStatus": {
+        "OMITTED": "Sin pasaporte",
+        "ACTIVE": "Activo",
+        "EXPIRING_SOON": "Próximo a vencer",
+        "EXPIRED": "Vencido"
+      },
+      "addSuccess": "Nacionalidad añadida.",
+      "updateSuccess": "Nacionalidad actualizada.",
+      "deleteSuccess": "Nacionalidad eliminada.",
+      "saveError": "No se pudo guardar. Intenta de nuevo.",
+      "deleteError": "No se pudo eliminar. Intenta de nuevo.",
+      "deletePrimaryError": "No se puede eliminar la nacionalidad principal mientras existan otras.",
+      "errors": {
+        "countryRequired": "Selecciona un país.",
+        "nationalIdFormat": "El número de identificación solo puede contener letras mayúsculas, números y guiones.",
+        "passportIncomplete": "Completa los tres campos del pasaporte o déjalos todos vacíos.",
+        "passportFormat": "El número de pasaporte solo puede contener letras mayúsculas, números y guiones.",
+        "expiryBeforeIssue": "La fecha de vencimiento debe ser posterior a la fecha de expedición."
       }
     },
     "errors": {


### PR DESCRIPTION
## Summary

Implements the Nationalities & Travel Documents section of the user profile. The feature covers the full lifecycle: listing nationalities with country flag, national ID, passport number, and passport status badge; adding, editing, and deleting entries inline. Document number format (`^[A-Z0-9-]+$`) is enforced at all three layers — frontend UX, backend DTO validation, and database CHECK constraints — so invalid data is blocked before it can reach the DB.

## Changes

**Frontend**
- New `NationalitiesSection` component with add / inline-edit / two-click delete flows, mirroring the EmergencyContacts pattern
- Passport status badge with colour coding: green (ACTIVE), amber (EXPIRING_SOON), red (EXPIRED), neutral (OMITTED)
- Format constraint on `nationalIdNumber` and `passportNumber`: auto-uppercase on input, `ID_FORMAT_REGEX` validation with field-specific error highlighting (format error only reddens the number field; date errors only redden the date fields)
- Passport expiry auto-fills to issue date + 10 years when left empty
- List items use Phosphor `IdentificationCardIcon` / `BookOpenUserIcon` to visually distinguish national ID from passport number
- `profile/page.tsx` wired up with parallel data loading and the new tab

**Backend**
- `@Matches(/^[A-Z0-9-]+$/)` added to `nationalIdNumber` and `passportNumber` in both `CreateNationalityDto` and `UpdateNationalityDto`

**Database**
- `user-nationalities.schema.ts`: two new CHECK constraints (`national_id_number_format`, `passport_number_format`)
- Migration `0008_numerous_spot.sql` updated to include both constraints (squashed from an earlier draft)

**i18n**
- Full `profile.nationalities` key set in `en.json` and `es.json` (~35 keys including all error messages and passport status labels)

**Tests**
- `NationalitiesSection.test.tsx`: 35+ cases covering rendering, CRUD flows, all validation paths, auto-uppercase, expiry auto-fill, and icon rendering
- `nationality.dto.spec.ts`: format validation cases for both `nationalIdNumber` and `passportNumber` in Create and Update DTOs

## Testing

- All 685 frontend tests and 484 backend tests pass
- `./scripts/validate-i18n-keys.sh` — no missing or unmatched keys
- Pre-commit hooks: format, lint, security audit, type check all green

**Edge cases covered:**
- Passport incomplete (1 or 2 of 3 fields) → `passportIncomplete` error, no submission
- Expiry ≤ issue date → `expiryBeforeIssue` error on date fields only
- Format error on number → only number field turns red, dates unaffected
- Format error on dates → only date fields turn red, number unaffected
- Auto-fill does not overwrite an already-set expiry date
- Delete primary nationality → server returns 400 → `deletePrimaryError` toast

Closes #117