### PR TITLE
feat(onboarding): add yearVisible toggle in step 2

### DIFF
--- a/apps/web/src/app/onboarding/page.test.tsx
+++ b/apps/web/src/app/onboarding/page.test.tsx
@@ -731,6 +731,74 @@ describe('OnboardingPage', () => {
       expect(screen.getByText('onboarding.username.taken')).toBeInTheDocument();
     });
 
+    it('sends yearVisible: true when the checkbox is checked before submit', async () => {
+      mocks.mockApiPost.mockResolvedValue({ status: 201 });
+      vi.mocked(useAuth).mockReturnValue(
+        makeAuth({ currentUser: makeUser({ displayName: 'Test User' }) }),
+      );
+      mockGetByUrl();
+      const user = userEvent.setup({
+        advanceTimers: vi.advanceTimersByTime.bind(vi),
+        delay: null,
+      });
+      render(<OnboardingPage />);
+      await waitFor(() => expect(screen.getByTestId('username-input')).toBeInTheDocument());
+
+      await user.clear(screen.getByTestId('username-input'));
+      await user.type(screen.getByTestId('username-input'), 'newuser');
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(300);
+      });
+      await waitFor(() =>
+        expect(screen.getByText('onboarding.username.available')).toBeInTheDocument(),
+      );
+
+      await user.click(screen.getByTestId('next-btn'));
+      await waitFor(() => expect(screen.getByTestId('firstname-input')).toBeInTheDocument());
+
+      await user.type(screen.getByTestId('firstname-input'), 'JOHN');
+      await user.type(screen.getByTestId('lastname-input'), 'DOE');
+      await user.type(screen.getByTestId('dob-day-input'), '15');
+      await user.type(screen.getByTestId('dob-month-input'), '6');
+      await user.type(screen.getByTestId('dob-year-input'), '1990');
+      await user.click(screen.getByTestId('year-visible-checkbox'));
+      await user.type(screen.getByTestId('phone-number-input'), '3001234567');
+
+      await user.click(screen.getByTestId('next-btn'));
+      await waitFor(() => expect(screen.getByTestId('terms-checkbox')).toBeInTheDocument());
+
+      await user.type(screen.getByTestId('home-country-input'), 'CO');
+      await user.click(screen.getByTestId('terms-checkbox'));
+      await user.click(screen.getByTestId('submit-btn'));
+
+      await waitFor(() =>
+        expect(mocks.mockApiPost).toHaveBeenCalledWith(
+          '/v1/auth/register',
+          expect.objectContaining({
+            dateOfBirth: expect.objectContaining({ yearVisible: true }),
+          }),
+        ),
+      );
+    });
+
+    it('sends yearVisible: false when the checkbox is unchecked (default)', async () => {
+      mocks.mockApiPost.mockResolvedValue({ status: 201 });
+      const user = await renderFormWithAvailableUsername({
+        currentUser: makeUser({ displayName: 'Test User' }),
+      });
+
+      await user.click(screen.getByTestId('submit-btn'));
+
+      await waitFor(() =>
+        expect(mocks.mockApiPost).toHaveBeenCalledWith(
+          '/v1/auth/register',
+          expect.objectContaining({
+            dateOfBirth: expect.objectContaining({ yearVisible: false }),
+          }),
+        ),
+      );
+    });
+
     it('shows generic error toast on unexpected submit error', async () => {
       mocks.mockApiPost.mockRejectedValue(
         Object.assign(new Error('Server error'), {

--- a/apps/web/src/app/onboarding/page.tsx
+++ b/apps/web/src/app/onboarding/page.tsx
@@ -688,20 +688,21 @@ function Step2({
         {stepErrors.includes('minAge') && (
           <p className="text-xs text-destructive">{t('onboarding.validation.minAge')}</p>
         )}
-        <label htmlFor="year-visible-checkbox" className="flex cursor-pointer items-center gap-2">
-          <input
-            id="year-visible-checkbox"
-            type="checkbox"
-            checked={yearVisible}
-            onChange={(e) => onYearVisibleChange(e.target.checked)}
-            className="h-4 w-4 shrink-0 accent-primary"
-            data-testid="year-visible-checkbox"
-          />
-          <span className="text-sm text-muted-foreground">
-            {t('onboarding.dateOfBirth.yearVisibleLabel')}
-          </span>
-        </label>
       </div>
+
+      <label htmlFor="year-visible-checkbox" className="flex cursor-pointer items-center gap-2">
+        <input
+          id="year-visible-checkbox"
+          type="checkbox"
+          checked={yearVisible}
+          onChange={(e) => onYearVisibleChange(e.target.checked)}
+          className="h-4 w-4 shrink-0 accent-primary"
+          data-testid="year-visible-checkbox"
+        />
+        <span className="text-sm text-muted-foreground">
+          {t('onboarding.dateOfBirth.yearVisibleLabel')}
+        </span>
+      </label>
 
       <div className="flex flex-col gap-1.5">
         <Label id="phone-country-label">{t('onboarding.phone.label')}</Label>

--- a/apps/web/src/app/onboarding/page.tsx
+++ b/apps/web/src/app/onboarding/page.tsx
@@ -137,6 +137,7 @@ export default function OnboardingPage() {
   const [dobDay, setDobDay] = useState('');
   const [dobMonth, setDobMonth] = useState('');
   const [dobYear, setDobYear] = useState('');
+  const [yearVisible, setYearVisible] = useState(false);
   const [phoneCountry, setPhoneCountry] = useState('CO');
   const [phoneNumber, setPhoneNumber] = useState('');
 
@@ -272,7 +273,7 @@ export default function OnboardingPage() {
           day: parseInt(dobDay, 10),
           month: parseInt(dobMonth, 10),
           year: parseInt(dobYear, 10),
-          yearVisible: false,
+          yearVisible,
         },
         homeCountry,
         homeCity: homeCity.trim() || undefined,
@@ -353,6 +354,7 @@ export default function OnboardingPage() {
             dobDay={dobDay}
             dobMonth={dobMonth}
             dobYear={dobYear}
+            yearVisible={yearVisible}
             phoneCountry={phoneCountry}
             phoneNumber={phoneNumber}
             stepErrors={stepErrors}
@@ -376,6 +378,7 @@ export default function OnboardingPage() {
               setDobYear(v);
               setStepErrors([]);
             }}
+            onYearVisibleChange={setYearVisible}
             onPhoneCountryChange={(v) => {
               setPhoneCountry(v);
               setStepErrors([]);
@@ -544,6 +547,7 @@ interface Step2Props {
   dobDay: string;
   dobMonth: string;
   dobYear: string;
+  yearVisible: boolean;
   phoneCountry: string;
   phoneNumber: string;
   stepErrors: string[];
@@ -552,6 +556,7 @@ interface Step2Props {
   onDobDayChange: (v: string) => void;
   onDobMonthChange: (v: string) => void;
   onDobYearChange: (v: string) => void;
+  onYearVisibleChange: (v: boolean) => void;
   onPhoneCountryChange: (v: string) => void;
   onPhoneNumberChange: (v: string) => void;
   t: TFunction;
@@ -563,6 +568,7 @@ function Step2({
   dobDay,
   dobMonth,
   dobYear,
+  yearVisible,
   phoneCountry,
   phoneNumber,
   stepErrors,
@@ -571,6 +577,7 @@ function Step2({
   onDobDayChange,
   onDobMonthChange,
   onDobYearChange,
+  onYearVisibleChange,
   onPhoneCountryChange,
   onPhoneNumberChange,
   t,
@@ -681,6 +688,19 @@ function Step2({
         {stepErrors.includes('minAge') && (
           <p className="text-xs text-destructive">{t('onboarding.validation.minAge')}</p>
         )}
+        <label htmlFor="year-visible-checkbox" className="flex cursor-pointer items-center gap-2">
+          <input
+            id="year-visible-checkbox"
+            type="checkbox"
+            checked={yearVisible}
+            onChange={(e) => onYearVisibleChange(e.target.checked)}
+            className="h-4 w-4 shrink-0 accent-primary"
+            data-testid="year-visible-checkbox"
+          />
+          <span className="text-sm text-muted-foreground">
+            {t('onboarding.dateOfBirth.yearVisibleLabel')}
+          </span>
+        </label>
       </div>
 
       <div className="flex flex-col gap-1.5">

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -131,7 +131,8 @@
         "label": "Date of birth",
         "day": "Day",
         "month": "Month",
-        "year": "Year"
+        "year": "Year",
+        "yearVisibleLabel": "Show birth year on my public profile"
       },
       "phone": {
         "label": "Phone number",

--- a/apps/web/src/locales/es.json
+++ b/apps/web/src/locales/es.json
@@ -131,7 +131,8 @@
         "label": "Fecha de nacimiento",
         "day": "Día",
         "month": "Mes",
-        "year": "Año"
+        "year": "Año",
+        "yearVisibleLabel": "Mostrar año de nacimiento en mi perfil público"
       },
       "phone": {
         "label": "Número de teléfono",


### PR DESCRIPTION
## Summary

`yearVisible` in `dateOfBirth` was hardcoded to `false` at registration, giving users no control over whether their birth year appears on their public profile. This adds an opt-in checkbox in onboarding Step 2 so users can explicitly choose to show it.

## Changes

- **Onboarding page** — added `yearVisible` state (default `false`), wired into `handleSubmit` payload; passed as prop to `Step2` alongside a new `onYearVisibleChange` handler
- **Step2 component** — renders checkbox below the date-of-birth grid with label `"Show birth year on my public profile"` (`data-testid="year-visible-checkbox"`)
- **i18n** — added `auth.onboarding.dateOfBirth.yearVisibleLabel` to `en.json` and `es.json`
- **Tests** — two new tests covering `yearVisible: true` (checkbox checked) and `yearVisible: false` (default unchecked) in the submitted registration payload

## Testing

- [ ] Checkbox renders unchecked by default in step 2
- [ ] Checking the box sends `dateOfBirth.yearVisible: true` in the registration payload
- [ ] Leaving the box unchecked sends `dateOfBirth.yearVisible: false`
- [ ] Label renders correctly in both English and Spanish
- [ ] All 746 unit tests pass

Closes #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)