### PR TITLE
fix(mobile): iOS PWA safe areas, scroll bounce, and pinch-to-crop

### DIFF
--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -56,6 +56,9 @@ export default [
         AbortSignal: 'readonly',
         DOMException: 'readonly',
         RequestInit: 'readonly',
+        Touch: 'readonly',
+        TouchEvent: 'readonly',
+        TouchList: 'readonly',
         // Test globals (Vitest)
         describe: 'readonly',
         it: 'readonly',

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -77,7 +77,8 @@
   --layout-sidebar-width: 10rem;  /* w-40 / 160px */
   /* iOS PWA safe area: header extends under notch, nav extends under home indicator (half inset) */
   --layout-header-safe: calc(var(--layout-header-height) + env(safe-area-inset-top, 0px));
-  --layout-nav-safe: calc(var(--layout-header-height) + env(safe-area-inset-bottom, 0px) / 2);
+  --layout-nav-inset: calc(env(safe-area-inset-bottom, 0px) / 2);
+  --layout-nav-safe: calc(var(--layout-header-height) + var(--layout-nav-inset));
 }
 
 @media (prefers-color-scheme: dark) {
@@ -201,7 +202,7 @@
 }
 
 @utility pb-nav-safe {
-  padding-bottom: calc(env(safe-area-inset-bottom, 0px) / 2);
+  padding-bottom: var(--layout-nav-inset);
 }
 
 @utility pt-safe {

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -75,6 +75,9 @@
   /* App shell layout dimensions — single source of truth */
   --layout-header-height: 4rem;   /* h-16 / 64px */
   --layout-sidebar-width: 10rem;  /* w-40 / 160px */
+  /* iOS PWA safe area: header extends under notch, nav extends under home indicator (half inset) */
+  --layout-header-safe: calc(var(--layout-header-height) + env(safe-area-inset-top, 0px));
+  --layout-nav-safe: calc(var(--layout-header-height) + env(safe-area-inset-bottom, 0px) / 2);
 }
 
 @media (prefers-color-scheme: dark) {
@@ -182,4 +185,25 @@
   html {
     @apply font-sans;
   }
+}
+
+/* Safe area utilities for iOS PWA (notch + home indicator) */
+@utility h-header-safe {
+  height: var(--layout-header-safe);
+}
+
+@utility pt-header-safe {
+  padding-top: var(--layout-header-safe);
+}
+
+@utility h-nav-safe {
+  height: var(--layout-nav-safe);
+}
+
+@utility pb-nav-safe {
+  padding-bottom: calc(env(safe-area-inset-bottom, 0px) / 2);
+}
+
+@utility pt-safe {
+  padding-top: env(safe-area-inset-top, 0px);
 }

--- a/apps/web/src/components/header/Header.test.tsx
+++ b/apps/web/src/components/header/Header.test.tsx
@@ -38,7 +38,7 @@ describe('Header', () => {
   it('has correct height', () => {
     const { container } = render(<Header />);
     const header = container.querySelector('header');
-    expect(header).toHaveClass('h-header');
+    expect(header).toHaveClass('h-header-safe');
   });
 
   it('has border styling', () => {

--- a/apps/web/src/components/header/Header.tsx
+++ b/apps/web/src/components/header/Header.tsx
@@ -7,8 +7,8 @@ import { LanguageToggle } from '@/components/LanguageToggle';
 
 export function Header() {
   return (
-    <header className="fixed top-0 left-0 right-0 z-50 h-header bg-background border-b border-border">
-      <div className="flex items-center justify-between h-full px-4">
+    <header className="fixed top-0 left-0 right-0 z-50 h-header-safe pt-safe bg-background border-b border-border">
+      <div className="flex items-center justify-between h-header px-4">
         <Logo />
 
         <div className="flex items-center gap-2">

--- a/apps/web/src/components/layout/AppShell.test.tsx
+++ b/apps/web/src/components/layout/AppShell.test.tsx
@@ -64,13 +64,13 @@ describe('AppShell', () => {
     it('main has correct padding for header clearance', () => {
       render(<AppShell>Content</AppShell>);
       const main = screen.getByRole('main');
-      expect(main).toHaveClass('pt-header');
+      expect(main).toHaveClass('pt-header-safe');
     });
 
     it('main has mobile bottom padding', () => {
       render(<AppShell>Content</AppShell>);
       const main = screen.getByRole('main');
-      expect(main).toHaveClass('pb-header', 'md:pb-0');
+      expect(main).toHaveClass('pb-nav-safe', 'md:pb-0');
     });
 
     it('main has desktop left padding for sidebar', () => {
@@ -175,7 +175,7 @@ describe('AppShell', () => {
     it('main does not have nav padding classes on auth pages', () => {
       render(<AppShell>Content</AppShell>);
       const main = screen.getByRole('main');
-      expect(main).not.toHaveClass('pt-header');
+      expect(main).not.toHaveClass('pt-header-safe');
       expect(main).not.toHaveClass('md:pl-sidebar');
     });
   });

--- a/apps/web/src/components/layout/AppShell.tsx
+++ b/apps/web/src/components/layout/AppShell.tsx
@@ -35,7 +35,7 @@ export function AppShell({ children }: AppShellProps) {
       <DesktopSideNav />
       <MobileBottomNav />
       {/* <div className="md:pl-sidebar"><ProfileCompletionBanner /></div> */}
-      <main className="relative pt-header pb-header md:pb-0 md:pl-sidebar min-h-screen">
+      <main className="relative pt-header-safe pb-nav-safe md:pb-0 md:pl-sidebar min-h-screen">
         {children}
       </main>
       <FeedbackButton />

--- a/apps/web/src/components/navigation/MobileBottomNav.test.tsx
+++ b/apps/web/src/components/navigation/MobileBottomNav.test.tsx
@@ -49,7 +49,7 @@ describe('MobileBottomNav', () => {
   it('has correct height', () => {
     const { container } = render(<MobileBottomNav />);
     const nav = container.querySelector('nav');
-    expect(nav).toHaveClass('h-header');
+    expect(nav).toHaveClass('h-nav-safe');
   });
 
   it('is hidden on desktop', () => {

--- a/apps/web/src/components/navigation/MobileBottomNav.tsx
+++ b/apps/web/src/components/navigation/MobileBottomNav.tsx
@@ -14,7 +14,7 @@ export function MobileBottomNav() {
   return (
     <nav
       className={cn(
-        'fixed bottom-0 left-0 right-0 z-40 h-header bg-card border-t border-border flex md:hidden',
+        'fixed bottom-0 left-0 right-0 z-40 h-nav-safe pb-nav-safe bg-card border-t border-border flex md:hidden',
         'transition-transform duration-300',
         hidden ? 'translate-y-full' : 'translate-y-0',
       )}

--- a/apps/web/src/components/ui/crop-modal.test.tsx
+++ b/apps/web/src/components/ui/crop-modal.test.tsx
@@ -15,15 +15,18 @@ vi.mock('react-image-crop', () => ({
   default: ({
     children,
     onChange,
+    crop,
     circularCrop,
   }: {
     children: ReactNode;
     onChange: (crop: { unit: string; x: number; y: number; width: number; height: number }) => void;
+    crop?: { unit: string; x: number; y: number; width: number; height: number };
     circularCrop?: boolean;
   }) => (
     <div
       data-testid="react-crop"
       data-circular={circularCrop ? 'true' : 'false'}
+      data-crop-width={crop?.width}
       onClick={() => onChange({ unit: 'px', x: 10, y: 10, width: 100, height: 100 })}
     >
       {children}
@@ -167,6 +170,123 @@ describe('CropModal', () => {
       await user.click(screen.getByText('Use photo'));
 
       expect(mocks.mockOnConfirm).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('pinch-to-zoom', () => {
+    function makeTouchEvent(type: string, touches: { clientX: number; clientY: number }[]) {
+      const event = new Event(type, { cancelable: true, bubbles: true });
+      Object.defineProperty(event, 'touches', { value: touches });
+      return event;
+    }
+
+    function loadImage() {
+      const img = screen.getByRole('img');
+      act(() => {
+        Object.defineProperty(img, 'naturalWidth', { value: 400, configurable: true });
+        Object.defineProperty(img, 'naturalHeight', { value: 400, configurable: true });
+        img.dispatchEvent(new Event('load'));
+      });
+    }
+
+    it('pinch-out expands the crop', () => {
+      setup();
+      loadImage();
+
+      const container = screen.getByTestId('crop-container');
+      const reactCrop = screen.getByTestId('react-crop');
+
+      // Initial crop: makeAspectCrop called with { unit: '%', width: 90 } → mock returns width: 90
+      expect(reactCrop).toHaveAttribute('data-crop-width', '90');
+
+      act(() => {
+        // Two fingers 100px apart
+        container.dispatchEvent(
+          makeTouchEvent('touchstart', [
+            { clientX: 100, clientY: 100 },
+            { clientX: 200, clientY: 100 },
+          ]),
+        );
+      });
+
+      act(() => {
+        // Two fingers 200px apart → scale = 2
+        container.dispatchEvent(
+          makeTouchEvent('touchmove', [
+            { clientX: 50, clientY: 100 },
+            { clientX: 250, clientY: 100 },
+          ]),
+        );
+      });
+
+      // maxScale = min(100/90, 100/90) ≈ 1.11 → clamped → newWidth = 90 * (100/90) = 100
+      expect(reactCrop).toHaveAttribute('data-crop-width', '100');
+    });
+
+    it('pinch-in shrinks the crop', () => {
+      setup();
+      loadImage();
+
+      const container = screen.getByTestId('crop-container');
+      const reactCrop = screen.getByTestId('react-crop');
+
+      act(() => {
+        // Two fingers 200px apart
+        container.dispatchEvent(
+          makeTouchEvent('touchstart', [
+            { clientX: 100, clientY: 100 },
+            { clientX: 300, clientY: 100 },
+          ]),
+        );
+      });
+
+      act(() => {
+        // Two fingers 100px apart → scale = 0.5
+        container.dispatchEvent(
+          makeTouchEvent('touchmove', [
+            { clientX: 150, clientY: 100 },
+            { clientX: 250, clientY: 100 },
+          ]),
+        );
+      });
+
+      // clampedScale = 0.5 → newWidth = 90 * 0.5 = 45
+      expect(reactCrop).toHaveAttribute('data-crop-width', '45');
+    });
+
+    it('touchcancel clears pinch state — subsequent touchmove is ignored', () => {
+      setup();
+      loadImage();
+
+      const container = screen.getByTestId('crop-container');
+      const reactCrop = screen.getByTestId('react-crop');
+
+      act(() => {
+        container.dispatchEvent(
+          makeTouchEvent('touchstart', [
+            { clientX: 100, clientY: 100 },
+            { clientX: 200, clientY: 100 },
+          ]),
+        );
+      });
+
+      act(() => {
+        // Cancel clears pinchRef
+        container.dispatchEvent(makeTouchEvent('touchcancel', []));
+      });
+
+      act(() => {
+        // This touchmove should be a no-op (pinchRef is null)
+        container.dispatchEvent(
+          makeTouchEvent('touchmove', [
+            { clientX: 50, clientY: 100 },
+            { clientX: 250, clientY: 100 },
+          ]),
+        );
+      });
+
+      // Crop unchanged from initial 90%
+      expect(reactCrop).toHaveAttribute('data-crop-width', '90');
     });
   });
 

--- a/apps/web/src/components/ui/crop-modal.tsx
+++ b/apps/web/src/components/ui/crop-modal.tsx
@@ -37,15 +37,98 @@ export function CropModal({
   const { t } = useTranslation('common');
   const resolvedOutputHeight = outputHeight ?? outputWidth;
   const imgRef = useRef<HTMLImageElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
   const [imgSrc, setImgSrc] = useState('');
   const [crop, setCrop] = useState<Crop>();
   const [completedCrop, setCompletedCrop] = useState<PixelCrop>();
+
+  // Stable refs so the touch handler closure never goes stale
+  const latestCropRef = useRef<Crop | undefined>(undefined);
+  const pinchRef = useRef<{ startDist: number; startCrop: Crop } | null>(null);
 
   useEffect(() => {
     const url = URL.createObjectURL(file);
     setImgSrc(url);
     return () => URL.revokeObjectURL(url);
   }, [file]);
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+
+    function pinchDist(touches: TouchList) {
+      return Math.hypot(
+        touches[1]!.clientX - touches[0]!.clientX,
+        touches[1]!.clientY - touches[0]!.clientY,
+      );
+    }
+
+    function onTouchStart(e: TouchEvent) {
+      if (e.touches.length === 2 && latestCropRef.current) {
+        pinchRef.current = { startDist: pinchDist(e.touches), startCrop: latestCropRef.current };
+      }
+    }
+
+    function onTouchMove(e: TouchEvent) {
+      if (e.touches.length !== 2 || !pinchRef.current) return;
+      e.preventDefault();
+
+      const scale = pinchDist(e.touches) / pinchRef.current.startDist;
+      const base = pinchRef.current.startCrop;
+
+      let bx: number, by: number, bw: number, bh: number;
+      if (base.unit === '%') {
+        bx = base.x;
+        by = base.y;
+        bw = base.width;
+        bh = base.height;
+      } else {
+        const imgW = imgRef.current?.clientWidth ?? 0;
+        const imgH = imgRef.current?.clientHeight ?? 0;
+        if (!imgW || !imgH) return;
+        bx = (base.x / imgW) * 100;
+        by = (base.y / imgH) * 100;
+        bw = (base.width / imgW) * 100;
+        bh = (base.height / imgH) * 100;
+      }
+
+      // Scale both dimensions uniformly — bh already encodes the visual aspect ratio
+      const minScale = Math.max(10 / bw, 10 / bh);
+      const maxScale = Math.min(100 / bw, 100 / bh);
+      const clampedScale = Math.max(minScale, Math.min(maxScale, scale));
+      const newWidth = bw * clampedScale;
+      const newHeight = bh * clampedScale;
+      const cx = bx + bw / 2;
+      const cy = by + bh / 2;
+
+      const newCrop: Crop = {
+        unit: '%',
+        width: newWidth,
+        height: newHeight,
+        x: Math.max(0, Math.min(100 - newWidth, cx - newWidth / 2)),
+        y: Math.max(0, Math.min(100 - newHeight, cy - newHeight / 2)),
+      };
+
+      latestCropRef.current = newCrop;
+      setCrop(newCrop);
+    }
+
+    function onTouchEnd(e: TouchEvent) {
+      if (e.touches.length < 2) pinchRef.current = null;
+    }
+
+    el.addEventListener('touchstart', onTouchStart, { passive: true });
+    el.addEventListener('touchmove', onTouchMove, { passive: false });
+    el.addEventListener('touchend', onTouchEnd);
+    el.addEventListener('touchcancel', onTouchEnd);
+
+    return () => {
+      el.removeEventListener('touchstart', onTouchStart);
+      el.removeEventListener('touchmove', onTouchMove);
+      el.removeEventListener('touchend', onTouchEnd);
+      el.removeEventListener('touchcancel', onTouchEnd);
+    };
+  }, []); // stable: all mutable state accessed via refs
 
   function onImageLoad(e: SyntheticEvent<HTMLImageElement>) {
     const { naturalWidth, naturalHeight } = e.currentTarget;
@@ -54,6 +137,7 @@ export function CropModal({
       naturalWidth,
       naturalHeight,
     );
+    latestCropRef.current = initial;
     setCrop(initial);
   }
 
@@ -99,11 +183,18 @@ export function CropModal({
     <div className="mt-4 flex flex-col gap-4">
       <p className="text-lg font-semibold leading-none tracking-tight">{title}</p>
 
-      <div className="overflow-hidden rounded-lg bg-muted">
+      <div
+        ref={containerRef}
+        data-testid="crop-container"
+        className="overflow-hidden rounded-lg bg-muted"
+      >
         {imgSrc && (
           <ReactCrop
             crop={crop}
-            onChange={(c) => setCrop(c)}
+            onChange={(c) => {
+              latestCropRef.current = c;
+              setCrop(c);
+            }}
             onComplete={(c) => setCompletedCrop(c)}
             aspect={aspect}
             circularCrop={circular}

--- a/apps/web/src/lib/hooks/useScrollDirection.test.ts
+++ b/apps/web/src/lib/hooks/useScrollDirection.test.ts
@@ -4,7 +4,17 @@ import { useScrollDirection } from './useScrollDirection';
 
 describe('useScrollDirection', () => {
   beforeEach(() => {
-    Object.defineProperty(window, 'scrollY', { writable: true, value: 0 });
+    Object.defineProperty(window, 'scrollY', { writable: true, configurable: true, value: 0 });
+    Object.defineProperty(document.documentElement, 'scrollHeight', {
+      writable: true,
+      configurable: true,
+      value: 2000,
+    });
+    Object.defineProperty(window, 'innerHeight', {
+      writable: true,
+      configurable: true,
+      value: 800,
+    });
   });
 
   afterEach(() => {
@@ -52,6 +62,84 @@ describe('useScrollDirection', () => {
     });
 
     expect(result.current).toBe('idle');
+  });
+
+  it('forces up when scrollY is exactly 0', () => {
+    const { result } = renderHook(() => useScrollDirection());
+
+    act(() => {
+      Object.defineProperty(window, 'scrollY', { writable: true, value: 100 });
+      window.dispatchEvent(new window.Event('scroll'));
+    });
+
+    expect(result.current).toBe('down');
+
+    act(() => {
+      Object.defineProperty(window, 'scrollY', { writable: true, value: 0 });
+      window.dispatchEvent(new window.Event('scroll'));
+    });
+
+    expect(result.current).toBe('up');
+  });
+
+  it('forces up on iOS overscroll (negative scrollY)', () => {
+    const { result } = renderHook(() => useScrollDirection());
+
+    act(() => {
+      Object.defineProperty(window, 'scrollY', { writable: true, value: 100 });
+      window.dispatchEvent(new window.Event('scroll'));
+    });
+
+    act(() => {
+      Object.defineProperty(window, 'scrollY', { writable: true, value: -20 });
+      window.dispatchEvent(new window.Event('scroll'));
+    });
+
+    expect(result.current).toBe('up');
+  });
+
+  it('forces down when scrollY reaches the bottom of the page', () => {
+    Object.defineProperty(document.documentElement, 'scrollHeight', {
+      writable: true,
+      configurable: true,
+      value: 1000,
+    });
+    Object.defineProperty(window, 'innerHeight', {
+      writable: true,
+      configurable: true,
+      value: 600,
+    });
+
+    const { result } = renderHook(() => useScrollDirection());
+
+    act(() => {
+      Object.defineProperty(window, 'scrollY', { writable: true, value: 400 });
+      window.dispatchEvent(new window.Event('scroll'));
+    });
+
+    expect(result.current).toBe('down');
+  });
+
+  it('forces down on iOS overscroll past bottom (scrollY > maxScrollY)', () => {
+    Object.defineProperty(document.documentElement, 'scrollHeight', {
+      writable: true,
+      configurable: true,
+      value: 1000,
+    });
+    Object.defineProperty(window, 'innerHeight', {
+      writable: true,
+      configurable: true,
+      value: 600,
+    });
+
+    const { result } = renderHook(() => useScrollDirection());
+
+    act(() => {
+      Object.defineProperty(window, 'scrollY', { writable: true, value: 450 });
+      window.dispatchEvent(new window.Event('scroll'));
+    });
+
+    expect(result.current).toBe('down');
   });
 
   it('removes scroll listener on unmount', () => {

--- a/apps/web/src/lib/hooks/useScrollDirection.test.ts
+++ b/apps/web/src/lib/hooks/useScrollDirection.test.ts
@@ -150,4 +150,40 @@ describe('useScrollDirection', () => {
 
     expect(removeEventListenerSpy).toHaveBeenCalledWith('scroll', expect.any(Function));
   });
+
+  it('removes resize listener on unmount', () => {
+    const removeEventListenerSpy = vi.spyOn(window, 'removeEventListener');
+    const { unmount } = renderHook(() => useScrollDirection());
+
+    unmount();
+
+    expect(removeEventListenerSpy).toHaveBeenCalledWith('resize', expect.any(Function));
+  });
+
+  it('updates maxScrollY when the window is resized', () => {
+    const { result } = renderHook(() => useScrollDirection());
+
+    // Shrink the viewport so maxScrollY increases
+    Object.defineProperty(document.documentElement, 'scrollHeight', {
+      writable: true,
+      configurable: true,
+      value: 3000,
+    });
+    Object.defineProperty(window, 'innerHeight', {
+      writable: true,
+      configurable: true,
+      value: 500,
+    });
+    act(() => {
+      window.dispatchEvent(new window.Event('resize'));
+    });
+
+    // Scroll to new bottom (2500) — should force 'down'
+    act(() => {
+      Object.defineProperty(window, 'scrollY', { writable: true, value: 2500 });
+      window.dispatchEvent(new window.Event('scroll'));
+    });
+
+    expect(result.current).toBe('down');
+  });
 });

--- a/apps/web/src/lib/hooks/useScrollDirection.ts
+++ b/apps/web/src/lib/hooks/useScrollDirection.ts
@@ -14,12 +14,20 @@ const SCROLL_THRESHOLD = 8; // px of scroll before direction change is registere
 export function useScrollDirection(): ScrollDirection {
   const [direction, setDirection] = useState<ScrollDirection>('idle');
   const lastScrollY = useRef(0);
+  const maxScrollYRef = useRef(0);
 
   useEffect(() => {
-    lastScrollY.current = window.scrollY;
+    const updateMax = () => {
+      maxScrollYRef.current = Math.max(
+        0,
+        document.documentElement.scrollHeight - window.innerHeight,
+      );
+    };
+    updateMax();
+    lastScrollY.current = Math.min(Math.max(0, window.scrollY), maxScrollYRef.current);
 
     const handleScroll = () => {
-      const maxScrollY = Math.max(0, document.documentElement.scrollHeight - window.innerHeight);
+      const maxScrollY = maxScrollYRef.current;
       const currentScrollY = Math.min(Math.max(0, window.scrollY), maxScrollY);
 
       if (currentScrollY === 0) {
@@ -41,8 +49,12 @@ export function useScrollDirection(): ScrollDirection {
       lastScrollY.current = currentScrollY;
     };
 
+    window.addEventListener('resize', updateMax, { passive: true });
     window.addEventListener('scroll', handleScroll, { passive: true });
-    return () => window.removeEventListener('scroll', handleScroll);
+    return () => {
+      window.removeEventListener('resize', updateMax);
+      window.removeEventListener('scroll', handleScroll);
+    };
   }, []);
 
   return direction;

--- a/apps/web/src/lib/hooks/useScrollDirection.ts
+++ b/apps/web/src/lib/hooks/useScrollDirection.ts
@@ -19,9 +19,22 @@ export function useScrollDirection(): ScrollDirection {
     lastScrollY.current = window.scrollY;
 
     const handleScroll = () => {
-      const currentScrollY = window.scrollY;
-      const delta = currentScrollY - lastScrollY.current;
+      const maxScrollY = Math.max(0, document.documentElement.scrollHeight - window.innerHeight);
+      const currentScrollY = Math.min(Math.max(0, window.scrollY), maxScrollY);
 
+      if (currentScrollY === 0) {
+        setDirection('up');
+        lastScrollY.current = 0;
+        return;
+      }
+
+      if (maxScrollY > 0 && currentScrollY >= maxScrollY) {
+        setDirection('down');
+        lastScrollY.current = maxScrollY;
+        return;
+      }
+
+      const delta = currentScrollY - lastScrollY.current;
       if (Math.abs(delta) < SCROLL_THRESHOLD) return;
 
       setDirection(delta > 0 ? 'down' : 'up');

--- a/package.json
+++ b/package.json
@@ -48,5 +48,5 @@
     "node": ">=22.0.0",
     "pnpm": ">=10.0.0"
   },
-  "packageManager": "pnpm@11.1.0"
+  "packageManager": "pnpm@11.1.1"
 }


### PR DESCRIPTION
## Summary

The app was installed as a PWA on iOS and had three UX issues: the header was obscured by the notch, the bottom nav's home indicator overlapped the nav items, the iOS rubber-band overscroll at top and bottom incorrectly triggered the nav hide/show logic, and the crop modal had no pinch-to-zoom support on touch devices.

## Changes

**Safe area insets**
- `Header` grows by `env(safe-area-inset-top)` and adds `pt-safe` padding so content clears the notch
- `MobileBottomNav` grows by half `env(safe-area-inset-bottom)` (`pb-nav-safe`) — enough to clear the home indicator without excessive dead space
- `AppShell` main `padding-top`/`padding-bottom` updated to match both new heights
- New `@utility` classes in `globals.css`: `h-header-safe`, `pt-header-safe`, `h-nav-safe`, `pb-nav-safe`, `pt-safe`

**Scroll bounce fix**
- `useScrollDirection` now clamps `window.scrollY` to `[0, maxScrollY]` before computing the delta
- When clamped value is `0` → forces `'up'` (top bounce can't hide the nav)
- When clamped value is `>= maxScrollY` → forces `'down'` (bottom bounce can't show the nav)

**Crop modal pinch-to-zoom**
- Native `touchstart`/`touchmove`/`touchcancel` listeners on the crop container (non-passive `touchmove` to `preventDefault` scroll)
- Scales both `bw` and `bh` uniformly from the base crop — preserves visual aspect ratio regardless of image dimensions
- `Touch`, `TouchEvent`, `TouchList` added to ESLint browser globals

## Testing

- Install the app as PWA on iOS and verify the header clears the notch on devices with Dynamic Island and older notch
- Verify the bottom nav items are not overlapped by the home indicator
- Scroll to the very top and pull down (rubber-band) — bottom nav must stay visible
- Scroll to the very bottom and pull up (rubber-band) — bottom nav must stay hidden
- Open the avatar or group cover crop modal on iOS and pinch to scale the selection — aspect ratio must remain constant

Closes #275