### PR TITLE
fix(ui): auto-focus search input in country combobox on open

### DIFF
--- a/apps/web/src/components/ui/country-combobox.tsx
+++ b/apps/web/src/components/ui/country-combobox.tsx
@@ -85,7 +85,7 @@ function CountryCombobox({
       </PopoverTrigger>
       <PopoverContent className="w-64 p-0" sideOffset={4}>
         <Command>
-          <CommandSearch placeholder={searchPlaceholder} />
+          <CommandSearch placeholder={searchPlaceholder} autoFocus />
           <CommandItems>
             <CommandNoResults>{noResultsText}</CommandNoResults>
             <CommandGroupSection>


### PR DESCRIPTION
## Summary

When the country picklist is opened, the search input was not receiving focus automatically. On desktop this is a minor inconvenience since the user can immediately type; on mobile (iPhone Safari, 414×896), it is a real friction point — the user had to tap the search field a second time to invoke the virtual keyboard and start filtering countries.

## Changes

- **`apps/web/src/components/ui/country-combobox.tsx`** — adds `autoFocus` to `<CommandSearch>` so the input receives focus as soon as the popover mounts.

## Why `autoFocus` and not `useRef + useEffect`

Mobile Safari only allows programmatic `focus()` calls that are synchronous within a user-gesture handler. A `useEffect` + `setTimeout` approach breaks that synchrony and the browser silently ignores the focus request. `autoFocus` fires during React's commit phase, which is still within the synchronous call stack of the user's tap event, so mobile Safari honours it.

## Testing

- Open the profile page → nationalities section → tap the country picker on a real iPhone or Chrome DevTools mobile emulation (414×896)
- Verify the virtual keyboard appears immediately and typing filters the list
- Verify desktop behaviour is unchanged
- All 910 frontend unit tests pass

Closes #235