### PR TITLE
chore(i18n): fix orphaned key detection and remove dead keys

### DIFF
--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -160,7 +160,16 @@ When any of the following changes are made to the frontend codebase:
 
 1. **Missing keys** — Keys used in code (`t('key')`) but not defined in `en.json`
 2. **Translation parity** — Keys in `en.json` that don't exist in `es.json`
-3. **Unused keys** — Keys defined in translation files but not referenced in code (informational only)
+3. **Unused keys** — Keys defined in translation files but not referenced in code
+
+**Script limitations — known blind spots:**
+
+The script uses regex, not AST analysis. It will NOT detect keys used via:
+
+- **Template literals**: ``t(`namespace.${variable}`)`` — the script whitelists all keys under the static prefix (e.g. ``t(`members.role.${role}`)`` covers all `groups.members.role.*` keys). This means truly unused keys under a shared prefix will not be reported as orphaned.
+- Dynamic key construction via variables: `const key = condition ? 'a' : 'b'; t(key)` — never detected.
+
+When reviewing unused keys, keep this in mind: a key reported as "unused" is genuinely unused. A key **not** reported as unused may still be dead if it lives under a template-literal prefix.
 
 **Key conventions:**
 
@@ -174,7 +183,10 @@ When any of the following changes are made to the frontend codebase:
 
 - If keys are missing in `en.json`, add them to the appropriate namespace
 - If keys are missing in `es.json`, translate and add them (maintain parity with `en.json`)
-- If many unused keys are reported, it's informational — no action required unless keys are confirmed obsolete
+- If unused keys are reported, classify them before acting:
+  - **Pre-planned keys** (auth flows, trips page, groups features not yet built) — keep them; they are intentionally defined ahead of implementation
+  - **Dead keys** (key exists in JSON, but code uses a different key, or the feature was removed) — delete from both `en.json` and `es.json`
+  - **~100 pre-planned keys** currently exist across `auth`, `common.actions`, `common.status`, `common.time`, `common.validation`, `errors`, `explore`, `groups`, `profile`, and `trips` namespaces — this is expected and not a problem
 
 **The script exits with code 1 if any keys are missing**, blocking commits via pre-commit hooks if integrated. All i18n keys must be valid before merging.
 

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -25,9 +25,7 @@
       "trips": "Trips",
       "groups": "Groups",
       "explore": "Explore",
-      "calendar": "Calendar",
       "profile": "Profile",
-      "settings": "Settings",
       "collapseSidebar": "Collapse sidebar",
       "expandSidebar": "Expand sidebar"
     },
@@ -792,7 +790,6 @@
       "loadError": "Failed to load profile",
       "retry": "Try again",
       "privateProfile": "This profile is private",
-      "privateProfileDescription": "{{displayName}} has set their profile to private.",
       "stats": {
         "heading": "Travel Stats",
         "tripsCompleted": "Trips",

--- a/apps/web/src/locales/es.json
+++ b/apps/web/src/locales/es.json
@@ -25,9 +25,7 @@
       "trips": "Viajes",
       "groups": "Grupos",
       "explore": "Explorar",
-      "calendar": "Calendario",
       "profile": "Perfil",
-      "settings": "Configuración",
       "collapseSidebar": "Contraer barra lateral",
       "expandSidebar": "Expandir barra lateral"
     },
@@ -792,7 +790,6 @@
       "loadError": "Error al cargar el perfil",
       "retry": "Intentar de nuevo",
       "privateProfile": "Este perfil es privado",
-      "privateProfileDescription": "{{displayName}} ha configurado su perfil como privado.",
       "stats": {
         "heading": "Estadísticas de viaje",
         "tripsCompleted": "Viajes",

--- a/scripts/validate-i18n-keys.mjs
+++ b/scripts/validate-i18n-keys.mjs
@@ -18,7 +18,7 @@ const WEB_DIR = 'apps/web';
 const SRC_DIR = join(WEB_DIR, 'src');
 const LOCALES_DIR = join(WEB_DIR, 'src', 'locales');
 
-const KNOWN_NAMESPACES = ['auth', 'trips', 'groups', 'profile', 'errors', 'common', 'explore', 'feedback'];
+const KNOWN_NAMESPACES = ['auth', 'trips', 'groups', 'profile', 'errors', 'common', 'explore', 'feedback', 'legal'];
 const EXPLICIT_NS_PATTERN = new RegExp(`^(${KNOWN_NAMESPACES.join('|')})\\\.`);
 
 console.log(`${BLUE}🔍 Validating i18n keys...${NC}\n`);
@@ -34,6 +34,15 @@ const sourceFiles = execSync(`find ${SRC_DIR} -type f \\( -name "*.tsx" -o -name
   .filter((f) => f && !f.includes('.test.'));
 
 const usedKeys = new Set();
+// Keys matched via template literal prefix — any en.json key starting with these is considered used.
+const templatePrefixes = new Set();
+
+function qualifyKey(key, namespace) {
+  if (key.includes(':')) return key.replace(':', '.');
+  if (namespace === 'common' && EXPLICIT_NS_PATTERN.test(key)) return key;
+  if (key.includes('.') || key.length > 0) return `${namespace}.${key}`;
+  return null;
+}
 
 for (const file of sourceFiles) {
   const content = readFileSync(file, 'utf8');
@@ -55,8 +64,9 @@ for (const file of sourceFiles) {
     if (arrayNsMatch) namespace = arrayNsMatch[1];
   }
 
-  // Extract all t('key') calls, including explicit namespace prefix (e.g. 'common:actions.save')
-  for (const match of filteredContent.matchAll(/t\(['"]([a-zA-Z0-9._:-]+)['"]\)/g)) {
+  // Extract static t('key') and t('key', {...}) calls — drop the closing ) requirement so
+  // interpolated calls like t('key', { n }) are also captured.
+  for (const match of filteredContent.matchAll(/t\(['"]([a-zA-Z0-9._:-]+)['"]/g)) {
     const key = match[1];
     if (key.includes(':')) {
       // Explicit namespace prefix — normalise colon to dot: common:actions.save → common.actions.save
@@ -68,6 +78,15 @@ for (const file of sourceFiles) {
     } else if (key.includes('.')) {
       usedKeys.add(`${namespace}.${key}`);
     }
+  }
+
+  // Extract template literal t() calls: t(`prefix.${variable}`) — capture the static prefix before ${.
+  // Any en.json key whose dotted path starts with the qualified prefix is treated as used.
+  for (const match of filteredContent.matchAll(/t\(`([a-zA-Z0-9._:-]*)\$\{/g)) {
+    const rawPrefix = match[1];
+    if (!rawPrefix) continue;
+    const qualified = qualifyKey(rawPrefix, namespace);
+    if (qualified) templatePrefixes.add(qualified);
   }
 }
 
@@ -124,7 +143,10 @@ if (missingInEs.length > 0) {
 // Step 5: Unused keys (informational only)
 console.log(`${BLUE}Step 5: Checking for unused keys...${NC}`);
 
-const unusedKeys = [...enKeys].filter((k) => !usedKeys.has(k)).sort();
+const prefixList = [...templatePrefixes];
+const unusedKeys = [...enKeys]
+  .filter((k) => !usedKeys.has(k) && !prefixList.some((p) => k.startsWith(p)))
+  .sort();
 
 if (unusedKeys.length > 0) {
   console.log(


### PR DESCRIPTION
## Summary

The `validate-i18n-keys` script had three blind spots that caused 262 false positives — real, actively-used keys reported as orphaned:

1. **Template literals** — `t(\`prefix.${var}\`)` patterns (used heavily in legal pages, NavItem, profile dropdowns) were invisible to the regex-based scanner.
2. **Interpolated calls** — `t('key', { n })` calls were not matched because the regex required an immediate closing `)`.
3. **Missing `legal` namespace** — The three legal pages (`privacy-policy`, `terms-of-service`, `account-deletion`) use `useTranslation(['legal', 'common'])` but `legal` was absent from `KNOWN_NAMESPACES`.

After fixing the script the reported orphan count dropped from **367 → 102**, and all remaining keys are intentionally pre-defined for features under active development.

## Changes

**Script fix (`scripts/validate-i18n-keys.mjs`)**
- Regex no longer requires closing `)` — interpolated calls are now captured.
- Added second scan pass for template literal `t()` calls: extracts the static prefix before `${` and whitelists all JSON keys that start with that prefix.
- Added `legal` to `KNOWN_NAMESPACES`.

**Dead key removal (`en.json` / `es.json`)**
- `common.navigation.calendar` — not present in `NAV_ITEMS`; calendar is post-MVP.
- `common.navigation.settings` — not present in `NAV_ITEMS`; no settings route in MVP.
- `profile.publicProfile.privateProfileDescription` — the public profile page renders `t('publicProfile.privateProfile')`. The `Description` variant is never called.

## Testing

- Run `./scripts/validate-i18n-keys.sh` — should report ✅ with 102 informational orphans (all pre-planned keys).
- Verify legal pages render correctly in both EN and ES (template-literal keys still resolve).
- Verify navigation labels still render (home, trips, groups, explore, profile).
- Verify the public profile private-state renders the short label without a missing-key warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)