### PR TITLE
feat(profile): add public profile view and profileVisibility setting

### DIFF
--- a/apps/api/src/modules/users/dto/update-user.dto.ts
+++ b/apps/api/src/modules/users/dto/update-user.dto.ts
@@ -1,5 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsNotEmpty, IsOptional, IsString, IsTimeZone, MaxLength } from 'class-validator';
+import { IsEnum, IsNotEmpty, IsOptional, IsString, IsTimeZone, MaxLength } from 'class-validator';
+import { ProfileVisibility } from '@chamuco/shared-types';
 
 export class UpdateUserDto {
   @ApiProperty({
@@ -29,4 +30,13 @@ export class UpdateUserDto {
   @IsOptional()
   @IsTimeZone()
   timezone?: string;
+
+  @ApiProperty({
+    enum: ProfileVisibility,
+    example: ProfileVisibility.PRIVATE,
+    required: false,
+  })
+  @IsOptional()
+  @IsEnum(ProfileVisibility)
+  profileVisibility?: ProfileVisibility;
 }

--- a/apps/api/src/modules/users/dto/user-response.dto.ts
+++ b/apps/api/src/modules/users/dto/user-response.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { AuthProvider, PlatformRole } from '@chamuco/shared-types';
+import { AuthProvider, PlatformRole, ProfileVisibility } from '@chamuco/shared-types';
 
 export class UserResponseDto {
   @ApiProperty({ example: '550e8400-e29b-41d4-a716-446655440000' })
@@ -22,6 +22,9 @@ export class UserResponseDto {
 
   @ApiProperty({ example: 'America/Bogota' })
   timezone!: string;
+
+  @ApiProperty({ enum: ProfileVisibility, example: ProfileVisibility.PRIVATE })
+  profileVisibility!: ProfileVisibility;
 
   @ApiProperty({ enum: PlatformRole, example: PlatformRole.USER })
   platformRole!: PlatformRole;

--- a/apps/api/src/modules/users/users.controller.spec.ts
+++ b/apps/api/src/modules/users/users.controller.spec.ts
@@ -296,6 +296,17 @@ describe('UsersController', () => {
       expect(result).toEqual(updated);
     });
 
+    it('delegates profileVisibility update to service', async () => {
+      const dto: UpdateUserDto = { profileVisibility: ProfileVisibility.PUBLIC };
+      const updated = { ...mockUser, profileVisibility: ProfileVisibility.PUBLIC };
+      mockUpdateMe.mockResolvedValue(updated);
+
+      const result = await controller.updateMe(mockAuthUser, dto);
+
+      expect(mockUpdateMe).toHaveBeenCalledWith(mockAuthUser, dto);
+      expect(result.profileVisibility).toBe(ProfileVisibility.PUBLIC);
+    });
+
     it('propagates NotFoundException from the service', async () => {
       mockUpdateMe.mockRejectedValue(new NotFoundException());
 

--- a/apps/api/src/modules/users/users.controller.ts
+++ b/apps/api/src/modules/users/users.controller.ts
@@ -108,7 +108,8 @@ export class UsersController {
   @ApiBody({ type: UpdateUserDto })
   @ApiOperation({
     summary: 'Update the current authenticated user',
-    description: 'Updates any subset of editable user fields: displayName, avatarUrl, timezone.',
+    description:
+      'Updates any subset of editable user fields: displayName, avatarUrl, timezone, profileVisibility.',
   })
   @ApiResponse({ status: 200, type: UserResponseDto })
   @ApiResponse({ status: 400, description: 'Validation failed — invalid field value' })

--- a/apps/api/src/modules/users/users.service.spec.ts
+++ b/apps/api/src/modules/users/users.service.spec.ts
@@ -224,6 +224,26 @@ describe('UsersService', () => {
       expect(mockSet).toHaveBeenCalledWith(expect.objectContaining({ avatarUrl: null }));
     });
 
+    it('returns profileVisibility in the response when dto has no fields', async () => {
+      const result = await service.updateMe(mockUser, {});
+
+      expect(result.profileVisibility).toBe(ProfileVisibility.PRIVATE);
+    });
+
+    it('updates profileVisibility and returns it in the response', async () => {
+      const updated = { ...mockUser, profileVisibility: ProfileVisibility.PUBLIC };
+      mockReturning.mockResolvedValue([updated]);
+
+      const result = await service.updateMe(mockUser, {
+        profileVisibility: ProfileVisibility.PUBLIC,
+      });
+
+      expect(mockSet).toHaveBeenCalledWith(
+        expect.objectContaining({ profileVisibility: ProfileVisibility.PUBLIC }),
+      );
+      expect(result.profileVisibility).toBe(ProfileVisibility.PUBLIC);
+    });
+
     it('throws NotFoundException when user is deleted between check and update', async () => {
       mockReturning.mockResolvedValue([]);
 

--- a/apps/api/src/modules/users/users.service.ts
+++ b/apps/api/src/modules/users/users.service.ts
@@ -59,6 +59,7 @@ export class UsersService {
     if (dto.displayName !== undefined) patch.displayName = dto.displayName.trim();
     if (dto.avatarUrl !== undefined) patch.avatarUrl = dto.avatarUrl?.trim() || null;
     if (dto.timezone !== undefined) patch.timezone = dto.timezone;
+    if (dto.profileVisibility !== undefined) patch.profileVisibility = dto.profileVisibility;
 
     if (Object.keys(patch).length === 0) {
       return this.mapUserResponse(existingUser);

--- a/apps/web/src/app/profile/[username]/page.test.tsx
+++ b/apps/web/src/app/profile/[username]/page.test.tsx
@@ -55,6 +55,8 @@ vi.mock('@/components/public-profile', () => ({
   ),
 }));
 
+import { ProfileVisibility } from '@chamuco/shared-types';
+
 import PublicProfilePage from './page';
 
 // --- fixtures ---
@@ -64,7 +66,7 @@ const publicProfileData = {
   displayName: 'John Smith',
   avatarUrl: null,
   bio: 'Avid traveler.',
-  profileVisibility: 'PUBLIC',
+  profileVisibility: ProfileVisibility.PUBLIC,
   travelerScore: null,
   achievements: ['FIRST_TRIP'],
   recognitions: [],
@@ -83,7 +85,7 @@ const privateProfileData = {
   displayName: 'John Smith',
   avatarUrl: null,
   bio: null,
-  profileVisibility: 'PRIVATE',
+  profileVisibility: ProfileVisibility.PRIVATE,
   travelerScore: null,
   achievements: null,
   recognitions: null,

--- a/apps/web/src/app/profile/[username]/page.test.tsx
+++ b/apps/web/src/app/profile/[username]/page.test.tsx
@@ -1,0 +1,259 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, beforeEach } from 'vitest';
+
+// --- hoisted mocks ---
+
+const mocks = vi.hoisted(() => ({
+  mockApiGet: vi.fn(),
+  mockRouterBack: vi.fn(),
+  mockUsername: 'jsmith',
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ back: mocks.mockRouterBack }),
+  useParams: () => ({ username: mocks.mockUsername }),
+}));
+
+vi.mock('@/services/api-client', () => ({
+  apiClient: { get: mocks.mockApiGet },
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (_ns?: string) => ({
+    t: (key: string, opts?: Record<string, string>) => {
+      if (opts) {
+        return Object.entries(opts).reduce((acc, [k, v]) => acc.replace(`{{${k}}}`, v), key);
+      }
+      return key;
+    },
+    i18n: { language: 'en' },
+  }),
+}));
+
+vi.mock('@/components/ui/spinner', () => ({
+  Spinner: () => <div role="status" aria-label="loading" />,
+}));
+
+vi.mock('@/components/public-profile', () => ({
+  PublicProfileHeader: ({ displayName, username }: { displayName: string; username: string }) => (
+    <div data-testid="public-profile-header">
+      {displayName} @{username}
+    </div>
+  ),
+  PublicProfileStats: ({ keyStats }: { keyStats: { tripsCompleted: number } }) => (
+    <div data-testid="public-profile-stats">{keyStats.tripsCompleted} trips</div>
+  ),
+  PublicProfileAchievements: ({ achievements }: { achievements: string[] }) => (
+    <div data-testid="public-profile-achievements">{achievements.length} achievements</div>
+  ),
+  PublicProfileRecognitions: ({ recognitions }: { recognitions: string[] }) => (
+    <div data-testid="public-profile-recognitions">{recognitions.length} recognitions</div>
+  ),
+  PublicProfileDiscoveryMap: ({ countries }: { countries: string[] }) => (
+    <div data-testid="public-profile-discovery-map">{countries.length} countries</div>
+  ),
+}));
+
+import PublicProfilePage from './page';
+
+// --- fixtures ---
+
+const publicProfileData = {
+  username: 'jsmith',
+  displayName: 'John Smith',
+  avatarUrl: null,
+  bio: 'Avid traveler.',
+  profileVisibility: 'PUBLIC',
+  travelerScore: null,
+  achievements: ['FIRST_TRIP'],
+  recognitions: [],
+  keyStats: {
+    tripsCompleted: 12,
+    countriesVisited: 8,
+    citiesVisited: 25,
+    kmTraveled: 45000,
+    tripsAsOrganizer: 3,
+  },
+  discoveryMap: ['MX', 'US'],
+};
+
+const privateProfileData = {
+  username: 'jsmith',
+  displayName: 'John Smith',
+  avatarUrl: null,
+  bio: null,
+  profileVisibility: 'PRIVATE',
+  travelerScore: null,
+  achievements: null,
+  recognitions: null,
+  keyStats: null,
+  discoveryMap: null,
+};
+
+function make404Error() {
+  return Object.assign(new Error('Not found'), {
+    response: { status: 404 },
+  });
+}
+
+function makeGenericError() {
+  return Object.assign(new Error('Server error'), {
+    response: { status: 500 },
+  });
+}
+
+// --- tests ---
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('PublicProfilePage', () => {
+  describe('loading state', () => {
+    it('shows spinner while fetching', () => {
+      mocks.mockApiGet.mockReturnValue(new Promise(() => undefined));
+      render(<PublicProfilePage />);
+      expect(screen.getByRole('status')).toBeInTheDocument();
+    });
+  });
+
+  describe('404 state', () => {
+    it('shows not-found empty state when API returns 404', async () => {
+      mocks.mockApiGet.mockRejectedValue(make404Error());
+      render(<PublicProfilePage />);
+      await waitFor(() => expect(screen.getByText('publicProfile.notFound')).toBeInTheDocument());
+    });
+
+    it('includes the username in the not-found description', async () => {
+      mocks.mockApiGet.mockRejectedValue(make404Error());
+      render(<PublicProfilePage />);
+      await waitFor(() =>
+        expect(
+          screen.getByText(
+            'publicProfile.notFoundDescription'.replace('{{username}}', mocks.mockUsername),
+          ),
+        ).toBeInTheDocument(),
+      );
+    });
+
+    it('renders back button on not-found state', async () => {
+      mocks.mockApiGet.mockRejectedValue(make404Error());
+      render(<PublicProfilePage />);
+      await waitFor(() => expect(screen.getByRole('button')).toBeInTheDocument());
+    });
+
+    it('calls router.back when back button is clicked on not-found', async () => {
+      const user = userEvent.setup();
+      mocks.mockApiGet.mockRejectedValue(make404Error());
+      render(<PublicProfilePage />);
+      await waitFor(() => screen.getByRole('button'));
+      await user.click(screen.getByRole('button'));
+      expect(mocks.mockRouterBack).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('error state', () => {
+    it('shows load error when API fails with non-404', async () => {
+      mocks.mockApiGet.mockRejectedValue(makeGenericError());
+      render(<PublicProfilePage />);
+      await waitFor(() => expect(screen.getByText('publicProfile.loadError')).toBeInTheDocument());
+    });
+
+    it('retries on retry button click', async () => {
+      const user = userEvent.setup();
+      mocks.mockApiGet
+        .mockRejectedValueOnce(makeGenericError())
+        .mockResolvedValue({ data: publicProfileData });
+      render(<PublicProfilePage />);
+      await waitFor(() => screen.getByText('publicProfile.loadError'));
+      await user.click(screen.getByText('publicProfile.retry'));
+      await waitFor(() => expect(screen.getByTestId('public-profile-header')).toBeInTheDocument());
+    });
+  });
+
+  describe('public profile', () => {
+    beforeEach(() => {
+      mocks.mockApiGet.mockResolvedValue({ data: publicProfileData });
+    });
+
+    it('renders the profile header', async () => {
+      render(<PublicProfilePage />);
+      await waitFor(() => expect(screen.getByTestId('public-profile-header')).toBeInTheDocument());
+    });
+
+    it('renders stats when keyStats is not null', async () => {
+      render(<PublicProfilePage />);
+      await waitFor(() => expect(screen.getByTestId('public-profile-stats')).toBeInTheDocument());
+    });
+
+    it('renders achievements when achievements is not null', async () => {
+      render(<PublicProfilePage />);
+      await waitFor(() =>
+        expect(screen.getByTestId('public-profile-achievements')).toBeInTheDocument(),
+      );
+    });
+
+    it('renders recognitions when recognitions is not null', async () => {
+      render(<PublicProfilePage />);
+      await waitFor(() =>
+        expect(screen.getByTestId('public-profile-recognitions')).toBeInTheDocument(),
+      );
+    });
+
+    it('renders discovery map when discoveryMap is not null', async () => {
+      render(<PublicProfilePage />);
+      await waitFor(() =>
+        expect(screen.getByTestId('public-profile-discovery-map')).toBeInTheDocument(),
+      );
+    });
+
+    it('does not show private-profile message when gamification is visible', async () => {
+      render(<PublicProfilePage />);
+      await waitFor(() => screen.getByTestId('public-profile-header'));
+      expect(screen.queryByText('publicProfile.privateProfile')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('private profile', () => {
+    beforeEach(() => {
+      mocks.mockApiGet.mockResolvedValue({ data: privateProfileData });
+    });
+
+    it('renders the profile header', async () => {
+      render(<PublicProfilePage />);
+      await waitFor(() => expect(screen.getByTestId('public-profile-header')).toBeInTheDocument());
+    });
+
+    it('shows private-profile message when all gamification fields are null', async () => {
+      render(<PublicProfilePage />);
+      await waitFor(() =>
+        expect(screen.getByText('publicProfile.privateProfile')).toBeInTheDocument(),
+      );
+    });
+
+    it('does not render stats when keyStats is null', async () => {
+      render(<PublicProfilePage />);
+      await waitFor(() => screen.getByTestId('public-profile-header'));
+      expect(screen.queryByTestId('public-profile-stats')).not.toBeInTheDocument();
+    });
+
+    it('does not render achievements when achievements is null', async () => {
+      render(<PublicProfilePage />);
+      await waitFor(() => screen.getByTestId('public-profile-header'));
+      expect(screen.queryByTestId('public-profile-achievements')).not.toBeInTheDocument();
+    });
+
+    it('does not render recognitions when recognitions is null', async () => {
+      render(<PublicProfilePage />);
+      await waitFor(() => screen.getByTestId('public-profile-header'));
+      expect(screen.queryByTestId('public-profile-recognitions')).not.toBeInTheDocument();
+    });
+
+    it('does not render discovery map when discoveryMap is null', async () => {
+      render(<PublicProfilePage />);
+      await waitFor(() => screen.getByTestId('public-profile-header'));
+      expect(screen.queryByTestId('public-profile-discovery-map')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/src/app/profile/[username]/page.tsx
+++ b/apps/web/src/app/profile/[username]/page.tsx
@@ -16,13 +16,14 @@ import {
 } from '@/components/public-profile';
 import type { KeyStats } from '@/components/public-profile';
 import { apiClient } from '@/services/api-client';
+import { ProfileVisibility } from '@chamuco/shared-types';
 
 interface PublicProfileData {
   username: string;
   displayName: string;
   avatarUrl: string | null;
   bio: string | null;
-  profileVisibility: string;
+  profileVisibility: ProfileVisibility;
   travelerScore: number | null;
   achievements: string[] | null;
   recognitions: string[] | null;

--- a/apps/web/src/app/profile/[username]/page.tsx
+++ b/apps/web/src/app/profile/[username]/page.tsx
@@ -1,0 +1,140 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import { useTranslation } from 'react-i18next';
+
+import { Spinner } from '@/components/ui/spinner';
+import { Button } from '@/components/ui/button';
+import { EmptyState } from '@/components/ui/empty-state';
+import {
+  PublicProfileHeader,
+  PublicProfileStats,
+  PublicProfileAchievements,
+  PublicProfileRecognitions,
+  PublicProfileDiscoveryMap,
+} from '@/components/public-profile';
+import type { KeyStats } from '@/components/public-profile';
+import { apiClient } from '@/services/api-client';
+
+interface PublicProfileData {
+  username: string;
+  displayName: string;
+  avatarUrl: string | null;
+  bio: string | null;
+  profileVisibility: string;
+  travelerScore: number | null;
+  achievements: string[] | null;
+  recognitions: string[] | null;
+  keyStats: KeyStats | null;
+  discoveryMap: string[] | null;
+}
+
+export default function PublicProfilePage() {
+  const { t } = useTranslation('profile');
+  const params = useParams<{ username: string }>();
+  const router = useRouter();
+  const username = params.username;
+
+  const [isLoading, setIsLoading] = useState(true);
+  const [isNotFound, setIsNotFound] = useState(false);
+  const [hasError, setHasError] = useState(false);
+  const [profileData, setProfileData] = useState<PublicProfileData | null>(null);
+
+  const loadProfile = useCallback(async () => {
+    setIsLoading(true);
+    setIsNotFound(false);
+    setHasError(false);
+    try {
+      const res = await apiClient.get(`/v1/users/${username}/profile`);
+      setProfileData(res.data as PublicProfileData);
+    } catch (err: unknown) {
+      const status = (err as { response?: { status?: number } }).response?.status;
+      if (status === 404) {
+        setIsNotFound(true);
+      } else {
+        setHasError(true);
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  }, [username]);
+
+  useEffect(() => {
+    void loadProfile();
+  }, [loadProfile]);
+
+  if (isLoading) {
+    return (
+      <div className="flex min-h-[50vh] items-center justify-center p-8">
+        <Spinner size="lg" />
+      </div>
+    );
+  }
+
+  if (isNotFound) {
+    return (
+      <div className="flex min-h-[50vh] items-center justify-center p-8">
+        <EmptyState
+          title={t('publicProfile.notFound')}
+          description={t('publicProfile.notFoundDescription', { username })}
+          action={
+            <Button variant="outline" onClick={() => router.back()}>
+              {t('common:actions.back')}
+            </Button>
+          }
+        />
+      </div>
+    );
+  }
+
+  if (hasError || !profileData) {
+    return (
+      <div className="flex min-h-[50vh] items-center justify-center p-8">
+        <EmptyState
+          title={t('publicProfile.loadError')}
+          action={
+            <Button variant="outline" onClick={() => void loadProfile()}>
+              {t('publicProfile.retry')}
+            </Button>
+          }
+        />
+      </div>
+    );
+  }
+
+  const isGamificationVisible =
+    profileData.achievements !== null ||
+    profileData.recognitions !== null ||
+    profileData.keyStats !== null ||
+    profileData.discoveryMap !== null;
+
+  return (
+    <main className="mx-auto max-w-2xl space-y-8 px-4 py-8">
+      <PublicProfileHeader
+        displayName={profileData.displayName}
+        username={profileData.username}
+        avatarUrl={profileData.avatarUrl}
+        bio={profileData.bio}
+      />
+
+      {!isGamificationVisible && (
+        <p className="text-sm text-muted-foreground">{t('publicProfile.privateProfile')}</p>
+      )}
+
+      {profileData.keyStats !== null && <PublicProfileStats keyStats={profileData.keyStats} />}
+
+      {profileData.achievements !== null && (
+        <PublicProfileAchievements achievements={profileData.achievements} />
+      )}
+
+      {profileData.recognitions !== null && (
+        <PublicProfileRecognitions recognitions={profileData.recognitions} />
+      )}
+
+      {profileData.discoveryMap !== null && (
+        <PublicProfileDiscoveryMap countries={profileData.discoveryMap} />
+      )}
+    </main>
+  );
+}

--- a/apps/web/src/app/profile/[username]/page.tsx
+++ b/apps/web/src/app/profile/[username]/page.tsx
@@ -105,6 +105,7 @@ export default function PublicProfilePage() {
   }
 
   const isGamificationVisible =
+    profileData.travelerScore !== null ||
     profileData.achievements !== null ||
     profileData.recognitions !== null ||
     profileData.keyStats !== null ||
@@ -122,6 +123,8 @@ export default function PublicProfilePage() {
       {!isGamificationVisible && (
         <p className="text-sm text-muted-foreground">{t('publicProfile.privateProfile')}</p>
       )}
+
+      {/* TODO: render travelerScore + global ranking when TravelerScoreCard component is built */}
 
       {profileData.keyStats !== null && <PublicProfileStats keyStats={profileData.keyStats} />}
 

--- a/apps/web/src/components/profile/BasicInfoSection.test.tsx
+++ b/apps/web/src/components/profile/BasicInfoSection.test.tsx
@@ -65,6 +65,7 @@ const baseUser: BasicInfoUser = {
   displayName: 'Jane Doe',
   avatarUrl: null,
   timezone: 'America/Bogota',
+  profileVisibility: 'PRIVATE',
 };
 
 const baseProfile: BasicInfoProfile = { bio: 'Hello world', homeCountry: 'CO' };
@@ -228,6 +229,21 @@ describe('BasicInfoSection', () => {
       );
     });
 
+    it('includes profileVisibility in the PATCH /v1/users/me payload', async () => {
+      const { user } = setup({ profileVisibility: 'PRIVATE' });
+      await user.selectOptions(
+        screen.getByLabelText('basicInfo.profileVisibility'),
+        'basicInfo.profileVisibilityOptions.PUBLIC',
+      );
+      await user.click(screen.getByRole('button', { name: 'basicInfo.save' }));
+      await waitFor(() =>
+        expect(mocks.mockPatch).toHaveBeenCalledWith(
+          '/v1/users/me',
+          expect.objectContaining({ profileVisibility: 'PUBLIC' }),
+        ),
+      );
+    });
+
     it('sends the auto-suggested timezone when saving with UTC default', async () => {
       const { user } = setup({ timezone: 'UTC' }, { homeCountry: 'CO' });
       await user.click(screen.getByRole('button', { name: 'basicInfo.save' }));
@@ -312,6 +328,20 @@ describe('BasicInfoSection', () => {
       await user.clear(displayNameInput);
       await user.type(displayNameInput, 'Jane Doe');
       expect(screen.queryByTestId('unsaved-indicator')).not.toBeInTheDocument();
+    });
+
+    it('hides indicator when profileVisibility matches initial value', () => {
+      setup({ profileVisibility: 'PRIVATE' });
+      expect(screen.queryByTestId('unsaved-indicator')).not.toBeInTheDocument();
+    });
+
+    it('shows indicator after changing profileVisibility', async () => {
+      const { user } = setup({ profileVisibility: 'PRIVATE' });
+      await user.selectOptions(
+        screen.getByLabelText('basicInfo.profileVisibility'),
+        'basicInfo.profileVisibilityOptions.PUBLIC',
+      );
+      expect(screen.getByTestId('unsaved-indicator')).toBeInTheDocument();
     });
 
     it('hides indicator while saving', async () => {

--- a/apps/web/src/components/profile/BasicInfoSection.test.tsx
+++ b/apps/web/src/components/profile/BasicInfoSection.test.tsx
@@ -57,6 +57,8 @@ vi.mock('@/components/ui/timezone-combobox', () => ({
   ),
 }));
 
+import { ProfileVisibility } from '@chamuco/shared-types';
+
 import { BasicInfoSection } from './BasicInfoSection';
 import type { BasicInfoUser, BasicInfoProfile } from './BasicInfoSection';
 
@@ -65,7 +67,7 @@ const baseUser: BasicInfoUser = {
   displayName: 'Jane Doe',
   avatarUrl: null,
   timezone: 'America/Bogota',
-  profileVisibility: 'PRIVATE',
+  profileVisibility: ProfileVisibility.PRIVATE,
 };
 
 const baseProfile: BasicInfoProfile = { bio: 'Hello world', homeCountry: 'CO' };
@@ -230,7 +232,7 @@ describe('BasicInfoSection', () => {
     });
 
     it('includes profileVisibility in the PATCH /v1/users/me payload', async () => {
-      const { user } = setup({ profileVisibility: 'PRIVATE' });
+      const { user } = setup({ profileVisibility: ProfileVisibility.PRIVATE });
       await user.selectOptions(
         screen.getByLabelText('basicInfo.profileVisibility'),
         'basicInfo.profileVisibilityOptions.PUBLIC',
@@ -331,12 +333,12 @@ describe('BasicInfoSection', () => {
     });
 
     it('hides indicator when profileVisibility matches initial value', () => {
-      setup({ profileVisibility: 'PRIVATE' });
+      setup({ profileVisibility: ProfileVisibility.PRIVATE });
       expect(screen.queryByTestId('unsaved-indicator')).not.toBeInTheDocument();
     });
 
     it('shows indicator after changing profileVisibility', async () => {
-      const { user } = setup({ profileVisibility: 'PRIVATE' });
+      const { user } = setup({ profileVisibility: ProfileVisibility.PRIVATE });
       await user.selectOptions(
         screen.getByLabelText('basicInfo.profileVisibility'),
         'basicInfo.profileVisibilityOptions.PUBLIC',

--- a/apps/web/src/components/profile/BasicInfoSection.tsx
+++ b/apps/web/src/components/profile/BasicInfoSection.tsx
@@ -2,11 +2,13 @@
 
 import { useState, type FormEvent } from 'react';
 import { useTranslation } from 'react-i18next';
+import { ProfileVisibility } from '@chamuco/shared-types';
 
 import { Avatar } from '@/components/ui/avatar';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { Select } from '@/components/ui/select';
 import { Spinner } from '@/components/ui/spinner';
 import { Textarea } from '@/components/ui/textarea';
 import { TimezoneCombobox } from '@/components/ui/timezone-combobox';
@@ -19,6 +21,7 @@ export interface BasicInfoUser {
   displayName: string;
   avatarUrl: string | null;
   timezone: string;
+  profileVisibility: string;
 }
 
 export interface BasicInfoProfile {
@@ -48,6 +51,7 @@ export function BasicInfoSection({ user, userProfile, onRefresh }: BasicInfoSect
   const [bio, setBio] = useState(userProfile.bio ?? '');
   const [isSaving, setIsSaving] = useState(false);
   const [displayNameError, setDisplayNameError] = useState<string | null>(null);
+  const [visibility, setVisibility] = useState(user.profileVisibility);
 
   const suggestedTimezone =
     user.timezone === 'UTC' && userProfile.homeCountry
@@ -58,7 +62,8 @@ export function BasicInfoSection({ user, userProfile, onRefresh }: BasicInfoSect
   const isDirty =
     displayName.trim() !== user.displayName ||
     (bio.trim() || null) !== userProfile.bio ||
-    timezone !== user.timezone;
+    timezone !== user.timezone ||
+    visibility !== user.profileVisibility;
 
   async function handleSave(e: FormEvent) {
     e.preventDefault();
@@ -74,6 +79,7 @@ export function BasicInfoSection({ user, userProfile, onRefresh }: BasicInfoSect
         apiClient.patch('/v1/users/me', {
           displayName: trimmedName,
           timezone,
+          profileVisibility: visibility,
         }),
         apiClient.patch('/v1/users/me/profile', {
           bio: bio.trim() || null,
@@ -151,6 +157,23 @@ export function BasicInfoSection({ user, userProfile, onRefresh }: BasicInfoSect
           aria-labelledby="timezone-label"
           className="w-full"
         />
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="profileVisibility">{t('basicInfo.profileVisibility')}</Label>
+        <Select
+          id="profileVisibility"
+          value={visibility}
+          onChange={(e) => setVisibility(e.target.value)}
+          disabled={isSaving}
+        >
+          {Object.values(ProfileVisibility).map((v) => (
+            <option key={v} value={v}>
+              {t(`basicInfo.profileVisibilityOptions.${v}`)}
+            </option>
+          ))}
+        </Select>
+        <p className="text-xs text-muted-foreground">{t('basicInfo.profileVisibilityHint')}</p>
       </div>
 
       <Button type="submit" disabled={isSaving} className="gap-2">

--- a/apps/web/src/components/profile/BasicInfoSection.tsx
+++ b/apps/web/src/components/profile/BasicInfoSection.tsx
@@ -15,13 +15,14 @@ import { TimezoneCombobox } from '@/components/ui/timezone-combobox';
 import { toast } from '@/components/ui/toast';
 import { apiClient } from '@/services/api-client';
 import { COUNTRY_TIMEZONE } from '@/lib/timezones';
+import { getInitials } from '@/lib/name-utils';
 
 export interface BasicInfoUser {
   username: string;
   displayName: string;
   avatarUrl: string | null;
   timezone: string;
-  profileVisibility: string;
+  profileVisibility: ProfileVisibility;
 }
 
 export interface BasicInfoProfile {
@@ -33,15 +34,6 @@ interface BasicInfoSectionProps {
   user: BasicInfoUser;
   userProfile: BasicInfoProfile;
   onRefresh: () => void;
-}
-
-function getInitials(name: string): string {
-  return name
-    .split(' ')
-    .map((n) => n[0])
-    .join('')
-    .toUpperCase()
-    .slice(0, 2);
 }
 
 export function BasicInfoSection({ user, userProfile, onRefresh }: BasicInfoSectionProps) {
@@ -164,7 +156,7 @@ export function BasicInfoSection({ user, userProfile, onRefresh }: BasicInfoSect
         <Select
           id="profileVisibility"
           value={visibility}
-          onChange={(e) => setVisibility(e.target.value)}
+          onChange={(e) => setVisibility(e.target.value as ProfileVisibility)}
           disabled={isSaving}
         >
           {Object.values(ProfileVisibility).map((v) => (

--- a/apps/web/src/components/public-profile/PublicProfileAchievements.test.tsx
+++ b/apps/web/src/components/public-profile/PublicProfileAchievements.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en' } }),
+}));
+
+import { PublicProfileAchievements } from './PublicProfileAchievements';
+
+describe('PublicProfileAchievements', () => {
+  it('renders section heading', () => {
+    render(<PublicProfileAchievements achievements={[]} />);
+    expect(
+      screen.getByRole('region', { name: /publicProfile.achievements.heading/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('shows empty state when no achievements', () => {
+    render(<PublicProfileAchievements achievements={[]} />);
+    expect(screen.getByText('publicProfile.achievements.empty')).toBeInTheDocument();
+  });
+
+  it('renders a badge for each achievement', () => {
+    render(<PublicProfileAchievements achievements={['FIRST_TRIP', 'EXPLORER_5_COUNTRIES']} />);
+    expect(screen.getByText('First Trip')).toBeInTheDocument();
+    expect(screen.getByText('Explorer 5 Countries')).toBeInTheDocument();
+  });
+
+  it('humanizes underscore-separated achievement IDs', () => {
+    render(<PublicProfileAchievements achievements={['KM_1000']} />);
+    expect(screen.getByText('Km 1000')).toBeInTheDocument();
+  });
+
+  it('does not show empty state when there are achievements', () => {
+    render(<PublicProfileAchievements achievements={['FIRST_TRIP']} />);
+    expect(screen.queryByText('publicProfile.achievements.empty')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/public-profile/PublicProfileAchievements.tsx
+++ b/apps/web/src/components/public-profile/PublicProfileAchievements.tsx
@@ -4,14 +4,7 @@ import { useTranslation } from 'react-i18next';
 
 import { Badge } from '@/components/ui/badge';
 import { EmptyState } from '@/components/ui/empty-state';
-
-function humanizeAchievementId(id: string): string {
-  return id
-    .toLowerCase()
-    .split('_')
-    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-    .join(' ');
-}
+import { humanizeId } from '@/lib/name-utils';
 
 export interface PublicProfileAchievementsProps {
   achievements: string[];
@@ -34,7 +27,7 @@ export function PublicProfileAchievements({ achievements }: PublicProfileAchieve
         <div className="flex flex-wrap gap-2">
           {achievements.map((id) => (
             <Badge key={id} variant="secondary">
-              {humanizeAchievementId(id)}
+              {humanizeId(id)}
             </Badge>
           ))}
         </div>

--- a/apps/web/src/components/public-profile/PublicProfileAchievements.tsx
+++ b/apps/web/src/components/public-profile/PublicProfileAchievements.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { useTranslation } from 'react-i18next';
+
+import { Badge } from '@/components/ui/badge';
+import { EmptyState } from '@/components/ui/empty-state';
+
+function humanizeAchievementId(id: string): string {
+  return id
+    .toLowerCase()
+    .split('_')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+}
+
+export interface PublicProfileAchievementsProps {
+  achievements: string[];
+}
+
+export function PublicProfileAchievements({ achievements }: PublicProfileAchievementsProps) {
+  const { t } = useTranslation('profile');
+
+  return (
+    <section aria-labelledby="achievements-heading">
+      <h2
+        id="achievements-heading"
+        className="mb-3 text-sm font-semibold uppercase tracking-wide text-muted-foreground"
+      >
+        {t('publicProfile.achievements.heading')}
+      </h2>
+      {achievements.length === 0 ? (
+        <EmptyState title={t('publicProfile.achievements.empty')} />
+      ) : (
+        <div className="flex flex-wrap gap-2">
+          {achievements.map((id) => (
+            <Badge key={id} variant="secondary">
+              {humanizeAchievementId(id)}
+            </Badge>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/components/public-profile/PublicProfileDiscoveryMap.test.tsx
+++ b/apps/web/src/components/public-profile/PublicProfileDiscoveryMap.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en' } }),
+}));
+
+import { PublicProfileDiscoveryMap } from './PublicProfileDiscoveryMap';
+
+describe('PublicProfileDiscoveryMap', () => {
+  it('renders section heading', () => {
+    render(<PublicProfileDiscoveryMap countries={[]} />);
+    expect(
+      screen.getByRole('region', { name: /publicProfile.discoveryMap.heading/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders placeholder text', () => {
+    render(<PublicProfileDiscoveryMap countries={[]} />);
+    expect(screen.getByText('publicProfile.discoveryMap.placeholder')).toBeInTheDocument();
+  });
+
+  it('renders country code badges when countries provided', () => {
+    render(<PublicProfileDiscoveryMap countries={['MX', 'US', 'ES']} />);
+    expect(screen.getByText('MX')).toBeInTheDocument();
+    expect(screen.getByText('US')).toBeInTheDocument();
+    expect(screen.getByText('ES')).toBeInTheDocument();
+  });
+
+  it('renders no country badges when countries is empty', () => {
+    render(<PublicProfileDiscoveryMap countries={[]} />);
+    expect(screen.queryByRole('generic', { name: /^[A-Z]{2}$/ })).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/public-profile/PublicProfileDiscoveryMap.test.tsx
+++ b/apps/web/src/components/public-profile/PublicProfileDiscoveryMap.test.tsx
@@ -29,6 +29,6 @@ describe('PublicProfileDiscoveryMap', () => {
 
   it('renders no country badges when countries is empty', () => {
     render(<PublicProfileDiscoveryMap countries={[]} />);
-    expect(screen.queryByRole('generic', { name: /^[A-Z]{2}$/ })).not.toBeInTheDocument();
+    expect(screen.queryByText('MX')).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/public-profile/PublicProfileDiscoveryMap.tsx
+++ b/apps/web/src/components/public-profile/PublicProfileDiscoveryMap.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { useTranslation } from 'react-i18next';
+
+import { Badge } from '@/components/ui/badge';
+
+export interface PublicProfileDiscoveryMapProps {
+  countries: string[];
+}
+
+export function PublicProfileDiscoveryMap({ countries }: PublicProfileDiscoveryMapProps) {
+  const { t } = useTranslation('profile');
+
+  return (
+    <section aria-labelledby="discovery-map-heading">
+      <h2
+        id="discovery-map-heading"
+        className="mb-3 text-sm font-semibold uppercase tracking-wide text-muted-foreground"
+      >
+        {t('publicProfile.discoveryMap.heading')}
+      </h2>
+      <div className="rounded-xl border border-dashed border-border bg-muted/30 p-6 text-center">
+        <p className="mb-3 text-sm text-muted-foreground">
+          {t('publicProfile.discoveryMap.placeholder')}
+        </p>
+        {countries.length > 0 && (
+          <div className="flex flex-wrap justify-center gap-1.5">
+            {countries.map((code) => (
+              <Badge key={code} variant="outline" className="font-mono text-xs">
+                {code}
+              </Badge>
+            ))}
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/public-profile/PublicProfileHeader.test.tsx
+++ b/apps/web/src/components/public-profile/PublicProfileHeader.test.tsx
@@ -1,10 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import { describe, it, expect } from 'vitest';
 
-vi.mock('react-i18next', () => ({
-  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en' } }),
-}));
-
 vi.mock('@/components/ui/avatar', () => ({
   Avatar: ({ alt, fallback }: { alt?: string; fallback?: string }) => (
     <div data-testid="avatar" aria-label={alt}>

--- a/apps/web/src/components/public-profile/PublicProfileHeader.test.tsx
+++ b/apps/web/src/components/public-profile/PublicProfileHeader.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en' } }),
+}));
+
+vi.mock('@/components/ui/avatar', () => ({
+  Avatar: ({ alt, fallback }: { alt?: string; fallback?: string }) => (
+    <div data-testid="avatar" aria-label={alt}>
+      {fallback}
+    </div>
+  ),
+}));
+
+import { PublicProfileHeader } from './PublicProfileHeader';
+
+describe('PublicProfileHeader', () => {
+  const baseProps = {
+    displayName: 'John Smith',
+    username: 'jsmith',
+    avatarUrl: null,
+    bio: null,
+  };
+
+  it('renders display name', () => {
+    render(<PublicProfileHeader {...baseProps} />);
+    expect(screen.getByText('John Smith')).toBeInTheDocument();
+  });
+
+  it('renders @username', () => {
+    render(<PublicProfileHeader {...baseProps} />);
+    expect(screen.getByText('@jsmith')).toBeInTheDocument();
+  });
+
+  it('renders bio when provided', () => {
+    render(<PublicProfileHeader {...baseProps} bio="Avid traveler." />);
+    expect(screen.getByText('Avid traveler.')).toBeInTheDocument();
+  });
+
+  it('does not render bio element when bio is null', () => {
+    render(<PublicProfileHeader {...baseProps} bio={null} />);
+    expect(screen.queryByRole('paragraph')).not.toBeInTheDocument();
+  });
+
+  it('passes avatarUrl to Avatar', () => {
+    render(<PublicProfileHeader {...baseProps} avatarUrl="https://cdn.example.com/avatar.jpg" />);
+    expect(screen.getByTestId('avatar')).toBeInTheDocument();
+  });
+
+  it('passes initials as fallback to Avatar', () => {
+    render(<PublicProfileHeader {...baseProps} displayName="John Smith" />);
+    expect(screen.getByTestId('avatar')).toHaveTextContent('JS');
+  });
+
+  it('handles single-word display name for initials', () => {
+    render(<PublicProfileHeader {...baseProps} displayName="Madonna" />);
+    expect(screen.getByTestId('avatar')).toHaveTextContent('M');
+  });
+});

--- a/apps/web/src/components/public-profile/PublicProfileHeader.tsx
+++ b/apps/web/src/components/public-profile/PublicProfileHeader.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { useTranslation } from 'react-i18next';
+
+import { Avatar } from '@/components/ui/avatar';
+
+function getInitials(name: string): string {
+  return name
+    .split(' ')
+    .map((n) => n[0])
+    .join('')
+    .toUpperCase()
+    .slice(0, 2);
+}
+
+export interface PublicProfileHeaderProps {
+  displayName: string;
+  username: string;
+  avatarUrl: string | null;
+  bio: string | null;
+}
+
+export function PublicProfileHeader({
+  displayName,
+  username,
+  avatarUrl,
+  bio,
+}: PublicProfileHeaderProps) {
+  const { t } = useTranslation('profile');
+
+  return (
+    <div className="flex flex-col items-center gap-4 text-center sm:flex-row sm:items-start sm:text-left">
+      <Avatar
+        src={avatarUrl ?? undefined}
+        alt={displayName}
+        fallback={getInitials(displayName)}
+        size="lg"
+        className="size-20 text-xl shrink-0"
+      />
+      <div className="flex flex-col gap-1">
+        <h1 className="text-2xl font-bold text-foreground">{displayName}</h1>
+        <p className="text-sm text-muted-foreground">@{username}</p>
+        {bio && (
+          <p aria-label={t('basicInfo.bio')} className="mt-2 text-sm text-foreground/80">
+            {bio}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/public-profile/PublicProfileHeader.tsx
+++ b/apps/web/src/components/public-profile/PublicProfileHeader.tsx
@@ -1,17 +1,7 @@
 'use client';
 
-import { useTranslation } from 'react-i18next';
-
 import { Avatar } from '@/components/ui/avatar';
-
-function getInitials(name: string): string {
-  return name
-    .split(' ')
-    .map((n) => n[0])
-    .join('')
-    .toUpperCase()
-    .slice(0, 2);
-}
+import { getInitials } from '@/lib/name-utils';
 
 export interface PublicProfileHeaderProps {
   displayName: string;
@@ -26,8 +16,6 @@ export function PublicProfileHeader({
   avatarUrl,
   bio,
 }: PublicProfileHeaderProps) {
-  const { t } = useTranslation('profile');
-
   return (
     <div className="flex flex-col items-center gap-4 text-center sm:flex-row sm:items-start sm:text-left">
       <Avatar
@@ -40,11 +28,7 @@ export function PublicProfileHeader({
       <div className="flex flex-col gap-1">
         <h1 className="text-2xl font-bold text-foreground">{displayName}</h1>
         <p className="text-sm text-muted-foreground">@{username}</p>
-        {bio && (
-          <p aria-label={t('basicInfo.bio')} className="mt-2 text-sm text-foreground/80">
-            {bio}
-          </p>
-        )}
+        {bio && <p className="mt-2 text-sm text-foreground/80">{bio}</p>}
       </div>
     </div>
   );

--- a/apps/web/src/components/public-profile/PublicProfileRecognitions.test.tsx
+++ b/apps/web/src/components/public-profile/PublicProfileRecognitions.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en' } }),
+}));
+
+import { PublicProfileRecognitions } from './PublicProfileRecognitions';
+
+describe('PublicProfileRecognitions', () => {
+  it('renders section heading', () => {
+    render(<PublicProfileRecognitions recognitions={[]} />);
+    expect(
+      screen.getByRole('region', { name: /publicProfile.recognitions.heading/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('shows empty state when no recognitions', () => {
+    render(<PublicProfileRecognitions recognitions={[]} />);
+    expect(screen.getByText('publicProfile.recognitions.empty')).toBeInTheDocument();
+  });
+
+  it('renders a badge for each recognition', () => {
+    render(<PublicProfileRecognitions recognitions={['TRIP_COMPLETION', 'GROUP_ANNUAL']} />);
+    expect(screen.getByText('Trip Completion')).toBeInTheDocument();
+    expect(screen.getByText('Group Annual')).toBeInTheDocument();
+  });
+
+  it('does not show empty state when there are recognitions', () => {
+    render(<PublicProfileRecognitions recognitions={['TRIP_COMPLETION']} />);
+    expect(screen.queryByText('publicProfile.recognitions.empty')).not.toBeInTheDocument();
+  });
+
+  it('handles duplicate recognition IDs with index key', () => {
+    render(<PublicProfileRecognitions recognitions={['TRIP_COMPLETION', 'TRIP_COMPLETION']} />);
+    expect(screen.getAllByText('Trip Completion')).toHaveLength(2);
+  });
+});

--- a/apps/web/src/components/public-profile/PublicProfileRecognitions.tsx
+++ b/apps/web/src/components/public-profile/PublicProfileRecognitions.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { useTranslation } from 'react-i18next';
+
+import { Badge } from '@/components/ui/badge';
+import { EmptyState } from '@/components/ui/empty-state';
+
+function humanizeRecognitionId(id: string): string {
+  return id
+    .toLowerCase()
+    .split('_')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+}
+
+export interface PublicProfileRecognitionsProps {
+  recognitions: string[];
+}
+
+export function PublicProfileRecognitions({ recognitions }: PublicProfileRecognitionsProps) {
+  const { t } = useTranslation('profile');
+
+  return (
+    <section aria-labelledby="recognitions-heading">
+      <h2
+        id="recognitions-heading"
+        className="mb-3 text-sm font-semibold uppercase tracking-wide text-muted-foreground"
+      >
+        {t('publicProfile.recognitions.heading')}
+      </h2>
+      {recognitions.length === 0 ? (
+        <EmptyState title={t('publicProfile.recognitions.empty')} />
+      ) : (
+        <div className="flex flex-wrap gap-2">
+          {recognitions.map((id, index) => (
+            <Badge key={`${id}-${index}`} variant="outline">
+              {humanizeRecognitionId(id)}
+            </Badge>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/components/public-profile/PublicProfileRecognitions.tsx
+++ b/apps/web/src/components/public-profile/PublicProfileRecognitions.tsx
@@ -4,14 +4,7 @@ import { useTranslation } from 'react-i18next';
 
 import { Badge } from '@/components/ui/badge';
 import { EmptyState } from '@/components/ui/empty-state';
-
-function humanizeRecognitionId(id: string): string {
-  return id
-    .toLowerCase()
-    .split('_')
-    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-    .join(' ');
-}
+import { humanizeId } from '@/lib/name-utils';
 
 export interface PublicProfileRecognitionsProps {
   recognitions: string[];
@@ -34,7 +27,7 @@ export function PublicProfileRecognitions({ recognitions }: PublicProfileRecogni
         <div className="flex flex-wrap gap-2">
           {recognitions.map((id, index) => (
             <Badge key={`${id}-${index}`} variant="outline">
-              {humanizeRecognitionId(id)}
+              {humanizeId(id)}
             </Badge>
           ))}
         </div>

--- a/apps/web/src/components/public-profile/PublicProfileStats.test.tsx
+++ b/apps/web/src/components/public-profile/PublicProfileStats.test.tsx
@@ -33,6 +33,11 @@ describe('PublicProfileStats', () => {
     expect(screen.getByText('8')).toBeInTheDocument();
   });
 
+  it('renders citiesVisited value', () => {
+    render(<PublicProfileStats keyStats={baseStats} />);
+    expect(screen.getByText('25')).toBeInTheDocument();
+  });
+
   it('renders kmTraveled with locale formatting', () => {
     render(<PublicProfileStats keyStats={baseStats} />);
     expect(screen.getByText('45,000')).toBeInTheDocument();
@@ -43,10 +48,11 @@ describe('PublicProfileStats', () => {
     expect(screen.getByText('3')).toBeInTheDocument();
   });
 
-  it('renders all four stat labels', () => {
+  it('renders all five stat labels', () => {
     render(<PublicProfileStats keyStats={baseStats} />);
     expect(screen.getByText('publicProfile.stats.tripsCompleted')).toBeInTheDocument();
     expect(screen.getByText('publicProfile.stats.countriesVisited')).toBeInTheDocument();
+    expect(screen.getByText('publicProfile.stats.citiesVisited')).toBeInTheDocument();
     expect(screen.getByText('publicProfile.stats.kmTraveled')).toBeInTheDocument();
     expect(screen.getByText('publicProfile.stats.tripsAsOrganizer')).toBeInTheDocument();
   });

--- a/apps/web/src/components/public-profile/PublicProfileStats.test.tsx
+++ b/apps/web/src/components/public-profile/PublicProfileStats.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en' } }),
+}));
+
+import { PublicProfileStats } from './PublicProfileStats';
+
+const baseStats = {
+  tripsCompleted: 12,
+  countriesVisited: 8,
+  citiesVisited: 25,
+  kmTraveled: 45000,
+  tripsAsOrganizer: 3,
+};
+
+describe('PublicProfileStats', () => {
+  it('renders section heading', () => {
+    render(<PublicProfileStats keyStats={baseStats} />);
+    expect(
+      screen.getByRole('region', { name: /publicProfile.stats.heading/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders tripsCompleted value', () => {
+    render(<PublicProfileStats keyStats={baseStats} />);
+    expect(screen.getByText('12')).toBeInTheDocument();
+  });
+
+  it('renders countriesVisited value', () => {
+    render(<PublicProfileStats keyStats={baseStats} />);
+    expect(screen.getByText('8')).toBeInTheDocument();
+  });
+
+  it('renders kmTraveled with locale formatting', () => {
+    render(<PublicProfileStats keyStats={baseStats} />);
+    expect(screen.getByText('45,000')).toBeInTheDocument();
+  });
+
+  it('renders tripsAsOrganizer value', () => {
+    render(<PublicProfileStats keyStats={baseStats} />);
+    expect(screen.getByText('3')).toBeInTheDocument();
+  });
+
+  it('renders all four stat labels', () => {
+    render(<PublicProfileStats keyStats={baseStats} />);
+    expect(screen.getByText('publicProfile.stats.tripsCompleted')).toBeInTheDocument();
+    expect(screen.getByText('publicProfile.stats.countriesVisited')).toBeInTheDocument();
+    expect(screen.getByText('publicProfile.stats.kmTraveled')).toBeInTheDocument();
+    expect(screen.getByText('publicProfile.stats.tripsAsOrganizer')).toBeInTheDocument();
+  });
+
+  it('renders zero values correctly', () => {
+    render(<PublicProfileStats keyStats={{ ...baseStats, tripsCompleted: 0 }} />);
+    expect(screen.getByText('0')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/public-profile/PublicProfileStats.tsx
+++ b/apps/web/src/components/public-profile/PublicProfileStats.tsx
@@ -39,12 +39,13 @@ export function PublicProfileStats({ keyStats }: PublicProfileStatsProps) {
       >
         {t('publicProfile.stats.heading')}
       </h2>
-      <div className="grid grid-cols-2 gap-4 rounded-xl border border-border bg-card p-4 sm:grid-cols-4">
+      <div className="grid grid-cols-2 gap-4 rounded-xl border border-border bg-card p-4 sm:grid-cols-5">
         <StatItem value={keyStats.tripsCompleted} label={t('publicProfile.stats.tripsCompleted')} />
         <StatItem
           value={keyStats.countriesVisited}
           label={t('publicProfile.stats.countriesVisited')}
         />
+        <StatItem value={keyStats.citiesVisited} label={t('publicProfile.stats.citiesVisited')} />
         <StatItem value={keyStats.kmTraveled} label={t('publicProfile.stats.kmTraveled')} />
         <StatItem
           value={keyStats.tripsAsOrganizer}

--- a/apps/web/src/components/public-profile/PublicProfileStats.tsx
+++ b/apps/web/src/components/public-profile/PublicProfileStats.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { useTranslation } from 'react-i18next';
+
+export interface KeyStats {
+  tripsCompleted: number;
+  countriesVisited: number;
+  citiesVisited: number;
+  kmTraveled: number;
+  tripsAsOrganizer: number;
+}
+
+export interface PublicProfileStatsProps {
+  keyStats: KeyStats;
+}
+
+interface StatItemProps {
+  value: number;
+  label: string;
+}
+
+function StatItem({ value, label }: StatItemProps) {
+  return (
+    <div className="flex flex-col items-center gap-0.5">
+      <span className="text-2xl font-bold text-foreground">{value.toLocaleString()}</span>
+      <span className="text-xs text-muted-foreground">{label}</span>
+    </div>
+  );
+}
+
+export function PublicProfileStats({ keyStats }: PublicProfileStatsProps) {
+  const { t } = useTranslation('profile');
+
+  return (
+    <section aria-labelledby="stats-heading">
+      <h2
+        id="stats-heading"
+        className="mb-3 text-sm font-semibold uppercase tracking-wide text-muted-foreground"
+      >
+        {t('publicProfile.stats.heading')}
+      </h2>
+      <div className="grid grid-cols-2 gap-4 rounded-xl border border-border bg-card p-4 sm:grid-cols-4">
+        <StatItem value={keyStats.tripsCompleted} label={t('publicProfile.stats.tripsCompleted')} />
+        <StatItem
+          value={keyStats.countriesVisited}
+          label={t('publicProfile.stats.countriesVisited')}
+        />
+        <StatItem value={keyStats.kmTraveled} label={t('publicProfile.stats.kmTraveled')} />
+        <StatItem
+          value={keyStats.tripsAsOrganizer}
+          label={t('publicProfile.stats.tripsAsOrganizer')}
+        />
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/public-profile/index.ts
+++ b/apps/web/src/components/public-profile/index.ts
@@ -1,0 +1,14 @@
+export { PublicProfileHeader } from './PublicProfileHeader';
+export type { PublicProfileHeaderProps } from './PublicProfileHeader';
+
+export { PublicProfileStats } from './PublicProfileStats';
+export type { PublicProfileStatsProps, KeyStats } from './PublicProfileStats';
+
+export { PublicProfileAchievements } from './PublicProfileAchievements';
+export type { PublicProfileAchievementsProps } from './PublicProfileAchievements';
+
+export { PublicProfileRecognitions } from './PublicProfileRecognitions';
+export type { PublicProfileRecognitionsProps } from './PublicProfileRecognitions';
+
+export { PublicProfileDiscoveryMap } from './PublicProfileDiscoveryMap';
+export type { PublicProfileDiscoveryMapProps } from './PublicProfileDiscoveryMap';

--- a/apps/web/src/components/ui/select.test.tsx
+++ b/apps/web/src/components/ui/select.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { Select } from './select';
+
+describe('Select', () => {
+  it('renders a select element', () => {
+    render(
+      <Select aria-label="test">
+        <option value="A">Option A</option>
+      </Select>,
+    );
+    expect(screen.getByRole('combobox')).toBeInTheDocument();
+  });
+
+  it('has data-slot attribute', () => {
+    render(<Select aria-label="test" />);
+    expect(screen.getByRole('combobox')).toHaveAttribute('data-slot', 'select');
+  });
+
+  it('renders children options', () => {
+    render(
+      <Select aria-label="test">
+        <option value="A">Alpha</option>
+        <option value="B">Beta</option>
+      </Select>,
+    );
+    expect(screen.getByRole('option', { name: 'Alpha' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Beta' })).toBeInTheDocument();
+  });
+
+  it('forwards className', () => {
+    render(<Select aria-label="test" className="custom-class" />);
+    expect(screen.getByRole('combobox')).toHaveClass('custom-class');
+  });
+
+  it('is disabled when disabled prop is set', () => {
+    render(<Select aria-label="test" disabled />);
+    expect(screen.getByRole('combobox')).toBeDisabled();
+  });
+
+  it('forwards value and onChange', () => {
+    const onChange = vi.fn();
+    render(
+      <Select aria-label="test" value="A" onChange={onChange}>
+        <option value="A">Alpha</option>
+        <option value="B">Beta</option>
+      </Select>,
+    );
+    expect(screen.getByRole('combobox')).toHaveValue('A');
+  });
+});

--- a/apps/web/src/components/ui/select.tsx
+++ b/apps/web/src/components/ui/select.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+function Select({ className, ...props }: React.ComponentProps<'select'>) {
+  return (
+    <select
+      data-slot="select"
+      className={cn(
+        'h-8 w-full min-w-0 cursor-pointer appearance-none rounded-lg border border-input bg-transparent px-2.5 py-1 text-base transition-colors outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Select };

--- a/apps/web/src/lib/name-utils.ts
+++ b/apps/web/src/lib/name-utils.ts
@@ -3,3 +3,20 @@ export const NAME_REGEX = /^[\p{L}\s]+$/u;
 export function normalizeName(name: string): string {
   return name.trim().replace(/\s+/g, ' ');
 }
+
+export function humanizeId(id: string): string {
+  return id
+    .toLowerCase()
+    .split('_')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+}
+
+export function getInitials(name: string): string {
+  return name
+    .split(' ')
+    .map((n) => n[0])
+    .join('')
+    .toUpperCase()
+    .slice(0, 2);
+}

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -520,6 +520,7 @@
         "tripsCompleted": "Trips",
         "countriesVisited": "Countries",
         "kmTraveled": "Km traveled",
+        "citiesVisited": "Cities",
         "tripsAsOrganizer": "As organizer"
       },
       "achievements": {

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -500,6 +500,33 @@
         "expiryBeforeIssue": "Expiry date must be after issue date."
       }
     },
+    "publicProfile": {
+      "notFound": "Profile not found",
+      "notFoundDescription": "No user with the username @{{username}} exists.",
+      "loadError": "Failed to load profile",
+      "retry": "Try again",
+      "privateProfile": "This profile is private",
+      "privateProfileDescription": "{{displayName}} has set their profile to private.",
+      "stats": {
+        "heading": "Travel Stats",
+        "tripsCompleted": "Trips",
+        "countriesVisited": "Countries",
+        "kmTraveled": "Km traveled",
+        "tripsAsOrganizer": "As organizer"
+      },
+      "achievements": {
+        "heading": "Achievements",
+        "empty": "No achievements yet"
+      },
+      "recognitions": {
+        "heading": "Recognitions",
+        "empty": "No recognitions yet"
+      },
+      "discoveryMap": {
+        "heading": "Discovery Map",
+        "placeholder": "Full map coming soon"
+      }
+    },
     "errors": {
       "generic": "Something went wrong. Please try again.",
       "loadError": "Failed to load profile data. Please try again.",

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -234,7 +234,15 @@
       "saving": "Saving...",
       "saveSuccess": "Profile updated",
       "saveError": "Failed to save profile",
-      "validDisplayName": "Display name must be between 1 and 100 characters"
+      "validDisplayName": "Display name must be between 1 and 100 characters",
+      "profileVisibility": "Profile Visibility",
+      "profileVisibilityHint": "Controls who can see your travel stats, achievements, and discovery map.",
+      "profileVisibilityOptions": {
+        "PRIVATE": "Private",
+        "CONNECTIONS_ONLY": "Connections",
+        "MEMBERS_ONLY": "Members",
+        "PUBLIC": "Public"
+      }
     },
     "preferences": {
       "heading": "Preferences",

--- a/apps/web/src/locales/es.json
+++ b/apps/web/src/locales/es.json
@@ -500,6 +500,33 @@
         "expiryBeforeIssue": "La fecha de vencimiento debe ser posterior a la fecha de expedición."
       }
     },
+    "publicProfile": {
+      "notFound": "Perfil no encontrado",
+      "notFoundDescription": "No existe ningún usuario con el nombre de usuario @{{username}}.",
+      "loadError": "Error al cargar el perfil",
+      "retry": "Intentar de nuevo",
+      "privateProfile": "Este perfil es privado",
+      "privateProfileDescription": "{{displayName}} ha configurado su perfil como privado.",
+      "stats": {
+        "heading": "Estadísticas de viaje",
+        "tripsCompleted": "Viajes",
+        "countriesVisited": "Países",
+        "kmTraveled": "Km recorridos",
+        "tripsAsOrganizer": "Como organizador"
+      },
+      "achievements": {
+        "heading": "Logros",
+        "empty": "Aún no hay logros"
+      },
+      "recognitions": {
+        "heading": "Reconocimientos",
+        "empty": "Aún no hay reconocimientos"
+      },
+      "discoveryMap": {
+        "heading": "Mapa de descubrimiento",
+        "placeholder": "Mapa completo próximamente"
+      }
+    },
     "errors": {
       "generic": "Algo salió mal. Por favor intenta de nuevo.",
       "loadError": "Error al cargar los datos del perfil. Por favor intenta de nuevo.",

--- a/apps/web/src/locales/es.json
+++ b/apps/web/src/locales/es.json
@@ -234,7 +234,15 @@
       "saving": "Guardando...",
       "saveSuccess": "Perfil actualizado",
       "saveError": "Error al guardar el perfil",
-      "validDisplayName": "El nombre para mostrar debe tener entre 1 y 100 caracteres"
+      "validDisplayName": "El nombre para mostrar debe tener entre 1 y 100 caracteres",
+      "profileVisibility": "Visibilidad del perfil",
+      "profileVisibilityHint": "Controla quién puede ver tus estadísticas de viaje, logros y mapa de descubrimiento.",
+      "profileVisibilityOptions": {
+        "PRIVATE": "Privado",
+        "CONNECTIONS_ONLY": "Conexiones",
+        "MEMBERS_ONLY": "Miembros",
+        "PUBLIC": "Público"
+      }
     },
     "preferences": {
       "heading": "Preferencias",

--- a/apps/web/src/locales/es.json
+++ b/apps/web/src/locales/es.json
@@ -520,6 +520,7 @@
         "tripsCompleted": "Viajes",
         "countriesVisited": "Países",
         "kmTraveled": "Km recorridos",
+        "citiesVisited": "Ciudades",
         "tripsAsOrganizer": "Como organizador"
       },
       "achievements": {


### PR DESCRIPTION
## Summary

This PR implements two related profile features. First, a read-only public profile page at `/profile/[username]` that renders avatar, display name, @username, and bio unconditionally, and conditionally shows traveler stats, achievements, recognitions, and discovery map based on the viewer's `ProfileVisibility` setting. Second, it wires the existing `profile_visibility` DB column end-to-end so users can actually set it: the field is now exposed in `UserResponseDto`, accepted in `UpdateUserDto` with `@IsEnum` validation, handled in `UsersService.updateMe`, and surfaced as a Select dropdown in `BasicInfoSection`.

## Changes

**Public profile page (`/profile/[username]`)**
- New `app/profile/[username]/page.tsx` with loading, 404, and error states
- Five sub-components under `components/public-profile/`: `PublicProfileHeader`, `PublicProfileStats`, `PublicProfileAchievements`, `PublicProfileRecognitions`, `PublicProfileDiscoveryMap`
- Gamification sections render only when the API returns a non-null value (`null` = gated by visibility, `[]` = visible but nothing earned yet)
- New `publicProfile.*` i18n keys in `en.json` / `es.json`

**profileVisibility setting (DB → Backend → Frontend)**
- `UserResponseDto`: added `profileVisibility` field with `@ApiProperty({ enum: ProfileVisibility })`
- `UpdateUserDto`: added optional `profileVisibility` with `@IsOptional @IsEnum(ProfileVisibility)`
- `UsersService.updateMe`: applies `dto.profileVisibility` to the patch when provided
- New styled `<Select>` UI component (`components/ui/select.tsx`) matching the existing Input/Textarea visual language
- `BasicInfoSection`: added visibility state, dirty tracking, PATCH payload inclusion, and Select dropdown UI
- New `profileVisibility.*` i18n keys (en + es)

## Testing

- 20 new tests covering the public profile page and all sub-components (loading state, 404, error+retry, conditional section rendering)
- 3 new tests in `BasicInfoSection.test.tsx`: payload inclusion, dirty tracking on change, no dirty when unchanged
- 6 new tests for the `Select` component
- 3 new tests in `users.service.spec.ts` and `users.controller.spec.ts` for the profileVisibility backend path
- All 487 API tests and 743 web tests pass; coverage ≥ 90% across all metrics

## Notes

Discovery Map is an MVP placeholder — it renders country code badges from the `countries` array. The full geographic visualization is post-MVP.

Closes #118