### PR TITLE
fix(onboarding): prevent redirect to sign-in after registration

### DIFF
--- a/apps/web/src/app/onboarding/page.test.tsx
+++ b/apps/web/src/app/onboarding/page.test.tsx
@@ -14,6 +14,7 @@ const mocks = vi.hoisted(() => ({
   mockToastError: vi.fn(),
   mockToastInfo: vi.fn(),
   mockSignOut: vi.fn(),
+  mockRefreshUser: vi.fn(),
 }));
 
 vi.mock('next/navigation', () => ({
@@ -23,6 +24,10 @@ vi.mock('next/navigation', () => ({
 
 vi.mock('@/hooks/useAuth', () => ({
   useAuth: vi.fn(),
+}));
+
+vi.mock('@/hooks/useUser', () => ({
+  useUser: () => ({ refresh: mocks.mockRefreshUser }),
 }));
 
 vi.mock('@/services/api-client', () => ({
@@ -204,6 +209,7 @@ async function renderFormAtStep3() {
 beforeEach(() => {
   vi.clearAllMocks();
   mocks.mockApiPatch.mockResolvedValue({ status: 200 });
+  mocks.mockRefreshUser.mockResolvedValue(undefined);
 });
 
 describe('OnboardingPage', () => {
@@ -243,7 +249,7 @@ describe('OnboardingPage', () => {
       await waitFor(() => expect(mocks.mockRouterReplace).toHaveBeenCalledWith('/'));
     });
 
-    it('redirects to /sign-in when GET /users/me returns an unexpected error', async () => {
+    it('shows the form and an error toast when GET /users/me returns an unexpected error', async () => {
       vi.mocked(useAuth).mockReturnValue(makeAuth());
       const serverErr = Object.assign(new Error('Server error'), {
         isAxiosError: true,
@@ -251,7 +257,9 @@ describe('OnboardingPage', () => {
       });
       mockGetByUrl({ meError: serverErr });
       render(<OnboardingPage />);
-      await waitFor(() => expect(mocks.mockRouterReplace).toHaveBeenCalledWith('/sign-in'));
+      await waitFor(() => expect(mocks.mockToastError).toHaveBeenCalledWith('error.failed'));
+      expect(screen.getByTestId('username-input')).toBeInTheDocument();
+      expect(mocks.mockRouterReplace).not.toHaveBeenCalledWith('/sign-in');
     });
   });
 
@@ -708,6 +716,17 @@ describe('OnboardingPage', () => {
           expect.objectContaining({ firstName: 'JUAN CARLOS', lastName: 'GARCIA LOPEZ' }),
         ),
       );
+    });
+
+    it('calls refreshUser after successful registration', async () => {
+      mocks.mockApiPost.mockResolvedValue({ status: 201 });
+      const user = await renderFormWithAvailableUsername({
+        currentUser: makeUser({ displayName: 'Test User' }),
+      });
+
+      await user.click(screen.getByTestId('submit-btn'));
+
+      await waitFor(() => expect(mocks.mockRefreshUser).toHaveBeenCalledTimes(1));
     });
 
     it('sets chamuco-registered cookie on successful registration', async () => {

--- a/apps/web/src/app/onboarding/page.tsx
+++ b/apps/web/src/app/onboarding/page.tsx
@@ -359,7 +359,7 @@ export default function OnboardingPage() {
         })
         .catch(() => {});
       // localStorage.setItem(PROFILE_INCOMPLETE_KEY, 'true'); // TODO: re-enable with banner
-      await refreshUser();
+      void refreshUser();
       router.replace('/');
     } catch (err) {
       if (isAxiosError(err) && err.response?.status === 409) {

--- a/apps/web/src/app/onboarding/page.tsx
+++ b/apps/web/src/app/onboarding/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { type SyntheticEvent, useEffect, useId, useState } from 'react';
+import { type SyntheticEvent, useEffect, useId, useRef, useState } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { Trans, useTranslation } from 'react-i18next';
@@ -11,6 +11,7 @@ import { useTheme } from 'next-themes';
 import { getCountryData, type TCountryCode } from 'countries-list';
 
 import { useAuth } from '@/hooks/useAuth';
+import { useUser } from '@/hooks/useUser';
 import { COOKIE_CHAMUCO_REGISTERED_SET } from '@/lib/auth-cookies';
 import { apiClient } from '@/services/api-client';
 import { Logo } from '@/components/header/Logo';
@@ -160,6 +161,9 @@ export default function OnboardingPage() {
   const { theme } = useTheme();
   const router = useRouter();
   const { currentUser, isLoading, signOut } = useAuth();
+  const { refresh: refreshUser } = useUser();
+  // Stable ref so the pre-flight effect doesn't re-run when language changes
+  const tRef = useRef(t);
 
   // Global state
   const [step, setStep] = useState(1);
@@ -222,6 +226,12 @@ export default function OnboardingPage() {
     }
   }, [currentUser, isLoading, router]);
 
+  // Keep tRef current so the pre-flight effect can read the latest translation
+  // without listing t as a dependency (which would re-run the effect on language change).
+  useEffect(() => {
+    tRef.current = t;
+  }, [t]);
+
   // Redirect already-registered users
   useEffect(() => {
     if (isLoading || !currentUser) return;
@@ -239,14 +249,17 @@ export default function OnboardingPage() {
         if (isAxiosError(err) && err.response?.status === 404) {
           setIsCheckingRegistration(false);
         } else {
-          toast.error(t('error.failed'));
-          router.replace('/sign-in');
+          // Non-404 errors (network failure, 5xx) are transient — show the form
+          // rather than bouncing the user back to sign-in. If they are already
+          // registered the submit will return 409, which is recoverable.
+          toast.error(tRef.current('error.failed'));
+          setIsCheckingRegistration(false);
         }
       });
     return () => {
       cancelled = true;
     };
-  }, [currentUser, isLoading, router, t]);
+  }, [currentUser, isLoading, router]);
 
   // Debounced username availability check
   useEffect(() => {
@@ -346,6 +359,7 @@ export default function OnboardingPage() {
         })
         .catch(() => {});
       // localStorage.setItem(PROFILE_INCOMPLETE_KEY, 'true'); // TODO: re-enable with banner
+      await refreshUser();
       router.replace('/');
     } catch (err) {
       if (isAxiosError(err) && err.response?.status === 409) {

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -159,7 +159,7 @@
       },
       "error": {
         "failed": "Registration failed. Please try again.",
-        "usernameTaken": "That username is already taken. Please choose another."
+        "usernameTaken": "That username is already taken. If this is your account, try signing in instead."
       },
       "validation": {
         "required": "This field is required",

--- a/apps/web/src/locales/es.json
+++ b/apps/web/src/locales/es.json
@@ -159,7 +159,7 @@
       },
       "error": {
         "failed": "El registro falló. Por favor intenta de nuevo.",
-        "usernameTaken": "Ese nombre de usuario ya está en uso. Por favor elige otro."
+        "usernameTaken": "Ese nombre de usuario ya está en uso. Si esta cuenta es tuya, intenta iniciar sesión."
       },
       "validation": {
         "required": "Este campo es obligatorio",


### PR DESCRIPTION
## Summary

User feedback (#220) reported that completing registration sent them back to the login screen instead of home. Root cause was three independent bugs in the onboarding pre-flight check and post-registration flow.

## Changes

**Bug 1 — Language toggle caused pre-flight check to re-run**
The `Redirect already-registered users` effect listed `t` (i18n translation function) as a dependency. Tapping the language toggle on the onboarding page produced a new `t` reference, re-triggering `GET /v1/users/me`. A transient non-404 error during that re-run then called `router.replace('/sign-in')`, overriding the navigation to `/` that `handleSubmit` had already issued.

Fix: capture `t` in a `useRef` (`tRef`) and sync it with a separate `useEffect([t])`. The pre-flight effect now depends only on `[currentUser, isLoading, router]` and reads `tRef.current` for the error toast.

**Bug 2 — Transient network/server errors sent the user to sign-in**
Any non-404 response from the pre-flight `GET /v1/users/me` (network timeout, 5xx) hit an `else` branch that called `router.replace('/sign-in')`. On mobile networks this is easy to trigger.

Fix: show the form instead (`setIsCheckingRegistration(false)` + toast). Worst case the user submits and gets a 409 (username taken by themselves), which is already handled gracefully.

**Bug 3 — `appUser` was null when home rendered after registration**
`UserProvider.fetchUser()` is only called when `currentUser` or `authLoading` changes. During onboarding it ran and returned 404 (user not yet registered). After a successful registration the user navigated to `/` but neither dep changed, so `fetchUser()` never re-ran — `appUser` stayed `null` and the header showed no `@username`.

Fix: `await refreshUser()` after the successful `POST /v1/auth/register` response, before `router.replace('/')`.

## Testing

- `guard redirects` — updated test: non-404 pre-flight errors now show the form + toast instead of redirecting to `/sign-in`
- `submit — registration` — new test: `refreshUser` is called exactly once after successful registration
- Full suite: 909 tests pass, lint clean

**Edge cases covered:**
- Language toggle during form fill no longer re-triggers the registration check
- Flaky mobile network on the pre-flight call no longer boots the user out
- `appUser` (username, avatar) is available immediately on the home page after first registration

Closes #220