### PR TITLE
feat(profile): normalize form UX, add SaveButton/FieldMessage, fix validation parity

### DIFF
--- a/apps/api/src/modules/users/dto/date-after.validator.spec.ts
+++ b/apps/api/src/modules/users/dto/date-after.validator.spec.ts
@@ -1,0 +1,64 @@
+import { ValidationArguments } from 'class-validator';
+import { IsDateAfterConstraint } from './date-after.validator';
+
+function makeArgs(object: Record<string, unknown>, property = 'expiryDate'): ValidationArguments {
+  return { object, value: undefined, constraints: ['issueDate'], targetName: '', property };
+}
+
+describe('IsDateAfterConstraint', () => {
+  const constraint = new IsDateAfterConstraint();
+
+  describe('skip cases (return true)', () => {
+    it('returns true when value is not a string', () => {
+      expect(constraint.validate(null, makeArgs({ issueDate: '2024-01-01' }))).toBe(true);
+    });
+
+    it('returns true when value is an empty string', () => {
+      expect(constraint.validate('', makeArgs({ issueDate: '2024-01-01' }))).toBe(true);
+    });
+
+    it('returns true when related value is missing', () => {
+      expect(constraint.validate('2025-01-01', makeArgs({}))).toBe(true);
+    });
+
+    it('returns true when related value is not a string', () => {
+      expect(constraint.validate('2025-01-01', makeArgs({ issueDate: 20240101 as never }))).toBe(
+        true,
+      );
+    });
+
+    it('returns true when related value is an empty string', () => {
+      expect(constraint.validate('2025-01-01', makeArgs({ issueDate: '' }))).toBe(true);
+    });
+
+    it('returns true when value is an invalid date string', () => {
+      expect(constraint.validate('not-a-date', makeArgs({ issueDate: '2024-01-01' }))).toBe(true);
+    });
+
+    it('returns true when related value is an invalid date string', () => {
+      expect(constraint.validate('2025-01-01', makeArgs({ issueDate: 'not-a-date' }))).toBe(true);
+    });
+  });
+
+  describe('comparison cases', () => {
+    it('returns true when value is strictly after related value', () => {
+      expect(constraint.validate('2026-01-01', makeArgs({ issueDate: '2024-01-01' }))).toBe(true);
+    });
+
+    it('returns false when value is before related value', () => {
+      expect(constraint.validate('2023-01-01', makeArgs({ issueDate: '2024-01-01' }))).toBe(false);
+    });
+
+    it('returns false when value equals related value (same day not allowed)', () => {
+      expect(constraint.validate('2024-01-01', makeArgs({ issueDate: '2024-01-01' }))).toBe(false);
+    });
+  });
+
+  describe('defaultMessage', () => {
+    it('includes the property name and related property name', () => {
+      const args = makeArgs({ issueDate: '2024-01-01' }, 'passportExpiryDate');
+      expect(constraint.defaultMessage(args)).toContain('passportExpiryDate');
+      expect(constraint.defaultMessage(args)).toContain('issueDate');
+    });
+  });
+});

--- a/apps/api/src/modules/users/dto/date-after.validator.ts
+++ b/apps/api/src/modules/users/dto/date-after.validator.ts
@@ -1,0 +1,38 @@
+import {
+  registerDecorator,
+  ValidationArguments,
+  ValidationOptions,
+  ValidatorConstraint,
+  ValidatorConstraintInterface,
+} from 'class-validator';
+
+@ValidatorConstraint({ name: 'isDateAfter', async: false })
+export class IsDateAfterConstraint implements ValidatorConstraintInterface {
+  validate(value: unknown, args: ValidationArguments): boolean {
+    if (typeof value !== 'string' || !value) return true;
+    const [relatedPropertyName] = args.constraints as [string];
+    const relatedValue = (args.object as Record<string, unknown>)[relatedPropertyName];
+    if (typeof relatedValue !== 'string' || !relatedValue) return true;
+    return new Date(value) > new Date(relatedValue);
+  }
+
+  defaultMessage(args: ValidationArguments): string {
+    const [relatedPropertyName] = args.constraints as [string];
+    return `${args.property} must be after ${relatedPropertyName}`;
+  }
+}
+
+export function IsDateAfter(
+  property: string,
+  validationOptions?: ValidationOptions,
+): PropertyDecorator {
+  return function (object: object, propertyName: string | symbol) {
+    registerDecorator({
+      target: object.constructor,
+      propertyName: propertyName as string,
+      options: validationOptions,
+      constraints: [property],
+      validator: IsDateAfterConstraint,
+    });
+  };
+}

--- a/apps/api/src/modules/users/dto/date-after.validator.ts
+++ b/apps/api/src/modules/users/dto/date-after.validator.ts
@@ -13,7 +13,10 @@ export class IsDateAfterConstraint implements ValidatorConstraintInterface {
     const [relatedPropertyName] = args.constraints as [string];
     const relatedValue = (args.object as Record<string, unknown>)[relatedPropertyName];
     if (typeof relatedValue !== 'string' || !relatedValue) return true;
-    return new Date(value) > new Date(relatedValue);
+    const d1 = new Date(value);
+    const d2 = new Date(relatedValue);
+    if (isNaN(d1.getTime()) || isNaN(d2.getTime())) return true;
+    return d1 > d2;
   }
 
   defaultMessage(args: ValidationArguments): string {

--- a/apps/api/src/modules/users/dto/emergency-contact.dto.ts
+++ b/apps/api/src/modules/users/dto/emergency-contact.dto.ts
@@ -44,13 +44,13 @@ export class EmergencyContactDto {
   @ApiProperty({
     example: 'mother',
     description: 'Relationship to the user',
-    minLength: 1,
-    maxLength: 100,
+    minLength: 2,
+    maxLength: 50,
   })
   @Transform(({ value }) => (typeof value === 'string' ? value.trim() : value))
   @IsString()
-  @MinLength(1)
-  @MaxLength(100)
+  @MinLength(2)
+  @MaxLength(50)
   relationship!: string;
 
   @ApiProperty({ example: true, description: 'Exactly one contact must be primary' })

--- a/apps/api/src/modules/users/dto/nationality.dto.ts
+++ b/apps/api/src/modules/users/dto/nationality.dto.ts
@@ -10,6 +10,7 @@ import {
   ValidateIf,
 } from 'class-validator';
 import { PassportStatus } from '@chamuco/shared-types';
+import { IsDateAfter } from './date-after.validator';
 
 // Condition: any passport field present in the payload
 const anyPassportFieldPresent = (o: {
@@ -123,6 +124,9 @@ export class CreateNationalityDto {
   @ValidateIf(anyPassportFieldPresent)
   @IsDefined({ message: 'passportExpiryDate is required when any passport field is provided' })
   @IsDateString({}, { message: 'passportExpiryDate must be a valid ISO 8601 date (YYYY-MM-DD)' })
+  @IsDateAfter('passportIssueDate', {
+    message: 'passportExpiryDate must be after passportIssueDate',
+  })
   passportExpiryDate?: string;
 }
 
@@ -185,5 +189,8 @@ export class UpdateNationalityDto {
   @ValidateIf(anyPassportFieldPresent)
   @IsDefined({ message: 'passportExpiryDate is required when any passport field is provided' })
   @IsDateString({}, { message: 'passportExpiryDate must be a valid ISO 8601 date (YYYY-MM-DD)' })
+  @IsDateAfter('passportIssueDate', {
+    message: 'passportExpiryDate must be after passportIssueDate',
+  })
   passportExpiryDate?: string;
 }

--- a/apps/api/src/modules/users/dto/update-user-health.dto.ts
+++ b/apps/api/src/modules/users/dto/update-user-health.dto.ts
@@ -1,7 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { DietaryPreference } from '@chamuco/shared-types';
 import { Type } from 'class-transformer';
-import { IsArray, IsEnum, IsOptional, IsString, ValidateNested } from 'class-validator';
+import { IsArray, IsEnum, IsOptional, IsString, MaxLength, ValidateNested } from 'class-validator';
 import {
   FoodAllergyItemDto,
   MedicalConditionItemDto,
@@ -15,14 +15,21 @@ export class UpdateUserHealthDto {
   @IsEnum(DietaryPreference)
   dietaryPreference?: DietaryPreference;
 
-  @ApiProperty({ example: 'No pork', nullable: true, required: false })
+  @ApiProperty({ example: 'No pork', maxLength: 300, nullable: true, required: false })
   @IsOptional()
   @IsString()
+  @MaxLength(300)
   dietaryNotes?: string | null;
 
-  @ApiProperty({ example: 'Hypertension medication', nullable: true, required: false })
+  @ApiProperty({
+    example: 'Hypertension medication',
+    maxLength: 1000,
+    nullable: true,
+    required: false,
+  })
   @IsOptional()
   @IsString()
+  @MaxLength(1000)
   generalMedicalNotes?: string | null;
 
   @ApiProperty({ type: FoodAllergyItemDto, isArray: true, required: false })

--- a/apps/web/src/app/onboarding/page.tsx
+++ b/apps/web/src/app/onboarding/page.tsx
@@ -23,6 +23,7 @@ import { LanguageToggle } from '@/components/LanguageToggle';
 import { ThemeToggle } from '@/components/ThemeToggle';
 import { CountryCombobox, getCallingCode } from '@/components/ui/country-combobox';
 import { CityCombobox } from '@/components/ui/city-combobox';
+import { FieldMessage } from '@/components/ui/field-message';
 import { NAME_REGEX, normalizeName } from '@/lib/name-utils';
 // TODO: re-enable once ProfileCompletionBanner is fully designed
 // import { PROFILE_INCOMPLETE_KEY } from '@/components/ProfileCompletionBanner';
@@ -86,10 +87,14 @@ type UsernameStatus = 'idle' | 'checking' | 'available' | 'taken' | 'invalid';
 // Step validation helpers
 // ---------------------------------------------------------------------------
 
-function validateStep1(usernameStatus: UsernameStatus, displayName: string): string[] {
-  const errors: string[] = [];
-  if (usernameStatus !== 'available') errors.push('username');
-  if (!displayName.trim()) errors.push('displayName');
+function validateStep1(
+  usernameStatus: UsernameStatus,
+  displayName: string,
+  t: TFunction,
+): Record<string, string> {
+  const errors: Record<string, string> = {};
+  if (usernameStatus !== 'available') errors.username = 'invalid';
+  if (!displayName.trim()) errors.displayName = t('onboarding.validation.required');
   return errors;
 }
 
@@ -106,30 +111,38 @@ function validateStep2(
   dobYear: string,
   phoneCountry: string,
   phoneNumber: string,
-): string[] {
-  const errors: string[] = [];
+  t: TFunction,
+): Record<string, string> {
+  const errors: Record<string, string> = {};
   const fn = normalizeName(firstName);
   const ln = normalizeName(lastName);
-  if (!fn || fn.length < 2) errors.push('firstName');
-  else if (fn.length > 100 || !NAME_REGEX.test(fn)) errors.push('firstNameInvalid');
-  if (!ln || ln.length < 2) errors.push('lastName');
-  else if (ln.length > 100 || !NAME_REGEX.test(ln)) errors.push('lastNameInvalid');
+  if (!fn || fn.length < 2) errors.firstName = t('onboarding.validation.required');
+  else if (fn.length > 100 || !NAME_REGEX.test(fn))
+    errors.firstName = t('onboarding.validation.invalidName');
+  if (!ln || ln.length < 2) errors.lastName = t('onboarding.validation.required');
+  else if (ln.length > 100 || !NAME_REGEX.test(ln))
+    errors.lastName = t('onboarding.validation.invalidName');
   const d = parseInt(dobDay, 10);
   const m = parseInt(dobMonth, 10);
   const y = parseInt(dobYear, 10);
   if (!dobDay || !dobMonth || !dobYear || isNaN(d) || isNaN(m) || isNaN(y))
-    errors.push('dobRequired');
+    errors.dob = t('onboarding.validation.required');
   else if (d < 1 || d > 31 || m < 1 || m > 12 || y < 1900 || !isValidCalendarDay(d, m, y))
-    errors.push('dobInvalid');
-  else if (computeAge(d, m, y) < 16) errors.push('minAge');
-  if (!isValidPhoneNumber(phoneNumber, phoneCountry as CountryCode)) errors.push('phoneNumber');
+    errors.dob = t('onboarding.validation.invalidDob');
+  else if (computeAge(d, m, y) < 16) errors.dob = t('onboarding.validation.minAge');
+  if (!isValidPhoneNumber(phoneNumber, phoneCountry as CountryCode))
+    errors.phone = t('onboarding.validation.invalidPhone');
   return errors;
 }
 
-function validateStep3(homeCountry: string, termsAccepted: boolean): string[] {
-  const errors: string[] = [];
-  if (!homeCountry) errors.push('homeCountry');
-  if (!termsAccepted) errors.push('terms');
+function validateStep3(
+  homeCountry: string,
+  termsAccepted: boolean,
+  t: TFunction,
+): Record<string, string> {
+  const errors: Record<string, string> = {};
+  if (!homeCountry) errors.homeCountry = t('onboarding.validation.required');
+  if (!termsAccepted) errors.terms = t('onboarding.terms.required');
   return errors;
 }
 
@@ -170,7 +183,16 @@ export default function OnboardingPage() {
   const [termsAccepted, setTermsAccepted] = useState(false);
 
   // Step-level error keys
-  const [stepErrors, setStepErrors] = useState<string[]>([]);
+  const [stepErrors, setStepErrors] = useState<Record<string, string>>({});
+
+  function clearError(field: string) {
+    setStepErrors((prev) => {
+      if (!prev[field]) return prev;
+      const next = { ...prev };
+      delete next[field];
+      return next;
+    });
+  }
 
   // Pre-fill from OAuth provider
   useEffect(() => {
@@ -240,12 +262,12 @@ export default function OnboardingPage() {
   function handleUsernameChange(value: string) {
     setUsernameUserEdited(true);
     applyUsername(value);
-    setStepErrors([]);
+    clearError('username');
   }
 
   function handleDisplayNameChange(value: string) {
     setDisplayName(value);
-    setStepErrors([]);
+    clearError('displayName');
     if (!usernameUserEdited) {
       applyUsername(toUsernameSlug(value));
     }
@@ -256,9 +278,9 @@ export default function OnboardingPage() {
       setFirstName((v) => normalizeName(v));
       setLastName((v) => normalizeName(v));
     }
-    let errors: string[] = [];
+    let errors: Record<string, string> = {};
     if (step === 1) {
-      errors = validateStep1(usernameStatus, displayName);
+      errors = validateStep1(usernameStatus, displayName, t);
     } else if (step === 2) {
       errors = validateStep2(
         firstName,
@@ -268,20 +290,21 @@ export default function OnboardingPage() {
         dobYear,
         phoneCountry,
         phoneNumber,
+        t,
       );
     }
-    if (errors.length > 0) {
+    if (Object.keys(errors).length > 0) {
       setStepErrors(errors);
       return;
     }
-    setStepErrors([]);
+    setStepErrors({});
     setStep((s) => s + 1);
   }
 
   async function handleSubmit(e: SyntheticEvent) {
     e.preventDefault();
-    const errors = validateStep3(homeCountry, termsAccepted);
-    if (errors.length > 0) {
+    const errors = validateStep3(homeCountry, termsAccepted, t);
+    if (Object.keys(errors).length > 0) {
       setStepErrors(errors);
       return;
     }
@@ -316,7 +339,7 @@ export default function OnboardingPage() {
     } catch (err) {
       if (isAxiosError(err) && err.response?.status === 409) {
         setStep(1);
-        setStepErrors([]);
+        setStepErrors({});
         setUsernameStatus('taken');
         toast.error(t('onboarding.error.usernameTaken'));
       } else {
@@ -390,32 +413,32 @@ export default function OnboardingPage() {
             stepErrors={stepErrors}
             onFirstNameChange={(v) => {
               setFirstName(v.toUpperCase());
-              setStepErrors([]);
+              clearError('firstName');
             }}
             onLastNameChange={(v) => {
               setLastName(v.toUpperCase());
-              setStepErrors([]);
+              clearError('lastName');
             }}
             onDobDayChange={(v) => {
               setDobDay(v);
-              setStepErrors([]);
+              clearError('dob');
             }}
             onDobMonthChange={(v) => {
               setDobMonth(v);
-              setStepErrors([]);
+              clearError('dob');
             }}
             onDobYearChange={(v) => {
               setDobYear(v);
-              setStepErrors([]);
+              clearError('dob');
             }}
             onYearVisibleChange={setYearVisible}
             onPhoneCountryChange={(v) => {
               setPhoneCountry(v);
-              setStepErrors([]);
+              clearError('phone');
             }}
             onPhoneNumberChange={(v) => {
               setPhoneNumber(v);
-              setStepErrors([]);
+              clearError('phone');
             }}
             t={t}
           />
@@ -429,12 +452,12 @@ export default function OnboardingPage() {
             stepErrors={stepErrors}
             onHomeCountryChange={(v) => {
               setHomeCountry(v);
-              setStepErrors([]);
+              clearError('homeCountry');
             }}
             onHomeCityChange={(v) => setHomeCity(v.toUpperCase())}
             onTermsChange={(v) => {
               setTermsAccepted(v);
-              setStepErrors([]);
+              clearError('terms');
             }}
             t={t}
           />
@@ -473,7 +496,7 @@ export default function OnboardingPage() {
               size="lg"
               onClick={() => {
                 setStep((s) => s - 1);
-                setStepErrors([]);
+                setStepErrors({});
               }}
               disabled={isSubmitting}
               className="h-11 text-muted-foreground hover:text-foreground"
@@ -507,7 +530,7 @@ interface Step1Props {
   username: string;
   displayName: string;
   usernameStatus: UsernameStatus;
-  stepErrors: string[];
+  stepErrors: Record<string, string>;
   onUsernameChange: (v: string) => void;
   onDisplayNameChange: (v: string) => void;
   t: TFunction;
@@ -533,12 +556,10 @@ function Step1({
           value={displayName}
           onChange={(e) => onDisplayNameChange(e.target.value)}
           placeholder={t('onboarding.displayName.placeholder')}
-          aria-invalid={stepErrors.includes('displayName')}
+          aria-invalid={!!stepErrors.displayName}
           data-testid="displayname-input"
         />
-        {stepErrors.includes('displayName') && (
-          <p className="text-xs text-destructive">{t('onboarding.validation.required')}</p>
-        )}
+        <FieldMessage error={stepErrors.displayName} className="text-xs" />
       </div>
 
       <div className="flex flex-col gap-1.5">
@@ -580,7 +601,7 @@ interface Step2Props {
   yearVisible: boolean;
   phoneCountry: string;
   phoneNumber: string;
-  stepErrors: string[];
+  stepErrors: Record<string, string>;
   onFirstNameChange: (v: string) => void;
   onLastNameChange: (v: string) => void;
   onDobDayChange: (v: string) => void;
@@ -625,17 +646,15 @@ function Step2({
           placeholder={t('onboarding.firstName.placeholder')}
           value={firstName}
           onChange={(e) => onFirstNameChange(e.target.value)}
-          aria-invalid={stepErrors.includes('firstName') || stepErrors.includes('firstNameInvalid')}
+          aria-invalid={!!stepErrors.firstName}
           data-testid="firstname-input"
           className="uppercase placeholder:normal-case"
         />
-        {stepErrors.includes('firstName') ? (
-          <p className="text-xs text-destructive">{t('onboarding.validation.required')}</p>
-        ) : stepErrors.includes('firstNameInvalid') ? (
-          <p className="text-xs text-destructive">{t('onboarding.validation.invalidName')}</p>
-        ) : (
-          <p className="text-xs text-muted-foreground">{t('onboarding.firstName.hint')}</p>
-        )}
+        <FieldMessage
+          error={stepErrors.firstName}
+          hint={t('onboarding.firstName.hint')}
+          className="text-xs"
+        />
       </div>
 
       <div className="flex flex-col gap-1.5">
@@ -648,17 +667,15 @@ function Step2({
           placeholder={t('onboarding.lastName.placeholder')}
           value={lastName}
           onChange={(e) => onLastNameChange(e.target.value)}
-          aria-invalid={stepErrors.includes('lastName') || stepErrors.includes('lastNameInvalid')}
+          aria-invalid={!!stepErrors.lastName}
           data-testid="lastname-input"
           className="uppercase placeholder:normal-case"
         />
-        {stepErrors.includes('lastName') ? (
-          <p className="text-xs text-destructive">{t('onboarding.validation.required')}</p>
-        ) : stepErrors.includes('lastNameInvalid') ? (
-          <p className="text-xs text-destructive">{t('onboarding.validation.invalidName')}</p>
-        ) : (
-          <p className="text-xs text-muted-foreground">{t('onboarding.lastName.hint')}</p>
-        )}
+        <FieldMessage
+          error={stepErrors.lastName}
+          hint={t('onboarding.lastName.hint')}
+          className="text-xs"
+        />
       </div>
 
       <div className="flex flex-col gap-1.5">
@@ -672,11 +689,7 @@ function Step2({
             placeholder={t('onboarding.dateOfBirth.day')}
             value={dobDay}
             onChange={(e) => onDobDayChange(e.target.value)}
-            aria-invalid={
-              stepErrors.includes('dobRequired') ||
-              stepErrors.includes('dobInvalid') ||
-              stepErrors.includes('minAge')
-            }
+            aria-invalid={!!stepErrors.dob}
             data-testid="dob-day-input"
           />
           <Input
@@ -687,11 +700,7 @@ function Step2({
             placeholder={t('onboarding.dateOfBirth.month')}
             value={dobMonth}
             onChange={(e) => onDobMonthChange(e.target.value)}
-            aria-invalid={
-              stepErrors.includes('dobRequired') ||
-              stepErrors.includes('dobInvalid') ||
-              stepErrors.includes('minAge')
-            }
+            aria-invalid={!!stepErrors.dob}
             data-testid="dob-month-input"
           />
           <Input
@@ -701,23 +710,11 @@ function Step2({
             placeholder={t('onboarding.dateOfBirth.year')}
             value={dobYear}
             onChange={(e) => onDobYearChange(e.target.value)}
-            aria-invalid={
-              stepErrors.includes('dobRequired') ||
-              stepErrors.includes('dobInvalid') ||
-              stepErrors.includes('minAge')
-            }
+            aria-invalid={!!stepErrors.dob}
             data-testid="dob-year-input"
           />
         </div>
-        {stepErrors.includes('dobRequired') && (
-          <p className="text-xs text-destructive">{t('onboarding.validation.required')}</p>
-        )}
-        {stepErrors.includes('dobInvalid') && (
-          <p className="text-xs text-destructive">{t('onboarding.validation.invalidDob')}</p>
-        )}
-        {stepErrors.includes('minAge') && (
-          <p className="text-xs text-destructive">{t('onboarding.validation.minAge')}</p>
-        )}
+        <FieldMessage error={stepErrors.dob} className="text-xs" />
       </div>
 
       <label htmlFor="year-visible-checkbox" className="flex cursor-pointer items-center gap-2">
@@ -744,7 +741,7 @@ function Step2({
             placeholder={t('onboarding.phone.countryPlaceholder')}
             searchPlaceholder={t('onboarding.phone.search')}
             noResultsText={t('onboarding.phone.noResults')}
-            aria-invalid={stepErrors.includes('phoneCode')}
+            aria-invalid={!!stepErrors.phone}
             aria-labelledby="phone-country-label"
             data-testid="phone-code-input"
           />
@@ -753,16 +750,11 @@ function Step2({
             value={phoneNumber}
             onChange={(e) => onPhoneNumberChange(e.target.value)}
             placeholder={t('onboarding.phone.number')}
-            aria-invalid={stepErrors.includes('phoneNumber')}
+            aria-invalid={!!stepErrors.phone}
             data-testid="phone-number-input"
           />
         </div>
-        {stepErrors.includes('phoneCode') && (
-          <p className="text-xs text-destructive">{t('onboarding.validation.invalidPhoneCode')}</p>
-        )}
-        {stepErrors.includes('phoneNumber') && (
-          <p className="text-xs text-destructive">{t('onboarding.validation.invalidPhone')}</p>
-        )}
+        <FieldMessage error={stepErrors.phone} className="text-xs" />
       </div>
     </div>
   );
@@ -776,7 +768,7 @@ interface Step3Props {
   homeCountry: string;
   homeCity: string;
   termsAccepted: boolean;
-  stepErrors: string[];
+  stepErrors: Record<string, string>;
   onHomeCountryChange: (v: string) => void;
   onHomeCityChange: (v: string) => void;
   onTermsChange: (v: boolean) => void;
@@ -804,14 +796,12 @@ function Step3({
           placeholder={t('onboarding.homeCountry.placeholder')}
           searchPlaceholder={t('onboarding.homeCountry.search')}
           noResultsText={t('onboarding.homeCountry.noResults')}
-          aria-invalid={stepErrors.includes('homeCountry')}
+          aria-invalid={!!stepErrors.homeCountry}
           aria-labelledby="home-country-label"
           data-testid="home-country-input"
           className="w-full"
         />
-        {stepErrors.includes('homeCountry') && (
-          <p className="text-xs text-destructive">{t('onboarding.validation.required')}</p>
-        )}
+        <FieldMessage error={stepErrors.homeCountry} className="text-xs" />
       </div>
 
       <div className="flex flex-col gap-1.5">
@@ -859,9 +849,7 @@ function Step3({
           />
         </span>
       </label>
-      {stepErrors.includes('terms') && (
-        <p className="text-xs text-destructive">{t('onboarding.terms.required')}</p>
-      )}
+      <FieldMessage error={stepErrors.terms} className="text-xs" />
     </div>
   );
 }

--- a/apps/web/src/app/onboarding/page.tsx
+++ b/apps/web/src/app/onboarding/page.tsx
@@ -93,7 +93,8 @@ function validateStep1(
   t: TFunction,
 ): Record<string, string> {
   const errors: Record<string, string> = {};
-  if (usernameStatus !== 'available') errors.username = 'invalid';
+  if (usernameStatus !== 'available')
+    errors.username = t('onboarding.validation.usernameUnavailable');
   if (!displayName.trim()) errors.displayName = t('onboarding.validation.required');
   return errors;
 }

--- a/apps/web/src/components/feedback/FeedbackButton.tsx
+++ b/apps/web/src/components/feedback/FeedbackButton.tsx
@@ -15,7 +15,7 @@ export function FeedbackButton() {
       <Button
         variant="outline"
         size="icon"
-        className="fixed bottom-6 right-6 z-50 size-12 rounded-full shadow-lg"
+        className="fixed bottom-20 right-6 z-50 size-12 rounded-full shadow-lg md:bottom-6"
         onClick={() => setOpen(true)}
         aria-label={t('button.label')}
       >

--- a/apps/web/src/components/profile/BasicInfoSection.test.tsx
+++ b/apps/web/src/components/profile/BasicInfoSection.test.tsx
@@ -188,7 +188,8 @@ describe('BasicInfoSection', () => {
 
   describe('saving', () => {
     it('calls PATCH /users/me and /users/me/profile on submit', async () => {
-      const { user } = setup();
+      // timezone: 'UTC' + homeCountry: 'CO' auto-suggests 'America/Bogota' → form is dirty
+      const { user } = setup({ timezone: 'UTC' });
       await user.click(screen.getByRole('button', { name: 'basicInfo.save' }));
       await waitFor(() => {
         expect(mocks.mockPatch).toHaveBeenCalledWith(
@@ -203,13 +204,13 @@ describe('BasicInfoSection', () => {
     });
 
     it('calls onRefresh after successful save', async () => {
-      const { user, onRefresh } = setup();
+      const { user, onRefresh } = setup({ timezone: 'UTC' });
       await user.click(screen.getByRole('button', { name: 'basicInfo.save' }));
       await waitFor(() => expect(onRefresh).toHaveBeenCalledOnce());
     });
 
     it('shows success toast on save', async () => {
-      const { user } = setup();
+      const { user } = setup({ timezone: 'UTC' });
       await user.click(screen.getByRole('button', { name: 'basicInfo.save' }));
       await waitFor(() =>
         expect(mocks.mockToastSuccess).toHaveBeenCalledWith('basicInfo.saveSuccess'),
@@ -218,13 +219,13 @@ describe('BasicInfoSection', () => {
 
     it('shows error toast when save fails', async () => {
       mocks.mockPatch.mockRejectedValue(new Error('network error'));
-      const { user } = setup();
+      const { user } = setup({ timezone: 'UTC' });
       await user.click(screen.getByRole('button', { name: 'basicInfo.save' }));
       await waitFor(() => expect(mocks.mockToastError).toHaveBeenCalledWith('basicInfo.saveError'));
     });
 
     it('sends null bio when bio is empty', async () => {
-      const { user } = setup(undefined, { bio: null });
+      const { user } = setup({ timezone: 'UTC' }, { bio: null });
       await user.click(screen.getByRole('button', { name: 'basicInfo.save' }));
       await waitFor(() =>
         expect(mocks.mockPatch).toHaveBeenCalledWith('/v1/users/me/profile', { bio: null }),
@@ -285,7 +286,7 @@ describe('BasicInfoSection', () => {
       await user.click(screen.getByRole('button', { name: 'basicInfo.save' }));
       expect(screen.getByText('basicInfo.validDisplayName')).toBeInTheDocument();
 
-      await user.type(displayNameInput, 'Jane Doe');
+      await user.type(displayNameInput, 'Jane Doe Updated');
       await user.click(screen.getByRole('button', { name: 'basicInfo.save' }));
       await waitFor(() => expect(mocks.mockToastSuccess).toHaveBeenCalled());
       expect(screen.queryByText('basicInfo.validDisplayName')).not.toBeInTheDocument();

--- a/apps/web/src/components/profile/BasicInfoSection.tsx
+++ b/apps/web/src/components/profile/BasicInfoSection.tsx
@@ -5,14 +5,14 @@ import { useTranslation } from 'react-i18next';
 import { ProfileVisibility } from '@chamuco/shared-types';
 
 import { Avatar } from '@/components/ui/avatar';
-import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { SaveButton } from '@/components/ui/save-button';
 import { Select } from '@/components/ui/select';
-import { Spinner } from '@/components/ui/spinner';
 import { Textarea } from '@/components/ui/textarea';
 import { TimezoneCombobox } from '@/components/ui/timezone-combobox';
 import { toast } from '@/components/ui/toast';
+import { FieldMessage } from '@/components/ui/field-message';
 import { apiClient } from '@/services/api-client';
 import { COUNTRY_TIMEZONE } from '@/lib/timezones';
 import { getInitials } from '@/lib/name-utils';
@@ -112,13 +112,13 @@ export function BasicInfoSection({ user, userProfile, onRefresh }: BasicInfoSect
           aria-invalid={displayNameError !== null}
           disabled={isSaving}
         />
-        {displayNameError && <p className="text-sm text-destructive">{displayNameError}</p>}
+        <FieldMessage error={displayNameError} />
       </div>
 
       <div className="space-y-1.5">
         <Label htmlFor="username">{t('basicInfo.username')}</Label>
         <Input id="username" value={`@${user.username}`} readOnly disabled />
-        <p className="text-xs text-muted-foreground">{t('basicInfo.usernameHint')}</p>
+        <FieldMessage hint={t('basicInfo.usernameHint')} />
       </div>
 
       <div className="space-y-1.5">
@@ -165,16 +165,10 @@ export function BasicInfoSection({ user, userProfile, onRefresh }: BasicInfoSect
             </option>
           ))}
         </Select>
-        <p className="text-xs text-muted-foreground">{t('basicInfo.profileVisibilityHint')}</p>
+        <FieldMessage hint={t('basicInfo.profileVisibilityHint')} />
       </div>
 
-      <Button type="submit" disabled={isSaving} className="gap-2">
-        {isSaving && <Spinner size="sm" />}
-        {!isSaving && isDirty && (
-          <span data-testid="unsaved-indicator" className="size-2 rounded-full bg-amber-500" />
-        )}
-        {isSaving ? t('basicInfo.saving') : t('basicInfo.save')}
-      </Button>
+      <SaveButton isSaving={isSaving} isDirty={isDirty} label={t('basicInfo.save')} />
     </form>
   );
 }

--- a/apps/web/src/components/profile/EmergencyContactsSection.test.tsx
+++ b/apps/web/src/components/profile/EmergencyContactsSection.test.tsx
@@ -317,6 +317,39 @@ describe('EmergencyContactsSection', () => {
       expect(mocks.mockPost).not.toHaveBeenCalled();
     });
 
+    it('shows fullNameInvalid error when fullName exceeds 100 characters', async () => {
+      const { user } = setup([]);
+      await user.click(screen.getByRole('button', { name: 'emergencyContacts.add' }));
+      await user.type(screen.getByLabelText('emergencyContacts.fullName'), 'A'.repeat(101));
+      await user.type(screen.getByLabelText('emergencyContacts.phoneNumber'), '3009876543');
+      await user.type(screen.getByLabelText('emergencyContacts.relationship'), 'Sister');
+      await user.click(screen.getByRole('button', { name: 'emergencyContacts.save' }));
+      expect(screen.getByText('emergencyContacts.errors.fullNameInvalid')).toBeInTheDocument();
+      expect(mocks.mockPost).not.toHaveBeenCalled();
+    });
+
+    it('shows relationshipRequired error when relationship is one character', async () => {
+      const { user } = setup([]);
+      await user.click(screen.getByRole('button', { name: 'emergencyContacts.add' }));
+      await user.type(screen.getByLabelText('emergencyContacts.fullName'), 'Ana López');
+      await user.type(screen.getByLabelText('emergencyContacts.phoneNumber'), '3009876543');
+      await user.type(screen.getByLabelText('emergencyContacts.relationship'), 'A');
+      await user.click(screen.getByRole('button', { name: 'emergencyContacts.save' }));
+      expect(screen.getByText('emergencyContacts.errors.relationshipRequired')).toBeInTheDocument();
+      expect(mocks.mockPost).not.toHaveBeenCalled();
+    });
+
+    it('shows relationshipInvalid error when relationship exceeds 50 characters', async () => {
+      const { user } = setup([]);
+      await user.click(screen.getByRole('button', { name: 'emergencyContacts.add' }));
+      await user.type(screen.getByLabelText('emergencyContacts.fullName'), 'Ana López');
+      await user.type(screen.getByLabelText('emergencyContacts.phoneNumber'), '3009876543');
+      await user.type(screen.getByLabelText('emergencyContacts.relationship'), 'A'.repeat(51));
+      await user.click(screen.getByRole('button', { name: 'emergencyContacts.save' }));
+      expect(screen.getByText('emergencyContacts.errors.relationshipInvalid')).toBeInTheDocument();
+      expect(mocks.mockPost).not.toHaveBeenCalled();
+    });
+
     it('accepts accented characters in fullName and relationship', async () => {
       const { user } = setup([]);
       await user.click(screen.getByRole('button', { name: 'emergencyContacts.add' }));
@@ -373,6 +406,7 @@ describe('EmergencyContactsSection', () => {
       const { user } = setup();
       const editButtons = screen.getAllByRole('button', { name: 'emergencyContacts.edit' });
       await user.click(editButtons[0]!);
+      await user.type(screen.getByLabelText('emergencyContacts.fullName'), ' ');
       await user.click(screen.getByRole('button', { name: 'emergencyContacts.save' }));
       await waitFor(() =>
         expect(mocks.mockToastSuccess).toHaveBeenCalledWith('emergencyContacts.updateSuccess'),
@@ -383,6 +417,7 @@ describe('EmergencyContactsSection', () => {
       const { user, onRefresh } = setup();
       const editButtons = screen.getAllByRole('button', { name: 'emergencyContacts.edit' });
       await user.click(editButtons[0]!);
+      await user.type(screen.getByLabelText('emergencyContacts.fullName'), ' ');
       await user.click(screen.getByRole('button', { name: 'emergencyContacts.save' }));
       await waitFor(() => expect(onRefresh).toHaveBeenCalledOnce());
     });
@@ -400,6 +435,7 @@ describe('EmergencyContactsSection', () => {
       const { user } = setup();
       const editButtons = screen.getAllByRole('button', { name: 'emergencyContacts.edit' });
       await user.click(editButtons[0]!);
+      await user.type(screen.getByLabelText('emergencyContacts.fullName'), ' ');
       await user.click(screen.getByRole('button', { name: 'emergencyContacts.save' }));
       await waitFor(() =>
         expect(mocks.mockToastError).toHaveBeenCalledWith('emergencyContacts.saveError'),

--- a/apps/web/src/components/profile/EmergencyContactsSection.test.tsx
+++ b/apps/web/src/components/profile/EmergencyContactsSection.test.tsx
@@ -317,17 +317,6 @@ describe('EmergencyContactsSection', () => {
       expect(mocks.mockPost).not.toHaveBeenCalled();
     });
 
-    it('shows fullNameInvalid error when fullName exceeds 100 characters', async () => {
-      const { user } = setup([]);
-      await user.click(screen.getByRole('button', { name: 'emergencyContacts.add' }));
-      await user.type(screen.getByLabelText('emergencyContacts.fullName'), 'A'.repeat(101));
-      await user.type(screen.getByLabelText('emergencyContacts.phoneNumber'), '3009876543');
-      await user.type(screen.getByLabelText('emergencyContacts.relationship'), 'Sister');
-      await user.click(screen.getByRole('button', { name: 'emergencyContacts.save' }));
-      expect(screen.getByText('emergencyContacts.errors.fullNameInvalid')).toBeInTheDocument();
-      expect(mocks.mockPost).not.toHaveBeenCalled();
-    });
-
     it('shows relationshipRequired error when relationship is one character', async () => {
       const { user } = setup([]);
       await user.click(screen.getByRole('button', { name: 'emergencyContacts.add' }));
@@ -336,17 +325,6 @@ describe('EmergencyContactsSection', () => {
       await user.type(screen.getByLabelText('emergencyContacts.relationship'), 'A');
       await user.click(screen.getByRole('button', { name: 'emergencyContacts.save' }));
       expect(screen.getByText('emergencyContacts.errors.relationshipRequired')).toBeInTheDocument();
-      expect(mocks.mockPost).not.toHaveBeenCalled();
-    });
-
-    it('shows relationshipInvalid error when relationship exceeds 50 characters', async () => {
-      const { user } = setup([]);
-      await user.click(screen.getByRole('button', { name: 'emergencyContacts.add' }));
-      await user.type(screen.getByLabelText('emergencyContacts.fullName'), 'Ana López');
-      await user.type(screen.getByLabelText('emergencyContacts.phoneNumber'), '3009876543');
-      await user.type(screen.getByLabelText('emergencyContacts.relationship'), 'A'.repeat(51));
-      await user.click(screen.getByRole('button', { name: 'emergencyContacts.save' }));
-      expect(screen.getByText('emergencyContacts.errors.relationshipInvalid')).toBeInTheDocument();
       expect(mocks.mockPost).not.toHaveBeenCalled();
     });
 
@@ -514,6 +492,46 @@ describe('EmergencyContactsSection', () => {
       await user.click(screen.getByRole('button', { name: 'emergencyContacts.deleteConfirm' }));
       await waitFor(() =>
         expect(mocks.mockToastError).toHaveBeenCalledWith('emergencyContacts.saveError'),
+      );
+    });
+  });
+
+  describe('input constraints', () => {
+    it('sets maxLength 100 on fullName input in add form', async () => {
+      const { user } = setup();
+      await user.click(screen.getByRole('button', { name: 'emergencyContacts.add' }));
+      expect(screen.getByLabelText('emergencyContacts.fullName')).toHaveAttribute(
+        'maxLength',
+        '100',
+      );
+    });
+
+    it('sets maxLength 50 on relationship input in add form', async () => {
+      const { user } = setup();
+      await user.click(screen.getByRole('button', { name: 'emergencyContacts.add' }));
+      expect(screen.getByLabelText('emergencyContacts.relationship')).toHaveAttribute(
+        'maxLength',
+        '50',
+      );
+    });
+
+    it('sets maxLength 100 on fullName input in edit form', async () => {
+      const { user } = setup();
+      const editButtons = screen.getAllByRole('button', { name: 'emergencyContacts.edit' });
+      await user.click(editButtons[0]!);
+      expect(screen.getByLabelText('emergencyContacts.fullName')).toHaveAttribute(
+        'maxLength',
+        '100',
+      );
+    });
+
+    it('sets maxLength 50 on relationship input in edit form', async () => {
+      const { user } = setup();
+      const editButtons = screen.getAllByRole('button', { name: 'emergencyContacts.edit' });
+      await user.click(editButtons[0]!);
+      expect(screen.getByLabelText('emergencyContacts.relationship')).toHaveAttribute(
+        'maxLength',
+        '50',
       );
     });
   });

--- a/apps/web/src/components/profile/EmergencyContactsSection.tsx
+++ b/apps/web/src/components/profile/EmergencyContactsSection.tsx
@@ -165,6 +165,7 @@ function ContactForm({
           value={form.relationship}
           onChange={(e) => onChange({ relationship: e.target.value.toUpperCase() })}
           autoCapitalize="characters"
+          minLength={2}
           maxLength={50}
           aria-invalid={errors.relationship !== null}
           disabled={isSaving}

--- a/apps/web/src/components/profile/EmergencyContactsSection.tsx
+++ b/apps/web/src/components/profile/EmergencyContactsSection.tsx
@@ -116,6 +116,7 @@ function ContactForm({
           onChange={(e) => onChange({ fullName: e.target.value.toUpperCase() })}
           autoCapitalize="characters"
           autoComplete="off"
+          maxLength={100}
           aria-invalid={errors.fullName !== null}
           disabled={isSaving}
           className="uppercase placeholder:normal-case"
@@ -164,6 +165,7 @@ function ContactForm({
           value={form.relationship}
           onChange={(e) => onChange({ relationship: e.target.value.toUpperCase() })}
           autoCapitalize="characters"
+          maxLength={50}
           aria-invalid={errors.relationship !== null}
           disabled={isSaving}
           className="uppercase placeholder:normal-case"

--- a/apps/web/src/components/profile/EmergencyContactsSection.tsx
+++ b/apps/web/src/components/profile/EmergencyContactsSection.tsx
@@ -9,7 +9,9 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { CountryCombobox, getCallingCode } from '@/components/ui/country-combobox';
+import { SaveButton } from '@/components/ui/save-button';
 import { toast } from '@/components/ui/toast';
+import { FieldMessage } from '@/components/ui/field-message';
 import { apiClient } from '@/services/api-client';
 import { NAME_REGEX, normalizeName } from '@/lib/name-utils';
 
@@ -80,6 +82,7 @@ interface ContactFormProps {
   form: FormState;
   errors: FormErrors;
   isSaving: boolean;
+  isDirty: boolean;
   onChange: (patch: Partial<FormState>) => void;
   onSubmit: (e: FormEvent) => void;
   onCancel: () => void;
@@ -91,6 +94,7 @@ function ContactForm({
   form,
   errors,
   isSaving,
+  isDirty,
   onChange,
   onSubmit,
   onCancel,
@@ -116,7 +120,7 @@ function ContactForm({
           disabled={isSaving}
           className="uppercase placeholder:normal-case"
         />
-        {errors.fullName && <p className="text-sm text-destructive">{errors.fullName}</p>}
+        <FieldMessage error={errors.fullName} />
       </div>
 
       <div className="space-y-1.5">
@@ -149,7 +153,7 @@ function ContactForm({
             />
           </div>
         </div>
-        {errors.phone && <p className="text-sm text-destructive">{errors.phone}</p>}
+        <FieldMessage error={errors.phone} />
       </div>
 
       <div className="space-y-1.5">
@@ -169,7 +173,7 @@ function ContactForm({
             <option key={key} value={t(`emergencyContacts.relationshipOptions.${key}`)} />
           ))}
         </datalist>
-        {errors.relationship && <p className="text-sm text-destructive">{errors.relationship}</p>}
+        <FieldMessage error={errors.relationship} />
       </div>
 
       <label className="flex cursor-pointer items-center gap-2 text-sm">
@@ -184,9 +188,7 @@ function ContactForm({
       </label>
 
       <div className="flex gap-2">
-        <Button type="submit" size="sm" disabled={isSaving}>
-          {saveLabel}
-        </Button>
+        <SaveButton size="sm" isSaving={isSaving} isDirty={isDirty} label={saveLabel} />
         <Button type="button" size="sm" variant="outline" onClick={onCancel} disabled={isSaving}>
           {t('emergencyContacts.cancel')}
         </Button>
@@ -207,10 +209,23 @@ export function EmergencyContactsSection({ contacts, onRefresh }: EmergencyConta
   const [isAdding, setIsAdding] = useState(false);
   const [addForm, setAddForm] = useState<FormState>(makeEmptyForm(contacts.length === 0));
   const [editForm, setEditForm] = useState<FormState>(makeEmptyForm());
+  const [initialEditForm, setInitialEditForm] = useState<FormState>(makeEmptyForm());
   const [addErrors, setAddErrors] = useState<FormErrors>(EMPTY_ERRORS);
   const [editErrors, setEditErrors] = useState<FormErrors>(EMPTY_ERRORS);
   const [isSaving, setIsSaving] = useState(false);
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
+
+  const isEditDirty =
+    editingId !== null &&
+    (editForm.fullName !== initialEditForm.fullName ||
+      editForm.phoneCountryIso !== initialEditForm.phoneCountryIso ||
+      editForm.phoneLocalNumber !== initialEditForm.phoneLocalNumber ||
+      editForm.relationship !== initialEditForm.relationship ||
+      editForm.isPrimary !== initialEditForm.isPrimary);
+  const isAddDirty =
+    addForm.fullName.trim() !== '' ||
+    addForm.phoneLocalNumber.trim() !== '' ||
+    addForm.relationship.trim() !== '';
 
   useEffect(() => {
     if (!confirmDeleteId) return;
@@ -227,7 +242,7 @@ export function EmergencyContactsSection({ contacts, onRefresh }: EmergencyConta
     if (!fn || fn.length < 2) {
       errors.fullName = t('emergencyContacts.errors.fullNameRequired');
       hasError = true;
-    } else if (fn.length > 150 || !NAME_REGEX.test(fn)) {
+    } else if (fn.length > 100 || !NAME_REGEX.test(fn)) {
       errors.fullName = t('emergencyContacts.errors.fullNameInvalid');
       hasError = true;
     }
@@ -256,14 +271,16 @@ export function EmergencyContactsSection({ contacts, onRefresh }: EmergencyConta
   function startEdit(contact: EmergencyContactDto) {
     setEditingId(contact.id);
     const iso = getIsoFromCallingCode(contact.phoneCountryCode);
-    setEditForm({
+    const form: FormState = {
       fullName: contact.fullName.toUpperCase(),
       phoneCountryIso: iso,
       phoneCountryCode: contact.phoneCountryCode,
       phoneLocalNumber: contact.phoneLocalNumber,
       relationship: contact.relationship.toUpperCase(),
       isPrimary: contact.isPrimary,
-    });
+    };
+    setEditForm(form);
+    setInitialEditForm(form);
     setEditErrors(EMPTY_ERRORS);
     setIsAdding(false);
     setConfirmDeleteId(null);
@@ -386,6 +403,7 @@ export function EmergencyContactsSection({ contacts, onRefresh }: EmergencyConta
                 form={editForm}
                 errors={editErrors}
                 isSaving={isSaving}
+                isDirty={isEditDirty}
                 onChange={(patch) => setEditForm((f) => ({ ...f, ...patch }))}
                 onSubmit={handleUpdate}
                 onCancel={cancelEdit}
@@ -447,6 +465,7 @@ export function EmergencyContactsSection({ contacts, onRefresh }: EmergencyConta
           form={addForm}
           errors={addErrors}
           isSaving={isSaving}
+          isDirty={isAddDirty}
           onChange={(patch) => setAddForm((f) => ({ ...f, ...patch }))}
           onSubmit={handleAdd}
           onCancel={cancelAdd}

--- a/apps/web/src/components/profile/HealthSection.test.tsx
+++ b/apps/web/src/components/profile/HealthSection.test.tsx
@@ -379,7 +379,7 @@ describe('HealthSection', () => {
       const { user } = setup();
       await user.click(screen.getByRole('button', { name: 'health.dietaryPreference.VEGAN' }));
       await user.click(screen.getByRole('button', { name: /health\.save/ }));
-      expect(screen.getByRole('button', { name: /health\.saving/ })).toBeDisabled();
+      expect(screen.getByRole('button', { name: /health\.save/ })).toBeDisabled();
     });
 
     it('sends null for dietaryNotes when dietaryPreference is not OTHER', async () => {

--- a/apps/web/src/components/profile/HealthSection.tsx
+++ b/apps/web/src/components/profile/HealthSection.tsx
@@ -3,12 +3,12 @@
 import { useState, useMemo, type FormEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { SaveButton } from '@/components/ui/save-button';
 import { Textarea } from '@/components/ui/textarea';
-import { Spinner } from '@/components/ui/spinner';
 import { toast } from '@/components/ui/toast';
+import { FieldMessage } from '@/components/ui/field-message';
 import { apiClient } from '@/services/api-client';
 import {
   DietaryPreference,
@@ -120,7 +120,7 @@ function HealthArrayField({
             aria-invalid={otherError !== null}
             data-testid={`${fieldId}-description-OTHER`}
           />
-          {otherError && <p className="text-sm text-destructive">{otherError}</p>}
+          <FieldMessage error={otherError} />
         </div>
       )}
     </fieldset>
@@ -386,16 +386,10 @@ export function HealthSection({ health, onRefresh }: HealthSectionProps) {
           maxLength={1000}
           disabled={isSaving}
         />
-        <p className="text-xs text-muted-foreground">{t('health.generalMedicalNotes.hint')}</p>
+        <FieldMessage hint={t('health.generalMedicalNotes.hint')} />
       </fieldset>
 
-      <Button type="submit" disabled={isSaving || !isDirty} className="gap-2">
-        {isSaving && <Spinner size="sm" />}
-        {!isSaving && isDirty && (
-          <span data-testid="unsaved-indicator" className="size-2 rounded-full bg-amber-500" />
-        )}
-        {isSaving ? t('health.saving') : t('health.save')}
-      </Button>
+      <SaveButton isSaving={isSaving} isDirty={isDirty} label={t('health.save')} />
     </form>
   );
 }

--- a/apps/web/src/components/profile/LoyaltyProgramsSection.test.tsx
+++ b/apps/web/src/components/profile/LoyaltyProgramsSection.test.tsx
@@ -205,6 +205,7 @@ describe('LoyaltyProgramsSection', () => {
       const { user } = setup();
       const editButtons = screen.getAllByRole('button', { name: 'loyaltyPrograms.edit' });
       await user.click(editButtons[0]!);
+      await user.type(screen.getByLabelText('loyaltyPrograms.programName'), ' ');
       await user.click(screen.getByRole('button', { name: 'loyaltyPrograms.save' }));
       await waitFor(() =>
         expect(mocks.mockToastSuccess).toHaveBeenCalledWith('loyaltyPrograms.updateSuccess'),
@@ -217,6 +218,33 @@ describe('LoyaltyProgramsSection', () => {
       await user.click(editButtons[0]!);
       await user.click(screen.getByRole('button', { name: 'loyaltyPrograms.cancel' }));
       expect(screen.queryByDisplayValue('LifeMiles')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('input constraints', () => {
+    it('sets maxLength 100 on programName input in add form', async () => {
+      const { user } = setup();
+      await user.click(screen.getByRole('button', { name: 'loyaltyPrograms.add' }));
+      expect(screen.getByLabelText('loyaltyPrograms.programName')).toHaveAttribute(
+        'maxLength',
+        '100',
+      );
+    });
+
+    it('sets maxLength 100 on memberId input in add form', async () => {
+      const { user } = setup();
+      await user.click(screen.getByRole('button', { name: 'loyaltyPrograms.add' }));
+      expect(screen.getByLabelText('loyaltyPrograms.memberId')).toHaveAttribute('maxLength', '100');
+    });
+
+    it('sets maxLength 100 on programName input in edit form', async () => {
+      const { user } = setup();
+      const editButtons = screen.getAllByRole('button', { name: 'loyaltyPrograms.edit' });
+      await user.click(editButtons[0]!);
+      expect(screen.getByLabelText('loyaltyPrograms.programName')).toHaveAttribute(
+        'maxLength',
+        '100',
+      );
     });
   });
 

--- a/apps/web/src/components/profile/LoyaltyProgramsSection.tsx
+++ b/apps/web/src/components/profile/LoyaltyProgramsSection.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { SaveButton } from '@/components/ui/save-button';
 import { Textarea } from '@/components/ui/textarea';
 import { toast } from '@/components/ui/toast';
 import { apiClient } from '@/services/api-client';
@@ -34,6 +35,7 @@ interface ProgramFormProps {
   idPrefix: string;
   form: FormState;
   isSaving: boolean;
+  isDirty: boolean;
   onChangeProgramName: (v: string) => void;
   onChangeMemberId: (v: string) => void;
   onChangeNotes: (v: string) => void;
@@ -46,6 +48,7 @@ function ProgramForm({
   idPrefix,
   form,
   isSaving,
+  isDirty,
   onChangeProgramName,
   onChangeMemberId,
   onChangeNotes,
@@ -63,6 +66,7 @@ function ProgramForm({
           value={form.programName}
           onChange={(e) => onChangeProgramName(e.target.value)}
           required
+          maxLength={100}
           disabled={isSaving}
         />
       </div>
@@ -73,6 +77,7 @@ function ProgramForm({
           value={form.memberId}
           onChange={(e) => onChangeMemberId(e.target.value)}
           required
+          maxLength={100}
           disabled={isSaving}
         />
       </div>
@@ -88,9 +93,7 @@ function ProgramForm({
         />
       </div>
       <div className="flex gap-2">
-        <Button type="submit" size="sm" disabled={isSaving}>
-          {saveLabel}
-        </Button>
+        <SaveButton size="sm" isSaving={isSaving} isDirty={isDirty} label={saveLabel} />
         <Button type="button" size="sm" variant="outline" onClick={onCancel} disabled={isSaving}>
           {t('loyaltyPrograms.cancel')}
         </Button>
@@ -106,8 +109,16 @@ export function LoyaltyProgramsSection({ programs, onRefresh }: LoyaltyProgramsS
   const [isAdding, setIsAdding] = useState(false);
   const [addForm, setAddForm] = useState<FormState>(EMPTY_FORM);
   const [editForm, setEditForm] = useState<FormState>(EMPTY_FORM);
+  const [initialEditForm, setInitialEditForm] = useState<FormState>(EMPTY_FORM);
   const [isSaving, setIsSaving] = useState(false);
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
+
+  const isEditDirty =
+    editingId !== null &&
+    (editForm.programName !== initialEditForm.programName ||
+      editForm.memberId !== initialEditForm.memberId ||
+      editForm.notes !== initialEditForm.notes);
+  const isAddDirty = addForm.programName.trim() !== '' || addForm.memberId.trim() !== '';
 
   useEffect(() => {
     if (!confirmDeleteId) return;
@@ -118,11 +129,13 @@ export function LoyaltyProgramsSection({ programs, onRefresh }: LoyaltyProgramsS
 
   function startEdit(program: LoyaltyProgramDto) {
     setEditingId(program.id);
-    setEditForm({
+    const form: FormState = {
       programName: program.programName,
       memberId: program.memberId,
       notes: program.notes ?? '',
-    });
+    };
+    setEditForm(form);
+    setInitialEditForm(form);
     setIsAdding(false);
     setConfirmDeleteId(null);
   }
@@ -220,6 +233,7 @@ export function LoyaltyProgramsSection({ programs, onRefresh }: LoyaltyProgramsS
                 idPrefix={`edit-${program.id}`}
                 form={editForm}
                 isSaving={isSaving}
+                isDirty={isEditDirty}
                 onChangeProgramName={(v) => setEditForm((f) => ({ ...f, programName: v }))}
                 onChangeMemberId={(v) => setEditForm((f) => ({ ...f, memberId: v }))}
                 onChangeNotes={(v) => setEditForm((f) => ({ ...f, notes: v }))}
@@ -275,6 +289,7 @@ export function LoyaltyProgramsSection({ programs, onRefresh }: LoyaltyProgramsS
           idPrefix="add"
           form={addForm}
           isSaving={isSaving}
+          isDirty={isAddDirty}
           onChangeProgramName={(v) => setAddForm((f) => ({ ...f, programName: v }))}
           onChangeMemberId={(v) => setAddForm((f) => ({ ...f, memberId: v }))}
           onChangeNotes={(v) => setAddForm((f) => ({ ...f, notes: v }))}

--- a/apps/web/src/components/profile/NationalitiesSection.test.tsx
+++ b/apps/web/src/components/profile/NationalitiesSection.test.tsx
@@ -335,12 +335,10 @@ describe('NationalitiesSection', () => {
       await waitFor(() => expect(mocks.mockPost).toHaveBeenCalledOnce());
     });
 
-    it('shows countryRequired error when no country selected', async () => {
+    it('disables save button when no country selected in add form', async () => {
       const { user } = setup([]);
       await user.click(screen.getByRole('button', { name: 'nationalities.add' }));
-      await user.click(screen.getByRole('button', { name: 'nationalities.save' }));
-      expect(screen.getByText('nationalities.errors.countryRequired')).toBeInTheDocument();
-      expect(mocks.mockPost).not.toHaveBeenCalled();
+      expect(screen.getByRole('button', { name: 'nationalities.save' })).toBeDisabled();
     });
 
     it('shows passportIncomplete error when only passport number provided', async () => {
@@ -468,6 +466,7 @@ describe('NationalitiesSection', () => {
       const { user } = setup();
       const editButtons = screen.getAllByRole('button', { name: 'nationalities.edit' });
       await user.click(editButtons[0]!);
+      await user.click(screen.getByRole('checkbox', { name: 'nationalities.primaryBadge' }));
       await user.click(screen.getByRole('button', { name: 'nationalities.save' }));
       await waitFor(() =>
         expect(mocks.mockToastSuccess).toHaveBeenCalledWith('nationalities.updateSuccess'),
@@ -478,6 +477,7 @@ describe('NationalitiesSection', () => {
       const { user, onRefresh } = setup();
       const editButtons = screen.getAllByRole('button', { name: 'nationalities.edit' });
       await user.click(editButtons[0]!);
+      await user.click(screen.getByRole('checkbox', { name: 'nationalities.primaryBadge' }));
       await user.click(screen.getByRole('button', { name: 'nationalities.save' }));
       await waitFor(() => expect(onRefresh).toHaveBeenCalledOnce());
     });
@@ -495,6 +495,7 @@ describe('NationalitiesSection', () => {
       const { user } = setup();
       const editButtons = screen.getAllByRole('button', { name: 'nationalities.edit' });
       await user.click(editButtons[0]!);
+      await user.click(screen.getByRole('checkbox', { name: 'nationalities.primaryBadge' }));
       await user.click(screen.getByRole('button', { name: 'nationalities.save' }));
       await waitFor(() =>
         expect(mocks.mockToastError).toHaveBeenCalledWith('nationalities.saveError'),

--- a/apps/web/src/components/profile/NationalitiesSection.tsx
+++ b/apps/web/src/components/profile/NationalitiesSection.tsx
@@ -37,7 +37,6 @@ interface FormState {
 }
 
 interface FormErrors {
-  countryCode: string | null;
   nationalId: string | null;
   passport: string | null;
   passportNumber: string | null;
@@ -45,7 +44,6 @@ interface FormErrors {
 }
 
 const EMPTY_ERRORS: FormErrors = {
-  countryCode: null,
   nationalId: null,
   passport: null,
   passportNumber: null,
@@ -134,10 +132,8 @@ function NationalityForm({
               searchPlaceholder={t('nationalities.countrySearch')}
               noResultsText={t('nationalities.countryNoResults')}
               aria-labelledby={`${idPrefix}-country-label`}
-              aria-invalid={errors.countryCode !== null}
               data-testid={`${idPrefix}-country`}
             />
-            <FieldMessage error={errors.countryCode} />
           </>
         )}
       </div>
@@ -281,18 +277,12 @@ export function NationalitiesSection({ data, onRefresh }: NationalitiesSectionPr
 
   function validate(form: FormState, setErrors: (e: FormErrors) => void): boolean {
     const errors: FormErrors = {
-      countryCode: null,
       nationalId: null,
       passport: null,
       passportNumber: null,
       passportDates: null,
     };
     let hasError = false;
-
-    if (!form.countryCode) {
-      errors.countryCode = t('nationalities.errors.countryRequired');
-      hasError = true;
-    }
 
     const trimmedNationalId = form.nationalIdNumber.trim();
     if (trimmedNationalId !== '' && !ID_FORMAT_REGEX.test(trimmedNationalId)) {

--- a/apps/web/src/components/profile/NationalitiesSection.tsx
+++ b/apps/web/src/components/profile/NationalitiesSection.tsx
@@ -10,7 +10,9 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { CountryCombobox } from '@/components/ui/country-combobox';
+import { SaveButton } from '@/components/ui/save-button';
 import { toast } from '@/components/ui/toast';
+import { FieldMessage } from '@/components/ui/field-message';
 import { apiClient } from '@/services/api-client';
 import { cn } from '@/lib/utils';
 
@@ -87,6 +89,7 @@ interface NationalityFormProps {
   form: FormState;
   errors: FormErrors;
   isSaving: boolean;
+  isDirty: boolean;
   readOnlyCountry?: boolean;
   onChange: (patch: Partial<FormState>) => void;
   onSubmit: (e: FormEvent) => void;
@@ -99,6 +102,7 @@ function NationalityForm({
   form,
   errors,
   isSaving,
+  isDirty,
   readOnlyCountry = false,
   onChange,
   onSubmit,
@@ -133,7 +137,7 @@ function NationalityForm({
               aria-invalid={errors.countryCode !== null}
               data-testid={`${idPrefix}-country`}
             />
-            {errors.countryCode && <p className="text-sm text-destructive">{errors.countryCode}</p>}
+            <FieldMessage error={errors.countryCode} />
           </>
         )}
       </div>
@@ -152,7 +156,7 @@ function NationalityForm({
           disabled={isSaving}
           aria-invalid={errors.nationalId !== null}
         />
-        {errors.nationalId && <p className="text-sm text-destructive">{errors.nationalId}</p>}
+        <FieldMessage error={errors.nationalId} />
       </div>
 
       <fieldset className="space-y-3 rounded-md border border-border p-3">
@@ -217,11 +221,7 @@ function NationalityForm({
           </div>
         </div>
 
-        {(errors.passport ?? errors.passportNumber ?? errors.passportDates) && (
-          <p className="text-sm text-destructive">
-            {errors.passport ?? errors.passportNumber ?? errors.passportDates}
-          </p>
-        )}
+        <FieldMessage error={errors.passport ?? errors.passportNumber ?? errors.passportDates} />
       </fieldset>
 
       <label className="flex cursor-pointer items-center gap-2 text-sm">
@@ -236,9 +236,7 @@ function NationalityForm({
       </label>
 
       <div className="flex gap-2">
-        <Button type="submit" size="sm" disabled={isSaving}>
-          {saveLabel}
-        </Button>
+        <SaveButton size="sm" isSaving={isSaving} isDirty={isDirty} label={saveLabel} />
         <Button type="button" size="sm" variant="outline" onClick={onCancel} disabled={isSaving}>
           {t('nationalities.cancel')}
         </Button>
@@ -259,10 +257,20 @@ export function NationalitiesSection({ data, onRefresh }: NationalitiesSectionPr
   const [isAdding, setIsAdding] = useState(false);
   const [addForm, setAddForm] = useState<FormState>(makeEmptyForm(data.length === 0));
   const [editForm, setEditForm] = useState<FormState>(makeEmptyForm());
+  const [initialEditForm, setInitialEditForm] = useState<FormState>(makeEmptyForm());
   const [addErrors, setAddErrors] = useState<FormErrors>(EMPTY_ERRORS);
   const [editErrors, setEditErrors] = useState<FormErrors>(EMPTY_ERRORS);
   const [isSaving, setIsSaving] = useState(false);
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
+
+  const isEditDirty =
+    editingId !== null &&
+    (editForm.nationalIdNumber !== initialEditForm.nationalIdNumber ||
+      editForm.passportNumber !== initialEditForm.passportNumber ||
+      editForm.passportIssueDate !== initialEditForm.passportIssueDate ||
+      editForm.passportExpiryDate !== initialEditForm.passportExpiryDate ||
+      editForm.isPrimary !== initialEditForm.isPrimary);
+  const isAddDirty = addForm.countryCode !== '';
 
   useEffect(() => {
     if (!confirmDeleteId) return;
@@ -342,7 +350,9 @@ export function NationalitiesSection({ data, onRefresh }: NationalitiesSectionPr
 
   function startEdit(nat: NationalityDto) {
     setEditingId(nat.id);
-    setEditForm(dtoToForm(nat));
+    const form = dtoToForm(nat);
+    setEditForm(form);
+    setInitialEditForm(form);
     setEditErrors(EMPTY_ERRORS);
     setIsAdding(false);
     setConfirmDeleteId(null);
@@ -456,6 +466,7 @@ export function NationalitiesSection({ data, onRefresh }: NationalitiesSectionPr
                 form={editForm}
                 errors={editErrors}
                 isSaving={isSaving}
+                isDirty={isEditDirty}
                 readOnlyCountry
                 onChange={(patch) => setEditForm((f) => ({ ...f, ...patch }))}
                 onSubmit={handleUpdate}
@@ -540,6 +551,7 @@ export function NationalitiesSection({ data, onRefresh }: NationalitiesSectionPr
           form={addForm}
           errors={addErrors}
           isSaving={isSaving}
+          isDirty={isAddDirty}
           onChange={(patch) => setAddForm((f) => ({ ...f, ...patch }))}
           onSubmit={handleAdd}
           onCancel={cancelAdd}

--- a/apps/web/src/components/profile/PersonalDetailsSection.tsx
+++ b/apps/web/src/components/profile/PersonalDetailsSection.tsx
@@ -5,13 +5,13 @@ import { useTranslation } from 'react-i18next';
 import { isValidPhoneNumber, type CountryCode } from 'libphonenumber-js';
 import { getCountryDataList } from 'countries-list';
 
-import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { Spinner } from '@/components/ui/spinner';
+import { SaveButton } from '@/components/ui/save-button';
 import { CountryCombobox, getCallingCode } from '@/components/ui/country-combobox';
 import { CityCombobox } from '@/components/ui/city-combobox';
 import { toast } from '@/components/ui/toast';
+import { FieldMessage } from '@/components/ui/field-message';
 import { apiClient } from '@/services/api-client';
 import { NAME_REGEX, normalizeName } from '@/lib/name-utils';
 
@@ -195,8 +195,7 @@ export function PersonalDetailsSection({ profile, onRefresh }: PersonalDetailsSe
             disabled={isSaving}
             className="uppercase placeholder:normal-case"
           />
-          {firstNameError && <p className="text-sm text-destructive">{firstNameError}</p>}
-          <p className="text-xs text-muted-foreground">{t('personalDetails.firstNameHint')}</p>
+          <FieldMessage error={firstNameError} hint={t('personalDetails.firstNameHint')} />
         </div>
 
         <div className="space-y-1.5">
@@ -212,8 +211,7 @@ export function PersonalDetailsSection({ profile, onRefresh }: PersonalDetailsSe
             disabled={isSaving}
             className="uppercase placeholder:normal-case"
           />
-          {lastNameError && <p className="text-sm text-destructive">{lastNameError}</p>}
-          <p className="text-xs text-muted-foreground">{t('personalDetails.lastNameHint')}</p>
+          <FieldMessage error={lastNameError} hint={t('personalDetails.lastNameHint')} />
         </div>
       </div>
 
@@ -266,7 +264,7 @@ export function PersonalDetailsSection({ profile, onRefresh }: PersonalDetailsSe
             />
           </div>
         </div>
-        {dobError && <p className="text-sm text-destructive">{dobError}</p>}
+        <FieldMessage error={dobError} />
         <label className="flex cursor-pointer items-center gap-2 text-sm">
           <input
             type="checkbox"
@@ -313,7 +311,7 @@ export function PersonalDetailsSection({ profile, onRefresh }: PersonalDetailsSe
             />
           </div>
         </div>
-        {phoneError && <p className="text-sm text-destructive">{phoneError}</p>}
+        <FieldMessage error={phoneError} />
       </div>
 
       <div className="space-y-1.5">
@@ -387,16 +385,10 @@ export function PersonalDetailsSection({ profile, onRefresh }: PersonalDetailsSe
             />
           </div>
         </div>
-        {homeCountryError && <p className="text-sm text-destructive">{homeCountryError}</p>}
+        <FieldMessage error={homeCountryError} />
       </div>
 
-      <Button type="submit" disabled={isSaving || !isDirty} className="gap-2">
-        {isSaving && <Spinner size="sm" />}
-        {!isSaving && isDirty && (
-          <span data-testid="unsaved-indicator" className="size-2 rounded-full bg-amber-500" />
-        )}
-        {isSaving ? t('personalDetails.saving') : t('personalDetails.save')}
-      </Button>
+      <SaveButton isSaving={isSaving} isDirty={isDirty} label={t('personalDetails.save')} />
     </form>
   );
 }

--- a/apps/web/src/components/ui/field-message.test.tsx
+++ b/apps/web/src/components/ui/field-message.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from '@testing-library/react';
+
+import { FieldMessage } from './field-message';
+
+describe('FieldMessage', () => {
+  it('renders error message when error is provided', () => {
+    render(<FieldMessage error="Something went wrong" />);
+    expect(screen.getByText('Something went wrong')).toBeInTheDocument();
+  });
+
+  it('renders hint message when hint is provided', () => {
+    render(<FieldMessage hint="Helpful hint" />);
+    expect(screen.getByText('Helpful hint')).toBeInTheDocument();
+  });
+
+  it('renders error and not hint when both are provided', () => {
+    render(<FieldMessage error="Error text" hint="Hint text" />);
+    expect(screen.getByText('Error text')).toBeInTheDocument();
+    expect(screen.queryByText('Hint text')).not.toBeInTheDocument();
+  });
+
+  it('renders nothing when neither error nor hint is provided', () => {
+    const { container } = render(<FieldMessage />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing when error is null and no hint', () => {
+    const { container } = render(<FieldMessage error={null} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('applies custom className to error paragraph', () => {
+    render(<FieldMessage error="Error" className="text-xs" />);
+    expect(screen.getByText('Error')).toHaveClass('text-xs');
+  });
+
+  it('applies custom className to hint paragraph', () => {
+    render(<FieldMessage hint="Hint" className="text-xs" />);
+    expect(screen.getByText('Hint')).toHaveClass('text-xs');
+  });
+
+  it('error paragraph has text-destructive class', () => {
+    render(<FieldMessage error="Error" />);
+    expect(screen.getByText('Error')).toHaveClass('text-destructive');
+  });
+
+  it('hint paragraph has text-muted-foreground class', () => {
+    render(<FieldMessage hint="Hint" />);
+    expect(screen.getByText('Hint')).toHaveClass('text-muted-foreground');
+  });
+});

--- a/apps/web/src/components/ui/field-message.tsx
+++ b/apps/web/src/components/ui/field-message.tsx
@@ -1,0 +1,17 @@
+import { cn } from '@/lib/utils';
+
+interface FieldMessageProps {
+  error?: string | null;
+  hint?: string;
+  className?: string;
+}
+
+export function FieldMessage({ error, hint, className }: FieldMessageProps) {
+  if (error) {
+    return <p className={cn('text-sm text-destructive', className)}>{error}</p>;
+  }
+  if (hint) {
+    return <p className={cn('text-sm text-muted-foreground', className)}>{hint}</p>;
+  }
+  return null;
+}

--- a/apps/web/src/components/ui/save-button.test.tsx
+++ b/apps/web/src/components/ui/save-button.test.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+vi.mock('@/components/ui/button', () => ({
+  Button: (props: React.ComponentProps<'button'>) => <button {...props} />,
+}));
+
+vi.mock('@/components/ui/spinner', () => ({
+  Spinner: () => <span data-testid="spinner" />,
+}));
+
+import { SaveButton } from './save-button';
+
+describe('SaveButton', () => {
+  it('renders with the provided label', () => {
+    render(<SaveButton label="Save" isSaving={false} isDirty={true} />);
+    expect(screen.getByRole('button', { name: /Save/ })).toBeInTheDocument();
+  });
+
+  it('is disabled when not dirty', () => {
+    render(<SaveButton label="Save" isSaving={false} isDirty={false} />);
+    expect(screen.getByRole('button')).toBeDisabled();
+  });
+
+  it('is disabled when saving', () => {
+    render(<SaveButton label="Save" isSaving={true} isDirty={true} />);
+    expect(screen.getByRole('button')).toBeDisabled();
+  });
+
+  it('is enabled when dirty and not saving', () => {
+    render(<SaveButton label="Save" isSaving={false} isDirty={true} />);
+    expect(screen.getByRole('button')).toBeEnabled();
+  });
+
+  it('shows spinner when saving', () => {
+    render(<SaveButton label="Save" isSaving={true} isDirty={true} />);
+    expect(screen.getByTestId('spinner')).toBeInTheDocument();
+  });
+
+  it('hides spinner when not saving', () => {
+    render(<SaveButton label="Save" isSaving={false} isDirty={true} />);
+    expect(screen.queryByTestId('spinner')).not.toBeInTheDocument();
+  });
+
+  it('shows unsaved-indicator when dirty and not saving', () => {
+    render(<SaveButton label="Save" isSaving={false} isDirty={true} />);
+    expect(screen.getByTestId('unsaved-indicator')).toBeInTheDocument();
+  });
+
+  it('hides unsaved-indicator when not dirty', () => {
+    render(<SaveButton label="Save" isSaving={false} isDirty={false} />);
+    expect(screen.queryByTestId('unsaved-indicator')).not.toBeInTheDocument();
+  });
+
+  it('hides unsaved-indicator when saving', () => {
+    render(<SaveButton label="Save" isSaving={true} isDirty={true} />);
+    expect(screen.queryByTestId('unsaved-indicator')).not.toBeInTheDocument();
+  });
+
+  it('renders as a submit button', () => {
+    render(<SaveButton label="Save" isSaving={false} isDirty={true} />);
+    expect(screen.getByRole('button')).toHaveAttribute('type', 'submit');
+  });
+});

--- a/apps/web/src/components/ui/save-button.tsx
+++ b/apps/web/src/components/ui/save-button.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { type ComponentPropsWithoutRef } from 'react';
+import { Button } from '@/components/ui/button';
+import { Spinner } from '@/components/ui/spinner';
+import { cn } from '@/lib/utils';
+
+interface SaveButtonProps extends Omit<
+  ComponentPropsWithoutRef<typeof Button>,
+  'children' | 'disabled' | 'type'
+> {
+  isSaving: boolean;
+  isDirty: boolean;
+  label: string;
+}
+
+export function SaveButton({ isSaving, isDirty, label, className, ...props }: SaveButtonProps) {
+  return (
+    <Button
+      type="submit"
+      disabled={isSaving || !isDirty}
+      className={cn('gap-2', className)}
+      {...props}
+    >
+      {isSaving && <Spinner size="sm" />}
+      {!isSaving && isDirty && (
+        <span data-testid="unsaved-indicator" className="size-2 rounded-full bg-amber-500" />
+      )}
+      {label}
+    </Button>
+  );
+}

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -232,7 +232,6 @@
       "timezoneSearchPlaceholder": "Search timezones...",
       "timezoneNoResults": "No timezone found.",
       "save": "Save changes",
-      "saving": "Saving...",
       "saveSuccess": "Profile updated",
       "saveError": "Failed to save profile",
       "validDisplayName": "Display name must be between 1 and 100 characters",
@@ -301,7 +300,6 @@
       "homeCity": "Home City",
       "homeCityPlaceholder": "e.g. Medellín",
       "save": "Save changes",
-      "saving": "Saving...",
       "saveSuccess": "Personal details updated",
       "saveError": "Failed to save personal details",
       "errors": {
@@ -418,8 +416,7 @@
         "otherDescriptionPlaceholder": "Please describe...",
         "otherDescriptionRequired": "Description is required for \"Other\""
       },
-      "save": "Save Health Profile",
-      "saving": "Saving...",
+      "save": "Save changes",
       "saveSuccess": "Health profile saved",
       "saveError": "Failed to save health profile"
     },

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -168,7 +168,8 @@
         "invalidPhone": "Enter a valid phone number (4–14 digits)",
         "invalidPhoneCode": "Enter a valid country code (e.g. +57)",
         "invalidName": "Letters and spaces only (2–100 characters), as on your passport",
-        "invalidDob": "Enter a valid date of birth"
+        "invalidDob": "Enter a valid date of birth",
+        "usernameUnavailable": "Choose an available username before continuing"
       }
     }
   },
@@ -499,7 +500,6 @@
       "deleteError": "Could not delete. Please try again.",
       "deletePrimaryError": "Cannot delete the primary nationality while others exist.",
       "errors": {
-        "countryRequired": "Select a country.",
         "nationalIdFormat": "National ID may only contain uppercase letters, numbers, and hyphens.",
         "passportIncomplete": "Provide all three passport fields or leave them all empty.",
         "passportFormat": "Passport number may only contain uppercase letters, numbers, and hyphens.",

--- a/apps/web/src/locales/es.json
+++ b/apps/web/src/locales/es.json
@@ -168,7 +168,8 @@
         "invalidPhone": "Ingresa un número de teléfono válido (4–14 dígitos)",
         "invalidPhoneCode": "Ingresa un código de país válido (ej. +57)",
         "invalidName": "Solo letras y espacios (2–100 caracteres), tal como aparece en tu pasaporte",
-        "invalidDob": "Ingresa una fecha de nacimiento válida"
+        "invalidDob": "Ingresa una fecha de nacimiento válida",
+        "usernameUnavailable": "Elige un nombre de usuario disponible antes de continuar"
       }
     }
   },
@@ -499,7 +500,6 @@
       "deleteError": "No se pudo eliminar. Intenta de nuevo.",
       "deletePrimaryError": "No se puede eliminar la nacionalidad principal mientras existan otras.",
       "errors": {
-        "countryRequired": "Selecciona un país.",
         "nationalIdFormat": "El número de identificación solo puede contener letras mayúsculas, números y guiones.",
         "passportIncomplete": "Completa los tres campos del pasaporte o déjalos todos vacíos.",
         "passportFormat": "El número de pasaporte solo puede contener letras mayúsculas, números y guiones.",

--- a/apps/web/src/locales/es.json
+++ b/apps/web/src/locales/es.json
@@ -232,7 +232,6 @@
       "timezoneSearchPlaceholder": "Buscar zonas horarias...",
       "timezoneNoResults": "No se encontró zona horaria.",
       "save": "Guardar cambios",
-      "saving": "Guardando...",
       "saveSuccess": "Perfil actualizado",
       "saveError": "Error al guardar el perfil",
       "validDisplayName": "El nombre para mostrar debe tener entre 1 y 100 caracteres",
@@ -301,7 +300,6 @@
       "homeCity": "Ciudad de Residencia",
       "homeCityPlaceholder": "ej. Medellín",
       "save": "Guardar cambios",
-      "saving": "Guardando...",
       "saveSuccess": "Datos personales actualizados",
       "saveError": "Error al guardar los datos personales",
       "errors": {
@@ -418,8 +416,7 @@
         "otherDescriptionPlaceholder": "Por favor describe...",
         "otherDescriptionRequired": "La descripción es requerida para \"Otro\""
       },
-      "save": "Guardar Perfil de Salud",
-      "saving": "Guardando...",
+      "save": "Guardar cambios",
       "saveSuccess": "Perfil de salud guardado",
       "saveError": "Error al guardar el perfil de salud"
     },


### PR DESCRIPTION
## Summary

- **`SaveButton` and `FieldMessage` components** — extracted as reusable UI primitives. `SaveButton` shows a dirty indicator (amber dot), spinner during save, and is disabled when `!isDirty || isSaving`. `FieldMessage` renders a per-field error (red) or hint (muted), with error taking precedence.
- **Onboarding per-field error state** — changed `stepErrors` from `string[]` to `Record<string, string>` with a `clearError(field)` helper, so fixing one field no longer clears errors on others.
- **Profile section cleanup** — replaced all ad-hoc `{error && <p>}` / `<p className="text-xs ...">hint</p>` patterns with `<FieldMessage error={...} hint={...} />` across BasicInfo, PersonalDetails, Health, Nationalities, and EmergencyContacts.
- **Frontend/backend validation parity** — fixed 6 mismatches: `fullName` max 100, `relationship` min 2 / max 50, `dietaryNotes` max 300, `generalMedicalNotes` max 1000, loyalty `programName`/`memberId` max 100. Added `maxLength` HTML attributes to all affected inputs.
- **`IsDateAfter` cross-field validator** — new NestJS custom decorator enforcing passport expiry date > issue date in `CreateNationalityDto` and `UpdateNationalityDto`.
- **Dead code removal** — removed unreachable `countryRequired` validation branch in `NationalitiesSection` (save is disabled when no country is selected, making the check unreachable on both add and edit paths).
- **Tests** — new unit tests for `SaveButton` and `FieldMessage`; added missing constraint tests in `EmergencyContactsSection` and `LoyaltyProgramsSection`; updated existing tests that broke due to the `SaveButton` dirty-state guard. All 794 web tests and 529 API tests pass.

> **Note:** Also includes a one-liner mobile positioning fix for `FeedbackButton` (`bottom-6 → bottom-20 md:bottom-6`) that was bundled in; unrelated to validation UX but trivial.

## Test plan

- [ ] Run `pnpm --filter web test` — all tests pass
- [ ] Run `pnpm --filter api test` — all tests pass
- [ ] Open profile page and verify save button shows amber dot when a field is changed and is disabled on pristine form
- [ ] Verify fixing one field in a form does not clear errors on other fields
- [ ] Submit onboarding with invalid fields and confirm per-field errors appear correctly
- [ ] Test passport form: set expiry date before issue date, verify error message
- [ ] Add an emergency contact with a very long name — confirm browser caps input at 100 chars

🤖 Generated with [Claude Code](https://claude.com/claude-code)