### PR TITLE
feat(auth): persist theme, language, and currency preferences at registration

### DIFF
--- a/apps/web/src/app/onboarding/page.test.tsx
+++ b/apps/web/src/app/onboarding/page.test.tsx
@@ -10,6 +10,7 @@ const mocks = vi.hoisted(() => ({
   mockRouterReplace: vi.fn(),
   mockApiGet: vi.fn(),
   mockApiPost: vi.fn(),
+  mockApiPatch: vi.fn(),
   mockToastError: vi.fn(),
   mockToastInfo: vi.fn(),
   mockSignOut: vi.fn(),
@@ -28,7 +29,12 @@ vi.mock('@/services/api-client', () => ({
   apiClient: {
     get: mocks.mockApiGet,
     post: mocks.mockApiPost,
+    patch: mocks.mockApiPatch,
   },
+}));
+
+vi.mock('next-themes', () => ({
+  useTheme: () => ({ theme: 'system', setTheme: vi.fn() }),
 }));
 
 vi.mock('@/components/ui/toast', () => ({
@@ -197,6 +203,7 @@ async function renderFormAtStep3() {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mocks.mockApiPatch.mockResolvedValue({ status: 200 });
 });
 
 describe('OnboardingPage', () => {
@@ -797,6 +804,39 @@ describe('OnboardingPage', () => {
           }),
         ),
       );
+    });
+
+    it('calls PATCH /v1/users/me/preferences after successful registration', async () => {
+      mocks.mockApiPost.mockResolvedValue({ status: 201 });
+      const user = await renderFormWithAvailableUsername({
+        currentUser: makeUser({ displayName: 'Test User' }),
+      });
+
+      await user.click(screen.getByTestId('submit-btn'));
+
+      await waitFor(() =>
+        expect(mocks.mockApiPatch).toHaveBeenCalledWith(
+          '/v1/users/me/preferences',
+          expect.objectContaining({
+            theme: 'SYSTEM', // useTheme mock returns 'system'
+            language: 'EN', // i18n mock returns 'en'
+            currency: 'COP', // homeCountry is 'CO' → COP
+          }),
+        ),
+      );
+    });
+
+    it('does not block registration if preferences PATCH fails', async () => {
+      mocks.mockApiPost.mockResolvedValue({ status: 201 });
+      mocks.mockApiPatch.mockRejectedValue(new Error('Network error'));
+      const user = await renderFormWithAvailableUsername({
+        currentUser: makeUser({ displayName: 'Test User' }),
+      });
+
+      await user.click(screen.getByTestId('submit-btn'));
+
+      await waitFor(() => expect(mocks.mockRouterReplace).toHaveBeenCalledWith('/'));
+      expect(mocks.mockToastError).not.toHaveBeenCalled();
     });
 
     it('shows generic error toast on unexpected submit error', async () => {

--- a/apps/web/src/app/onboarding/page.tsx
+++ b/apps/web/src/app/onboarding/page.tsx
@@ -67,7 +67,8 @@ function deriveCurrency(countryCode: string): 'COP' | 'USD' {
 }
 
 function resolveTheme(raw: string | undefined): string {
-  return (['light', 'dark', 'system'].includes(raw ?? '') ? raw! : 'system').toUpperCase();
+  if (raw === 'light' || raw === 'dark' || raw === 'system') return raw.toUpperCase();
+  return 'SYSTEM';
 }
 
 function resolveLanguage(raw: string): string {

--- a/apps/web/src/app/onboarding/page.tsx
+++ b/apps/web/src/app/onboarding/page.tsx
@@ -7,6 +7,8 @@ import { Trans, useTranslation } from 'react-i18next';
 import { isAxiosError } from 'axios';
 import { isValidPhoneNumber, type CountryCode } from 'libphonenumber-js';
 import type { TFunction } from 'i18next';
+import { useTheme } from 'next-themes';
+import { getCountryData, type TCountryCode } from 'countries-list';
 
 import { useAuth } from '@/hooks/useAuth';
 import { COOKIE_CHAMUCO_REGISTERED_SET } from '@/lib/auth-cookies';
@@ -52,6 +54,25 @@ function computeAge(day: number, month: number, year: number): number {
   const m = today.getMonth() + 1 - month;
   if (m < 0 || (m === 0 && today.getDate() < day)) age--;
   return age;
+}
+
+function deriveCurrency(countryCode: string): 'COP' | 'USD' {
+  try {
+    const primary = getCountryData(countryCode as TCountryCode).currency[0]?.toUpperCase();
+    if (primary === 'COP' || primary === 'USD') return primary;
+  } catch {
+    // unknown country code — use default
+  }
+  return 'COP';
+}
+
+function resolveTheme(raw: string | undefined): string {
+  return (['light', 'dark', 'system'].includes(raw ?? '') ? raw! : 'system').toUpperCase();
+}
+
+function resolveLanguage(raw: string): string {
+  const code = raw.slice(0, 2).toLowerCase();
+  return (['en', 'es'].includes(code) ? code : 'es').toUpperCase();
 }
 
 // ---------------------------------------------------------------------------
@@ -116,7 +137,8 @@ function validateStep3(homeCountry: string, termsAccepted: boolean): string[] {
 // ---------------------------------------------------------------------------
 
 export default function OnboardingPage() {
-  const { t } = useTranslation('auth');
+  const { t, i18n } = useTranslation('auth');
+  const { theme } = useTheme();
   const router = useRouter();
   const { currentUser, isLoading, signOut } = useAuth();
 
@@ -281,6 +303,13 @@ export default function OnboardingPage() {
         phoneLocalNumber: phoneNumber,
       });
       document.cookie = COOKIE_CHAMUCO_REGISTERED_SET;
+      void apiClient
+        .patch('/v1/users/me/preferences', {
+          theme: resolveTheme(theme),
+          language: resolveLanguage(i18n.language),
+          currency: deriveCurrency(homeCountry),
+        })
+        .catch(() => {});
       // localStorage.setItem(PROFILE_INCOMPLETE_KEY, 'true'); // TODO: re-enable with banner
       router.replace('/');
     } catch (err) {


### PR DESCRIPTION
## Summary

At registration time the frontend already has three meaningful signals — the user's active theme (from `next-themes`), their selected language (from `i18next`), and an inferred currency (from `homeCountry` via `countries-list`) — but they were thrown away, leaving the backend to insert `user_preferences` with static defaults. Rather than complicating the register endpoint, a fire-and-forget `PATCH /v1/users/me/preferences` is dispatched immediately after a successful registration. A failure here is silently swallowed so it can never roll back or block the registration flow.

## Changes

- **Preference helpers** — three pure functions added to `page.tsx`: `deriveCurrency` (ISO 3166-1 → `COP|USD`, fallback `COP`), `resolveTheme` (next-themes lowercase → enum uppercase, fallback `SYSTEM`), `resolveLanguage` (i18next locale → enum uppercase, fallback `ES`)
- **Fire-and-forget PATCH** — after setting the registered cookie, `void apiClient.patch('/v1/users/me/preferences', {...}).catch(() => {})` is dispatched with the resolved values; no `await`, no user-visible error on failure
- **Tests** — `mockApiPatch` wired into the `apiClient` mock; `next-themes` mocked to return `'system'`; two new tests: one asserting the PATCH is called with the correct mapped values (`SYSTEM` / `EN` / `COP`), one asserting that a rejected PATCH does not prevent the redirect or trigger an error toast

## Notes

`AppCurrency` currently only accepts `COP` and `USD`. `deriveCurrency` maps any country whose primary currency is neither to `COP`. This is intentional — the enum is intentionally narrow for now and the fallback matches the existing backend default.

Closes #163

🤖 Generated with [Claude Code](https://claude.com/claude-code)