### PR TITLE
feat(profile): add user store and preserve selected tab on reload

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -8,6 +8,7 @@ import { I18nProvider } from '@/components/I18nProvider';
 import { AppShell } from '@/components/layout';
 import { PreferencesSync } from '@/components/PreferencesSync';
 import { AuthProvider } from '@/store/auth';
+import { UserProvider } from '@/store/user';
 import { cn } from '@/lib/utils';
 import { SIDEBAR_STORAGE_KEY, SIDEBAR_COLLAPSED_WIDTH } from '@/lib/sidebar-constants';
 
@@ -58,8 +59,10 @@ export default function RootLayout({ children }: { children: ReactNode }) {
             storageKey="chamuco-theme"
           >
             <AuthProvider>
-              <PreferencesSync />
-              <AppShell>{children}</AppShell>
+              <UserProvider>
+                <PreferencesSync />
+                <AppShell>{children}</AppShell>
+              </UserProvider>
             </AuthProvider>
           </ThemeProvider>
         </I18nProvider>

--- a/apps/web/src/app/profile/layout.tsx
+++ b/apps/web/src/app/profile/layout.tsx
@@ -1,0 +1,17 @@
+import { Suspense, type ReactNode } from 'react';
+
+import { Spinner } from '@/components/ui/spinner';
+
+export default function ProfileLayout({ children }: { children: ReactNode }) {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex min-h-[50vh] items-center justify-center p-8">
+          <Spinner size="lg" />
+        </div>
+      }
+    >
+      {children}
+    </Suspense>
+  );
+}

--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -8,7 +8,7 @@ import {
   useRef,
   type KeyboardEvent,
 } from 'react';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { useTranslation } from 'react-i18next';
 
 import { Button } from '@/components/ui/button';
@@ -20,7 +20,7 @@ import { LoyaltyProgramsSection } from '@/components/profile/LoyaltyProgramsSect
 import { HealthSection } from '@/components/profile/HealthSection';
 import { EmergencyContactsSection } from '@/components/profile/EmergencyContactsSection';
 import { NationalitiesSection } from '@/components/profile/NationalitiesSection';
-import type { BasicInfoUser, BasicInfoProfile } from '@/components/profile/BasicInfoSection';
+import type { BasicInfoProfile } from '@/components/profile/BasicInfoSection';
 import type { PersonalDetailsProfile } from '@/components/profile/PersonalDetailsSection';
 import type { PreferencesData } from '@/components/profile/PreferencesSection';
 import type { LoyaltyProgramDto } from '@/components/profile/LoyaltyProgramsSection';
@@ -28,6 +28,7 @@ import type { HealthData } from '@/components/profile/HealthSection';
 import type { EmergencyContactDto } from '@/components/profile/EmergencyContactsSection';
 import type { NationalityDto } from '@/components/profile/NationalitiesSection';
 import { useAuth } from '@/hooks/useAuth';
+import { useUser } from '@/hooks/useUser';
 import { apiClient } from '@/services/api-client';
 import { toast } from '@/components/ui/toast';
 import { AppLanguage, AppCurrency, AppTheme } from '@chamuco/shared-types';
@@ -41,6 +42,16 @@ type Tab =
   | 'loyalty'
   | 'health'
   | 'emergency';
+
+const VALID_TABS: Tab[] = [
+  'basic',
+  'personal',
+  'nationalities',
+  'preferences',
+  'loyalty',
+  'health',
+  'emergency',
+];
 
 const DEFAULT_PERSONAL_DETAILS: PersonalDetailsProfile = {
   firstName: '',
@@ -66,7 +77,6 @@ const DEFAULT_HEALTH_DATA: HealthData = {
 };
 
 interface ProfileData {
-  user: BasicInfoUser;
   userProfile: BasicInfoProfile;
   personalDetails: PersonalDetailsProfile;
   preferences: PreferencesData;
@@ -79,9 +89,20 @@ interface ProfileData {
 export default function ProfilePage() {
   const { t } = useTranslation('profile');
   const { currentUser, isLoading: authLoading } = useAuth();
+  const { appUser, isLoading: userLoading } = useUser();
   const router = useRouter();
 
-  const [activeTab, setActiveTab] = useState<Tab>('basic');
+  const searchParams = useSearchParams();
+  const rawTab = searchParams.get('tab');
+  const [activeTab, setActiveTab] = useState<Tab>(
+    VALID_TABS.includes(rawTab as Tab) ? (rawTab as Tab) : 'basic',
+  );
+
+  function handleTabChange(tab: Tab) {
+    setActiveTab(tab);
+    router.replace(`/profile?tab=${tab}`, { scroll: false });
+  }
+
   const [data, setData] = useState<ProfileData | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [hasLoadError, setHasLoadError] = useState(false);
@@ -113,9 +134,8 @@ export default function ProfilePage() {
     if (!loadedOnce.current) setIsLoading(true);
     setHasLoadError(false);
     try {
-      const [userRes, profileRes, prefRes, loyaltyRes, healthRes, emergencyRes, nationalitiesRes] =
+      const [profileRes, prefRes, loyaltyRes, healthRes, emergencyRes, nationalitiesRes] =
         await Promise.allSettled([
-          apiClient.get('/v1/users/me'),
           apiClient.get('/v1/users/me/profile'),
           apiClient.get('/v1/users/me/preferences'),
           apiClient.get('/v1/users/me/loyalty-programs'),
@@ -124,16 +144,7 @@ export default function ProfilePage() {
           apiClient.get('/v1/users/me/nationalities'),
         ]);
 
-      if (userRes.status === 'rejected') throw userRes.reason;
-
-      const freshUser = userRes.value.data as BasicInfoUser;
-      setData((prev) => ({
-        user: {
-          ...freshUser,
-          // Preserve cached avatarUrl — it only changes on re-auth, not on saves.
-          // Avoids repeated requests to Google's photo CDN, which has tight rate limits.
-          avatarUrl: prev?.user.avatarUrl ?? freshUser.avatarUrl,
-        },
+      setData({
         userProfile:
           profileRes.status === 'fulfilled'
             ? (profileRes.value.data as BasicInfoProfile)
@@ -160,7 +171,7 @@ export default function ProfilePage() {
           nationalitiesRes.status === 'fulfilled'
             ? (nationalitiesRes.value.data as NationalityDto[])
             : [],
-      }));
+      });
     } catch {
       if (!loadedOnce.current) {
         setHasLoadError(true);
@@ -179,7 +190,7 @@ export default function ProfilePage() {
     }
   }, [authLoading, currentUser, loadData]);
 
-  if (authLoading || isLoading) {
+  if (authLoading || isLoading || userLoading) {
     return (
       <div className="flex min-h-[50vh] items-center justify-center p-8">
         <Spinner size="lg" />
@@ -225,21 +236,21 @@ export default function ProfilePage() {
     if (e.key === 'ArrowRight') {
       e.preventDefault();
       const next = tabKeys[(currentIndex + 1) % tabKeys.length]!;
-      setActiveTab(next);
+      handleTabChange(next);
       document.getElementById(`tab-${next}`)?.focus();
     } else if (e.key === 'ArrowLeft') {
       e.preventDefault();
       const prev = tabKeys[(currentIndex - 1 + tabKeys.length) % tabKeys.length]!;
-      setActiveTab(prev);
+      handleTabChange(prev);
       document.getElementById(`tab-${prev}`)?.focus();
     } else if (e.key === 'Home') {
       e.preventDefault();
-      setActiveTab(tabKeys[0]!);
+      handleTabChange(tabKeys[0]!);
       document.getElementById(`tab-${tabKeys[0]}`)?.focus();
     } else if (e.key === 'End') {
       e.preventDefault();
       const last = tabKeys[tabKeys.length - 1]!;
-      setActiveTab(last);
+      handleTabChange(last);
       document.getElementById(`tab-${last}`)?.focus();
     }
   }
@@ -262,7 +273,7 @@ export default function ProfilePage() {
               id={`tab-${key}`}
               role="tab"
               type="button"
-              onClick={() => setActiveTab(key)}
+              onClick={() => handleTabChange(key)}
               onKeyDown={(e) => handleTabKeyDown(e, key)}
               tabIndex={activeTab === key ? 0 : -1}
               aria-selected={activeTab === key}
@@ -291,7 +302,7 @@ export default function ProfilePage() {
         aria-labelledby="tab-basic"
         hidden={activeTab !== 'basic'}
       >
-        <BasicInfoSection user={data.user} userProfile={data.userProfile} onRefresh={loadData} />
+        <BasicInfoSection user={appUser!} userProfile={data.userProfile} onRefresh={loadData} />
       </div>
       <div
         id="panel-personal"

--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -34,16 +34,7 @@ import { toast } from '@/components/ui/toast';
 import { AppLanguage, AppCurrency, AppTheme } from '@chamuco/shared-types';
 import { cn } from '@/lib/utils';
 
-type Tab =
-  | 'basic'
-  | 'personal'
-  | 'nationalities'
-  | 'preferences'
-  | 'loyalty'
-  | 'health'
-  | 'emergency';
-
-const VALID_TABS: Tab[] = [
+const VALID_TABS = [
   'basic',
   'personal',
   'nationalities',
@@ -51,7 +42,9 @@ const VALID_TABS: Tab[] = [
   'loyalty',
   'health',
   'emergency',
-];
+] as const;
+
+type Tab = (typeof VALID_TABS)[number];
 
 const DEFAULT_PERSONAL_DETAILS: PersonalDetailsProfile = {
   firstName: '',
@@ -302,7 +295,9 @@ export default function ProfilePage() {
         aria-labelledby="tab-basic"
         hidden={activeTab !== 'basic'}
       >
-        <BasicInfoSection user={appUser!} userProfile={data.userProfile} onRefresh={loadData} />
+        {appUser && (
+          <BasicInfoSection user={appUser} userProfile={data.userProfile} onRefresh={loadData} />
+        )}
       </div>
       <div
         id="panel-personal"

--- a/apps/web/src/components/header/UserAvatar.test.tsx
+++ b/apps/web/src/components/header/UserAvatar.test.tsx
@@ -2,7 +2,9 @@ import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type { User } from 'firebase/auth';
+import { ProfileVisibility } from '@chamuco/shared-types';
 import type { AuthContextValue } from '@/store/auth';
+import type { UserContextValue } from '@/store/user';
 
 // --- hoisted mocks ---
 
@@ -20,6 +22,10 @@ vi.mock('next/navigation', () => ({
 
 vi.mock('@/hooks/useAuth', () => ({
   useAuth: vi.fn(),
+}));
+
+vi.mock('@/hooks/useUser', () => ({
+  useUser: vi.fn(),
 }));
 
 vi.mock('@/components/ui/toast', () => ({
@@ -58,6 +64,7 @@ vi.mock('@/components/ui/menu', () => ({
 }));
 
 import { useAuth } from '@/hooks/useAuth';
+import { useUser } from '@/hooks/useUser';
 import { UserAvatar } from './UserAvatar';
 
 // --- helpers ---
@@ -75,10 +82,25 @@ function makeAuth(overrides: Partial<AuthContextValue> = {}): AuthContextValue {
   };
 }
 
-function makeUser(overrides: Partial<User> = {}): User {
+function makeAppUser(overrides: Partial<UserContextValue['appUser']> = {}): UserContextValue {
+  return {
+    appUser: {
+      username: 'janedoe',
+      displayName: 'Jane Doe',
+      avatarUrl: null,
+      timezone: 'America/Bogota',
+      profileVisibility: ProfileVisibility.PUBLIC,
+      ...overrides,
+    },
+    isLoading: false,
+    refresh: vi.fn(),
+  };
+}
+
+function makeFirebaseUser(overrides: Partial<User> = {}): User {
   return {
     uid: 'uid-123',
-    displayName: 'Jane Doe',
+    displayName: 'Firebase Name',
     email: 'jane@example.com',
     photoURL: null,
     ...overrides,
@@ -88,12 +110,24 @@ function makeUser(overrides: Partial<User> = {}): User {
 beforeEach(() => {
   vi.clearAllMocks();
   mocks.mockSignOut.mockResolvedValue(undefined);
+  vi.mocked(useUser).mockReturnValue({
+    appUser: null,
+    isLoading: false,
+    refresh: vi.fn(),
+  });
 });
 
 describe('UserAvatar', () => {
   describe('loading state', () => {
     it('renders a non-interactive placeholder while auth state is loading', () => {
       vi.mocked(useAuth).mockReturnValue(makeAuth({ isLoading: true }));
+      render(<UserAvatar />);
+      expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    });
+
+    it('renders a non-interactive placeholder while user data is loading', () => {
+      vi.mocked(useAuth).mockReturnValue(makeAuth({ currentUser: makeFirebaseUser() }));
+      vi.mocked(useUser).mockReturnValue({ appUser: null, isLoading: true, refresh: vi.fn() });
       render(<UserAvatar />);
       expect(screen.queryByRole('button')).not.toBeInTheDocument();
     });
@@ -119,7 +153,8 @@ describe('UserAvatar', () => {
 
   describe('authenticated state', () => {
     beforeEach(() => {
-      vi.mocked(useAuth).mockReturnValue(makeAuth({ currentUser: makeUser() }));
+      vi.mocked(useAuth).mockReturnValue(makeAuth({ currentUser: makeFirebaseUser() }));
+      vi.mocked(useUser).mockReturnValue(makeAppUser());
     });
 
     it('renders a trigger button', () => {
@@ -127,18 +162,30 @@ describe('UserAvatar', () => {
       expect(screen.getByRole('button')).toBeInTheDocument();
     });
 
-    it('shows user initials when photoURL is null', () => {
+    it('shows user initials from appUser displayName when avatarUrl is null', () => {
       render(<UserAvatar />);
       expect(screen.getByRole('button')).toHaveTextContent('JD');
     });
 
-    it('shows a photo img when photoURL is set', () => {
-      vi.mocked(useAuth).mockReturnValue(
-        makeAuth({ currentUser: makeUser({ photoURL: 'https://example.com/avatar.jpg' }) }),
+    it('shows a photo img when appUser has avatarUrl', () => {
+      vi.mocked(useUser).mockReturnValue(
+        makeAppUser({ avatarUrl: 'https://example.com/avatar.jpg' }),
       );
       render(<UserAvatar />);
       const img = screen.getByRole('img');
       expect(img).toHaveAttribute('src', 'https://example.com/avatar.jpg');
+    });
+
+    it('falls back to firebase photoURL when appUser has no avatarUrl', () => {
+      vi.mocked(useAuth).mockReturnValue(
+        makeAuth({
+          currentUser: makeFirebaseUser({ photoURL: 'https://firebase.example.com/photo.jpg' }),
+        }),
+      );
+      vi.mocked(useUser).mockReturnValue(makeAppUser({ avatarUrl: null }));
+      render(<UserAvatar />);
+      const img = screen.getByRole('img');
+      expect(img).toHaveAttribute('src', 'https://firebase.example.com/photo.jpg');
     });
 
     it('renders the dropdown menu', () => {
@@ -146,26 +193,33 @@ describe('UserAvatar', () => {
       expect(screen.getByTestId('menu-popup')).toBeInTheDocument();
     });
 
-    it('shows the display name in the menu label', () => {
+    it('shows appUser displayName in the menu label', () => {
       render(<UserAvatar />);
       expect(screen.getByTestId('menu-label')).toHaveTextContent('Jane Doe');
     });
 
-    it('shows the email in the menu label when different from display name', () => {
+    it('shows @username in the menu label', () => {
       render(<UserAvatar />);
-      expect(screen.getByTestId('menu-label')).toHaveTextContent('jane@example.com');
+      expect(screen.getByTestId('menu-label')).toHaveTextContent('@janedoe');
     });
 
-    it('hides the email line when displayName equals email', () => {
+    it('hides username line when appUser is null', () => {
+      vi.mocked(useUser).mockReturnValue({ appUser: null, isLoading: false, refresh: vi.fn() });
       vi.mocked(useAuth).mockReturnValue(
-        makeAuth({
-          currentUser: makeUser({ displayName: null, email: 'jane@example.com' }),
-        }),
+        makeAuth({ currentUser: makeFirebaseUser({ displayName: 'Firebase Name' }) }),
       );
       render(<UserAvatar />);
-      // email is used as displayName — the secondary email line should not appear twice
       const label = screen.getByTestId('menu-label');
       expect(label.querySelectorAll('p')).toHaveLength(1);
+    });
+
+    it('falls back to firebase displayName when appUser is null', () => {
+      vi.mocked(useUser).mockReturnValue({ appUser: null, isLoading: false, refresh: vi.fn() });
+      vi.mocked(useAuth).mockReturnValue(
+        makeAuth({ currentUser: makeFirebaseUser({ displayName: 'Firebase Name' }) }),
+      );
+      render(<UserAvatar />);
+      expect(screen.getByTestId('menu-label')).toHaveTextContent('Firebase Name');
     });
 
     it('renders Profile and Sign out menu items', () => {
@@ -203,27 +257,26 @@ describe('UserAvatar', () => {
 
   describe('initials generation', () => {
     it('generates two initials from a two-word display name', () => {
-      vi.mocked(useAuth).mockReturnValue(
-        makeAuth({ currentUser: makeUser({ displayName: 'John Smith' }) }),
-      );
+      vi.mocked(useAuth).mockReturnValue(makeAuth({ currentUser: makeFirebaseUser() }));
+      vi.mocked(useUser).mockReturnValue(makeAppUser({ displayName: 'John Smith' }));
       render(<UserAvatar />);
       expect(screen.getByRole('button')).toHaveTextContent('JS');
     });
 
-    it('falls back to email-based initial when displayName is null', () => {
-      vi.mocked(useAuth).mockReturnValue(
-        makeAuth({ currentUser: makeUser({ displayName: null, email: 'admin@example.com' }) }),
-      );
+    it('generates one initial from a single-word display name', () => {
+      vi.mocked(useAuth).mockReturnValue(makeAuth({ currentUser: makeFirebaseUser() }));
+      vi.mocked(useUser).mockReturnValue(makeAppUser({ displayName: 'Janedoe' }));
       render(<UserAvatar />);
-      expect(screen.getByRole('button')).toHaveTextContent('A');
+      expect(screen.getByRole('button')).toHaveTextContent('J');
     });
 
-    it('shows "?" initial when both displayName and email are null', () => {
+    it('falls back to firebase displayName initial when appUser is null', () => {
       vi.mocked(useAuth).mockReturnValue(
-        makeAuth({ currentUser: makeUser({ displayName: null, email: null }) }),
+        makeAuth({ currentUser: makeFirebaseUser({ displayName: 'Admin User' }) }),
       );
+      vi.mocked(useUser).mockReturnValue({ appUser: null, isLoading: false, refresh: vi.fn() });
       render(<UserAvatar />);
-      expect(screen.getByRole('button')).toHaveTextContent('?');
+      expect(screen.getByRole('button')).toHaveTextContent('AU');
     });
   });
 });

--- a/apps/web/src/components/header/UserAvatar.tsx
+++ b/apps/web/src/components/header/UserAvatar.tsx
@@ -15,15 +15,7 @@ import {
   MenuLabel,
 } from '@/components/ui/menu';
 import { toast } from '@/components/ui/toast';
-
-function getInitials(name: string): string {
-  return name
-    .split(/[\s@]/)
-    .filter(Boolean)
-    .slice(0, 2)
-    .map((s) => s.charAt(0).toUpperCase())
-    .join('');
-}
+import { getInitials } from '@/lib/name-utils';
 
 export function UserAvatar() {
   const { t } = useTranslation(['common', 'auth', 'errors']);

--- a/apps/web/src/components/header/UserAvatar.tsx
+++ b/apps/web/src/components/header/UserAvatar.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next';
 import { UserCircleIcon, SignOutIcon, UserIcon } from '@phosphor-icons/react';
 
 import { useAuth } from '@/hooks/useAuth';
+import { useUser } from '@/hooks/useUser';
 import {
   MenuRoot,
   MenuTrigger,
@@ -15,10 +16,20 @@ import {
 } from '@/components/ui/menu';
 import { toast } from '@/components/ui/toast';
 
+function getInitials(name: string): string {
+  return name
+    .split(/[\s@]/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((s) => s.charAt(0).toUpperCase())
+    .join('');
+}
+
 export function UserAvatar() {
   const { t } = useTranslation(['common', 'auth', 'errors']);
   const router = useRouter();
-  const { currentUser, isLoading, signOut } = useAuth();
+  const { currentUser, isLoading: authLoading, signOut } = useAuth();
+  const { appUser, isLoading: userLoading } = useUser();
 
   async function handleSignOut() {
     try {
@@ -29,8 +40,7 @@ export function UserAvatar() {
     }
   }
 
-  // While auth state is resolving, render a non-interactive placeholder
-  if (isLoading) {
+  if (authLoading || (currentUser !== null && userLoading)) {
     return (
       <div className="rounded-lg p-2">
         <UserCircleIcon
@@ -42,7 +52,6 @@ export function UserAvatar() {
     );
   }
 
-  // Unauthenticated: link to sign-in
   if (!currentUser) {
     return (
       <button
@@ -56,16 +65,11 @@ export function UserAvatar() {
     );
   }
 
-  // Authenticated: show dropdown menu
   const displayName =
-    currentUser.displayName ?? currentUser.email ?? t('common:navigation.profile');
-  const email = currentUser.email;
-  const initials = (currentUser.displayName ?? currentUser.email ?? '?')
-    .split(/[\s@]/)
-    .filter(Boolean)
-    .slice(0, 2)
-    .map((s) => s.charAt(0).toUpperCase())
-    .join('');
+    appUser?.displayName ?? currentUser.displayName ?? t('common:navigation.profile');
+  const username = appUser?.username ?? null;
+  const avatarUrl = appUser?.avatarUrl ?? currentUser.photoURL ?? null;
+  const initials = getInitials(displayName !== t('common:navigation.profile') ? displayName : '?');
 
   return (
     <MenuRoot>
@@ -73,9 +77,9 @@ export function UserAvatar() {
         className="flex items-center justify-center h-9 w-9 rounded-full bg-primary text-primary-foreground text-sm font-semibold hover:opacity-90 transition-opacity focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
         aria-label={t('common:navigation.profile')}
       >
-        {currentUser.photoURL ? (
+        {avatarUrl ? (
           <img
-            src={currentUser.photoURL}
+            src={avatarUrl}
             alt={displayName}
             className="h-9 w-9 rounded-full object-cover"
             referrerPolicy="no-referrer"
@@ -89,7 +93,7 @@ export function UserAvatar() {
         {/* User info — non-interactive */}
         <MenuLabel>
           <p className="font-medium text-foreground truncate">{displayName}</p>
-          {email && displayName !== email && <p className="truncate">{email}</p>}
+          {username && <p className="truncate">{`@${username}`}</p>}
         </MenuLabel>
 
         <MenuSeparator />

--- a/apps/web/src/components/header/UserAvatar.tsx
+++ b/apps/web/src/components/header/UserAvatar.tsx
@@ -57,11 +57,10 @@ export function UserAvatar() {
     );
   }
 
-  const displayName =
-    appUser?.displayName ?? currentUser.displayName ?? t('common:navigation.profile');
+  const displayName = appUser?.displayName ?? currentUser.displayName ?? null;
   const username = appUser?.username ?? null;
   const avatarUrl = appUser?.avatarUrl ?? currentUser.photoURL ?? null;
-  const initials = getInitials(displayName !== t('common:navigation.profile') ? displayName : '?');
+  const initials = getInitials(displayName ?? '?');
 
   return (
     <MenuRoot>
@@ -72,7 +71,7 @@ export function UserAvatar() {
         {avatarUrl ? (
           <img
             src={avatarUrl}
-            alt={displayName}
+            alt={displayName ?? undefined}
             className="h-9 w-9 rounded-full object-cover"
             referrerPolicy="no-referrer"
           />
@@ -84,7 +83,9 @@ export function UserAvatar() {
       <MenuPopup>
         {/* User info — non-interactive */}
         <MenuLabel>
-          <p className="font-medium text-foreground truncate">{displayName}</p>
+          <p className="font-medium text-foreground truncate">
+            {displayName ?? t('common:navigation.profile')}
+          </p>
           {username && <p className="truncate">{`@${username}`}</p>}
         </MenuLabel>
 

--- a/apps/web/src/components/profile/BasicInfoSection.test.tsx
+++ b/apps/web/src/components/profile/BasicInfoSection.test.tsx
@@ -64,10 +64,11 @@ vi.mock('@/components/ui/timezone-combobox', () => ({
 
 import { ProfileVisibility } from '@chamuco/shared-types';
 
+import type { AppUser } from '@/store/user';
 import { BasicInfoSection } from './BasicInfoSection';
-import type { BasicInfoUser, BasicInfoProfile } from './BasicInfoSection';
+import type { BasicInfoProfile } from './BasicInfoSection';
 
-const baseUser: BasicInfoUser = {
+const baseUser: AppUser = {
   username: 'janedoe',
   displayName: 'Jane Doe',
   avatarUrl: null,
@@ -77,7 +78,7 @@ const baseUser: BasicInfoUser = {
 
 const baseProfile: BasicInfoProfile = { bio: 'Hello world', homeCountry: 'CO' };
 
-function setup(userOverride?: Partial<BasicInfoUser>, profileOverride?: Partial<BasicInfoProfile>) {
+function setup(userOverride?: Partial<AppUser>, profileOverride?: Partial<BasicInfoProfile>) {
   const onRefresh = vi.fn();
   const user = userEvent.setup();
   render(

--- a/apps/web/src/components/profile/BasicInfoSection.test.tsx
+++ b/apps/web/src/components/profile/BasicInfoSection.test.tsx
@@ -5,10 +5,15 @@ const mocks = vi.hoisted(() => ({
   mockPatch: vi.fn(),
   mockToastSuccess: vi.fn(),
   mockToastError: vi.fn(),
+  mockRefresh: vi.fn(),
 }));
 
 vi.mock('@/services/api-client', () => ({
   apiClient: { patch: mocks.mockPatch },
+}));
+
+vi.mock('@/hooks/useUser', () => ({
+  useUser: () => ({ appUser: null, isLoading: false, refresh: mocks.mockRefresh }),
 }));
 
 vi.mock('@/components/ui/toast', () => ({
@@ -207,6 +212,12 @@ describe('BasicInfoSection', () => {
       const { user, onRefresh } = setup({ timezone: 'UTC' });
       await user.click(screen.getByRole('button', { name: 'basicInfo.save' }));
       await waitFor(() => expect(onRefresh).toHaveBeenCalledOnce());
+    });
+
+    it('calls store refresh after successful save', async () => {
+      const { user } = setup({ timezone: 'UTC' });
+      await user.click(screen.getByRole('button', { name: 'basicInfo.save' }));
+      await waitFor(() => expect(mocks.mockRefresh).toHaveBeenCalledOnce());
     });
 
     it('shows success toast on save', async () => {

--- a/apps/web/src/components/profile/BasicInfoSection.tsx
+++ b/apps/web/src/components/profile/BasicInfoSection.tsx
@@ -15,16 +15,9 @@ import { toast } from '@/components/ui/toast';
 import { FieldMessage } from '@/components/ui/field-message';
 import { apiClient } from '@/services/api-client';
 import { useUser } from '@/hooks/useUser';
+import type { AppUser } from '@/store/user';
 import { COUNTRY_TIMEZONE } from '@/lib/timezones';
 import { getInitials } from '@/lib/name-utils';
-
-export interface BasicInfoUser {
-  username: string;
-  displayName: string;
-  avatarUrl: string | null;
-  timezone: string;
-  profileVisibility: ProfileVisibility;
-}
 
 export interface BasicInfoProfile {
   bio: string | null;
@@ -32,7 +25,7 @@ export interface BasicInfoProfile {
 }
 
 interface BasicInfoSectionProps {
-  user: BasicInfoUser;
+  user: AppUser;
   userProfile: BasicInfoProfile;
   onRefresh: () => void;
 }

--- a/apps/web/src/components/profile/BasicInfoSection.tsx
+++ b/apps/web/src/components/profile/BasicInfoSection.tsx
@@ -14,6 +14,7 @@ import { TimezoneCombobox } from '@/components/ui/timezone-combobox';
 import { toast } from '@/components/ui/toast';
 import { FieldMessage } from '@/components/ui/field-message';
 import { apiClient } from '@/services/api-client';
+import { useUser } from '@/hooks/useUser';
 import { COUNTRY_TIMEZONE } from '@/lib/timezones';
 import { getInitials } from '@/lib/name-utils';
 
@@ -38,6 +39,7 @@ interface BasicInfoSectionProps {
 
 export function BasicInfoSection({ user, userProfile, onRefresh }: BasicInfoSectionProps) {
   const { t } = useTranslation('profile');
+  const { refresh } = useUser();
 
   const [displayName, setDisplayName] = useState(user.displayName);
   const [bio, setBio] = useState(userProfile.bio ?? '');
@@ -78,6 +80,7 @@ export function BasicInfoSection({ user, userProfile, onRefresh }: BasicInfoSect
         }),
       ]);
       toast.success(t('basicInfo.saveSuccess'));
+      void refresh();
       onRefresh();
     } catch {
       toast.error(t('basicInfo.saveError'));

--- a/apps/web/src/components/ui/avatar.test.tsx
+++ b/apps/web/src/components/ui/avatar.test.tsx
@@ -1,5 +1,19 @@
+import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { describe, it, expect } from 'vitest';
+
+// Base UI's AvatarImage never mounts in JSDOM (image onLoad never fires).
+// Stub the primitives so the <img> is always rendered for prop assertions.
+vi.mock('@base-ui/react/avatar', () => ({
+  Avatar: {
+    Root: ({ children, ...props }: React.ComponentProps<'div'>) => <div {...props}>{children}</div>,
+    Image: ({ src, alt, className, referrerPolicy }: React.ComponentProps<'img'>) => (
+      <img src={src} alt={alt} className={className} referrerPolicy={referrerPolicy} />
+    ),
+    Fallback: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+  },
+}));
+
 import { Avatar } from './avatar';
 
 describe('Avatar', () => {
@@ -38,6 +52,12 @@ describe('Avatar', () => {
     // The fallback uses a 300ms delay to avoid flash-of-fallback while image loads.
     const { container } = render(<Avatar src="/avatar.jpg" alt="User" fallback="U" />);
     expect(container.querySelector('[data-slot="avatar"]')).toBeInTheDocument();
+  });
+
+  it('sets referrerPolicy="no-referrer" on the image to share the browser cache with other instances', () => {
+    const { container } = render(<Avatar src="/avatar.jpg" alt="User" fallback="U" />);
+    const img = container.querySelector('img');
+    expect(img).toHaveAttribute('referrerpolicy', 'no-referrer');
   });
 
   it('renders fallback when no src is provided', () => {

--- a/apps/web/src/components/ui/avatar.tsx
+++ b/apps/web/src/components/ui/avatar.tsx
@@ -46,6 +46,7 @@ function Avatar({ className, size, src, alt, fallback, ...props }: AvatarProps) 
           src={src}
           alt={alt ?? ''}
           className="aspect-square size-full object-cover"
+          referrerPolicy="no-referrer"
         />
       )}
       <AvatarPrimitive.Fallback

--- a/apps/web/src/hooks/useUser.test.ts
+++ b/apps/web/src/hooks/useUser.test.ts
@@ -1,0 +1,37 @@
+import React from 'react';
+import { renderHook } from '@testing-library/react';
+
+// Break the firebase import chain triggered by @/store/user → @/hooks/useAuth → @/store/auth → @/lib/firebase
+vi.mock('@/hooks/useAuth', () => ({ useAuth: vi.fn() }));
+
+import { ProfileVisibility } from '@chamuco/shared-types';
+import { UserContext } from '@/store/user';
+import type { UserContextValue } from '@/store/user';
+import { useUser } from './useUser';
+
+const mockContextValue: UserContextValue = {
+  appUser: {
+    username: 'janedoe',
+    displayName: 'Jane Doe',
+    avatarUrl: null,
+    timezone: 'America/Bogota',
+    profileVisibility: ProfileVisibility.PUBLIC,
+  },
+  isLoading: false,
+  refresh: vi.fn(),
+};
+
+describe('useUser', () => {
+  it('returns context value when inside UserProvider', () => {
+    const { result } = renderHook(() => useUser(), {
+      wrapper: ({ children }) =>
+        React.createElement(UserContext.Provider, { value: mockContextValue }, children),
+    });
+
+    expect(result.current).toBe(mockContextValue);
+  });
+
+  it('throws when used outside UserProvider', () => {
+    expect(() => renderHook(() => useUser())).toThrow('useUser must be used within a UserProvider');
+  });
+});

--- a/apps/web/src/hooks/useUser.ts
+++ b/apps/web/src/hooks/useUser.ts
@@ -1,0 +1,14 @@
+import { useContext } from 'react';
+
+import { UserContext } from '@/store/user';
+import type { UserContextValue } from '@/store/user';
+
+export function useUser(): UserContextValue {
+  const context = useContext(UserContext);
+
+  if (!context) {
+    throw new Error('useUser must be used within a UserProvider');
+  }
+
+  return context;
+}

--- a/apps/web/src/store/user.test.tsx
+++ b/apps/web/src/store/user.test.tsx
@@ -1,0 +1,176 @@
+import React from 'react';
+import { renderHook, waitFor } from '@testing-library/react';
+import type { User } from 'firebase/auth';
+import { ProfileVisibility } from '@chamuco/shared-types';
+import type { AuthContextValue } from '@/store/auth';
+
+// --- hoisted mocks ---
+
+const mocks = vi.hoisted(() => ({
+  mockApiGet: vi.fn(),
+}));
+
+vi.mock('@/hooks/useAuth', () => ({
+  useAuth: vi.fn(),
+}));
+
+vi.mock('@/services/api-client', () => ({
+  apiClient: { get: mocks.mockApiGet },
+}));
+
+import { useContext } from 'react';
+import { useAuth } from '@/hooks/useAuth';
+import { UserContext, UserProvider } from './user';
+
+// --- helpers ---
+
+function makeAuth(overrides: Partial<AuthContextValue> = {}): AuthContextValue {
+  return {
+    currentUser: null,
+    idToken: null,
+    isLoading: false,
+    getIdToken: vi.fn().mockResolvedValue(null),
+    signInWithGoogle: vi.fn(),
+    signInWithFacebook: vi.fn(),
+    signOut: vi.fn(),
+    ...overrides,
+  };
+}
+
+function makeFirebaseUser(overrides: Partial<User> = {}): User {
+  return {
+    uid: 'uid-123',
+    displayName: 'Firebase Name',
+    email: 'user@example.com',
+    photoURL: null,
+    ...overrides,
+  } as User;
+}
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  return <UserProvider>{children}</UserProvider>;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('UserProvider', () => {
+  it('stays loading while auth is still loading', () => {
+    vi.mocked(useAuth).mockReturnValue(makeAuth({ isLoading: true }));
+
+    const { result } = renderHook(() => useContext(UserContext), { wrapper });
+
+    expect(result.current?.isLoading).toBe(true);
+    expect(result.current?.appUser).toBeNull();
+    expect(mocks.mockApiGet).not.toHaveBeenCalled();
+  });
+
+  it('resolves to null without API call when no authenticated user', async () => {
+    vi.mocked(useAuth).mockReturnValue(makeAuth({ isLoading: false, currentUser: null }));
+
+    const { result } = renderHook(() => useContext(UserContext), { wrapper });
+
+    await waitFor(() => expect(result.current?.isLoading).toBe(false));
+    expect(result.current?.appUser).toBeNull();
+    expect(mocks.mockApiGet).not.toHaveBeenCalled();
+  });
+
+  it('fetches /v1/users/me and sets appUser when authenticated', async () => {
+    vi.mocked(useAuth).mockReturnValue(
+      makeAuth({ isLoading: false, currentUser: makeFirebaseUser() }),
+    );
+    mocks.mockApiGet.mockResolvedValue({
+      data: {
+        username: 'janedoe',
+        displayName: 'Jane Doe',
+        avatarUrl: null,
+        timezone: 'America/Bogota',
+        profileVisibility: ProfileVisibility.PUBLIC,
+      },
+    });
+
+    const { result } = renderHook(() => useContext(UserContext), { wrapper });
+
+    await waitFor(() => expect(result.current?.isLoading).toBe(false));
+    expect(result.current?.appUser).toEqual({
+      username: 'janedoe',
+      displayName: 'Jane Doe',
+      avatarUrl: null,
+      timezone: 'America/Bogota',
+      profileVisibility: ProfileVisibility.PUBLIC,
+    });
+    expect(mocks.mockApiGet).toHaveBeenCalledWith('/v1/users/me');
+  });
+
+  it('sets appUser to null when API call fails', async () => {
+    vi.mocked(useAuth).mockReturnValue(
+      makeAuth({ isLoading: false, currentUser: makeFirebaseUser() }),
+    );
+    mocks.mockApiGet.mockRejectedValue(new Error('network error'));
+
+    const { result } = renderHook(() => useContext(UserContext), { wrapper });
+
+    await waitFor(() => expect(result.current?.isLoading).toBe(false));
+    expect(result.current?.appUser).toBeNull();
+  });
+
+  it('clears appUser when user signs out', async () => {
+    const mockUseAuth = vi.mocked(useAuth);
+    mockUseAuth.mockReturnValue(makeAuth({ isLoading: false, currentUser: makeFirebaseUser() }));
+    mocks.mockApiGet.mockResolvedValue({
+      data: {
+        username: 'janedoe',
+        displayName: 'Jane Doe',
+        avatarUrl: null,
+        timezone: 'America/Bogota',
+        profileVisibility: ProfileVisibility.PUBLIC,
+      },
+    });
+
+    const { result, rerender } = renderHook(() => useContext(UserContext), { wrapper });
+
+    await waitFor(() => expect(result.current?.appUser).not.toBeNull());
+
+    mockUseAuth.mockReturnValue(makeAuth({ isLoading: false, currentUser: null }));
+    rerender();
+
+    await waitFor(() => {
+      expect(result.current?.appUser).toBeNull();
+      expect(result.current?.isLoading).toBe(false);
+    });
+  });
+
+  it('re-fetches when refresh is called', async () => {
+    vi.mocked(useAuth).mockReturnValue(
+      makeAuth({ isLoading: false, currentUser: makeFirebaseUser() }),
+    );
+    mocks.mockApiGet.mockResolvedValueOnce({
+      data: {
+        username: 'janedoe',
+        displayName: 'Jane Doe',
+        avatarUrl: null,
+        timezone: 'America/Bogota',
+        profileVisibility: ProfileVisibility.PUBLIC,
+      },
+    });
+
+    const { result } = renderHook(() => useContext(UserContext), { wrapper });
+
+    await waitFor(() => expect(result.current?.appUser?.displayName).toBe('Jane Doe'));
+
+    mocks.mockApiGet.mockResolvedValueOnce({
+      data: {
+        username: 'janedoe',
+        displayName: 'Jane Updated',
+        avatarUrl: null,
+        timezone: 'America/Bogota',
+        profileVisibility: ProfileVisibility.PUBLIC,
+      },
+    });
+
+    await result.current!.refresh();
+
+    await waitFor(() => expect(result.current?.appUser?.displayName).toBe('Jane Updated'));
+  });
+});

--- a/apps/web/src/store/user.tsx
+++ b/apps/web/src/store/user.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { createContext, useCallback, useEffect, useState } from 'react';
+import { createContext, useCallback, useEffect, useMemo, useState } from 'react';
 import type { ReactNode } from 'react';
 import { preload } from 'react-dom';
 import type { ProfileVisibility } from '@chamuco/shared-types';
@@ -52,13 +52,16 @@ export function UserProvider({ children }: { children: ReactNode }) {
     void fetchUser();
   }, [authLoading, currentUser, fetchUser]);
 
+  // Called during render (not in an effect) so React synchronously injects
+  // <link rel="preload"> before any consumer mounts, warming the browser cache.
   if (appUser?.avatarUrl) {
     preload(appUser.avatarUrl, { as: 'image', referrerPolicy: 'no-referrer' });
   }
 
-  return (
-    <UserContext.Provider value={{ appUser, isLoading, refresh: fetchUser }}>
-      {children}
-    </UserContext.Provider>
+  const value = useMemo(
+    () => ({ appUser, isLoading, refresh: fetchUser }),
+    [appUser, isLoading, fetchUser],
   );
+
+  return <UserContext.Provider value={value}>{children}</UserContext.Provider>;
 }

--- a/apps/web/src/store/user.tsx
+++ b/apps/web/src/store/user.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { createContext, useCallback, useEffect, useState } from 'react';
+import type { ReactNode } from 'react';
+import { preload } from 'react-dom';
+import type { ProfileVisibility } from '@chamuco/shared-types';
+
+import { useAuth } from '@/hooks/useAuth';
+import { apiClient } from '@/services/api-client';
+
+export interface AppUser {
+  username: string;
+  displayName: string;
+  avatarUrl: string | null;
+  timezone: string;
+  profileVisibility: ProfileVisibility;
+}
+
+export interface UserContextValue {
+  appUser: AppUser | null;
+  isLoading: boolean;
+  refresh: () => Promise<void>;
+}
+
+export const UserContext = createContext<UserContextValue | null>(null);
+
+export function UserProvider({ children }: { children: ReactNode }) {
+  const { currentUser, isLoading: authLoading } = useAuth();
+  const [appUser, setAppUser] = useState<AppUser | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const fetchUser = useCallback(async () => {
+    try {
+      const res = await apiClient.get<AppUser>('/v1/users/me');
+      setAppUser(res.data);
+    } catch {
+      setAppUser(null);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (authLoading) return;
+
+    if (!currentUser) {
+      setAppUser(null);
+      setIsLoading(false);
+      return;
+    }
+
+    void fetchUser();
+  }, [authLoading, currentUser, fetchUser]);
+
+  if (appUser?.avatarUrl) {
+    preload(appUser.avatarUrl, { as: 'image', referrerPolicy: 'no-referrer' });
+  }
+
+  return (
+    <UserContext.Provider value={{ appUser, isLoading, refresh: fetchUser }}>
+      {children}
+    </UserContext.Provider>
+  );
+}


### PR DESCRIPTION
## Summary

- **User store** — new `UserProvider` / `UserContext` (`store/user.tsx`) fetches `/v1/users/me` once on auth resolution; exposes `appUser`, `isLoading`, `refresh` to the whole app via `useUser()` hook
- **Header fix** — `UserAvatar` now reads `displayName`, `@username`, and `avatarUrl` from the store instead of Firebase auth data
- **Profile page deduplication** — removed the redundant `/v1/users/me` call from the profile page; `BasicInfoSection` calls `store.refresh()` after save so the header updates immediately without an extra round-trip
- **Avatar cache fix** — added `referrerPolicy="no-referrer"` to the `Avatar` component image and React 19 `preload()` in `UserProvider` so the header avatar and the profile page avatar share the same browser cache entry, eliminating the duplicate network request
- **Tab persistence** — active profile tab is now stored in the URL (`?tab=<key>`); reloading or sharing the URL restores the selected section

## Test plan

- [ ] Header shows API `displayName` and `@username` (not Firebase data)
- [ ] Network tab shows a single request for the avatar image when navigating to `/profile`
- [ ] Reload `/profile?tab=health` lands on the Health tab
- [ ] Navigating tabs updates the URL query param
- [ ] Invalid `?tab=` value falls back to Basic Info
- [ ] All 900 existing tests pass (`pnpm --filter web test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)