### PR TITLE
fix(profile): toast provider, validation, passport date & mobile tab affordance

### DIFF
--- a/apps/api/CLAUDE.md
+++ b/apps/api/CLAUDE.md
@@ -71,21 +71,3 @@ All user-generated media uploads follow the signed URL pattern — never proxy f
 4. Add the accepted MIME types to `ACCEPTED_TYPES` in `apps/web/src/components/ui/file-upload-button.tsx`
 
 **Runtime requirement:** `GOOGLE_CLOUD_STORAGE_BUCKET` env var must be set. Validated at startup by `environment.schema.ts`. For e2e tests, `test-bucket` is injected via `test/setup-env.ts`.
-
-### 5. JSONB arrays — never persist null values
-
-When writing objects into JSONB array columns (e.g. `loyalty_programs`, any future JSONB array field), strip all keys whose value is `null` or `undefined` before saving. PostgreSQL stores `null` verbatim, wasting space and complicating reads with unnecessary null checks.
-
-**Pattern — strip before insert or merge:**
-
-```typescript
-// Strip nulls before pushing a new entry
-const entry = Object.fromEntries(Object.entries(dto).filter(([, v]) => v != null));
-loyaltyPrograms: [...programs, entry];
-
-// Strip nulls after merging a patch
-const merged = { ...existing, ...patch };
-const entry = Object.fromEntries(Object.entries(merged).filter(([, v]) => v != null));
-```
-
-**Applies to:** every service method that writes objects into a JSONB array column. When a nullable field is absent (e.g. `notes` not provided), omit the key entirely — do not write `{ notes: null }`.

--- a/apps/api/CLAUDE.md
+++ b/apps/api/CLAUDE.md
@@ -71,3 +71,21 @@ All user-generated media uploads follow the signed URL pattern — never proxy f
 4. Add the accepted MIME types to `ACCEPTED_TYPES` in `apps/web/src/components/ui/file-upload-button.tsx`
 
 **Runtime requirement:** `GOOGLE_CLOUD_STORAGE_BUCKET` env var must be set. Validated at startup by `environment.schema.ts`. For e2e tests, `test-bucket` is injected via `test/setup-env.ts`.
+
+### 5. JSONB arrays — never persist null values
+
+When writing objects into JSONB array columns (e.g. `loyalty_programs`, any future JSONB array field), strip all keys whose value is `null` or `undefined` before saving. PostgreSQL stores `null` verbatim, wasting space and complicating reads with unnecessary null checks.
+
+**Pattern — strip before insert or merge:**
+
+```typescript
+// Strip nulls before pushing a new entry
+const entry = Object.fromEntries(Object.entries(dto).filter(([, v]) => v != null));
+loyaltyPrograms: [...programs, entry];
+
+// Strip nulls after merging a patch
+const merged = { ...existing, ...patch };
+const entry = Object.fromEntries(Object.entries(merged).filter(([, v]) => v != null));
+```
+
+**Applies to:** every service method that writes objects into a JSONB array column. When a nullable field is absent (e.g. `notes` not provided), omit the key entirely — do not write `{ notes: null }`.

--- a/apps/api/src/modules/users/dto/nationality.dto.spec.ts
+++ b/apps/api/src/modules/users/dto/nationality.dto.spec.ts
@@ -167,6 +167,18 @@ describe('CreateNationalityDto', () => {
       expect(errors.some((e) => e.property === 'passportIssueDate')).toBe(true);
     });
 
+    it('accepts today as passportIssueDate', async () => {
+      const today = new Date().toISOString().split('T')[0]!;
+      const dto = plainToInstance(CreateNationalityDto, {
+        ...validBase,
+        ...validPassport,
+        passportIssueDate: today,
+        passportExpiryDate: '2099-01-01',
+      });
+      const errors = await validate(dto);
+      expect(errors.some((e) => e.property === 'passportIssueDate')).toBe(false);
+    });
+
     it('rejects passportExpiryDate in non-ISO format', async () => {
       const dto = plainToInstance(CreateNationalityDto, {
         ...validBase,
@@ -329,6 +341,17 @@ describe('UpdateNationalityDto', () => {
       });
       const errors = await validate(dto);
       expect(errors.some((e) => e.property === 'passportIssueDate')).toBe(true);
+    });
+
+    it('accepts today as passportIssueDate', async () => {
+      const today = new Date().toISOString().split('T')[0]!;
+      const dto = plainToInstance(UpdateNationalityDto, {
+        ...validPassport,
+        passportIssueDate: today,
+        passportExpiryDate: '2099-01-01',
+      });
+      const errors = await validate(dto);
+      expect(errors.some((e) => e.property === 'passportIssueDate')).toBe(false);
     });
   });
 });

--- a/apps/api/src/modules/users/dto/nationality.dto.spec.ts
+++ b/apps/api/src/modules/users/dto/nationality.dto.spec.ts
@@ -14,6 +14,8 @@ const validPassport = {
   passportExpiryDate: '2030-01-15',
 };
 
+const tomorrow = new Date(Date.now() + 86400000).toISOString().split('T')[0];
+
 describe('CreateNationalityDto', () => {
   it('accepts a valid nationality without passport data', async () => {
     const dto = plainToInstance(CreateNationalityDto, validBase);
@@ -149,6 +151,17 @@ describe('CreateNationalityDto', () => {
         ...validBase,
         ...validPassport,
         passportIssueDate: '15/01/2020',
+      });
+      const errors = await validate(dto);
+      expect(errors.some((e) => e.property === 'passportIssueDate')).toBe(true);
+    });
+
+    it('rejects a future passportIssueDate', async () => {
+      const dto = plainToInstance(CreateNationalityDto, {
+        ...validBase,
+        ...validPassport,
+        passportIssueDate: tomorrow,
+        passportExpiryDate: '2099-01-01',
       });
       const errors = await validate(dto);
       expect(errors.some((e) => e.property === 'passportIssueDate')).toBe(true);
@@ -306,6 +319,16 @@ describe('UpdateNationalityDto', () => {
       });
       const errors = await validate(dto);
       expect(errors.some((e) => e.property === 'passportNumber')).toBe(false);
+    });
+
+    it('rejects a future passportIssueDate', async () => {
+      const dto = plainToInstance(UpdateNationalityDto, {
+        ...validPassport,
+        passportIssueDate: tomorrow,
+        passportExpiryDate: '2099-01-01',
+      });
+      const errors = await validate(dto);
+      expect(errors.some((e) => e.property === 'passportIssueDate')).toBe(true);
     });
   });
 });

--- a/apps/api/src/modules/users/dto/nationality.dto.ts
+++ b/apps/api/src/modules/users/dto/nationality.dto.ts
@@ -109,7 +109,8 @@ export class CreateNationalityDto {
 
   @ApiProperty({
     example: '2020-01-15',
-    description: 'Passport issue date (YYYY-MM-DD). Required when any passport field is provided.',
+    description:
+      'Passport issue date (YYYY-MM-DD). Required when any passport field is provided. Cannot be a future date.',
     required: false,
   })
   @ValidateIf(anyPassportFieldPresent)
@@ -177,7 +178,8 @@ export class UpdateNationalityDto {
 
   @ApiProperty({
     example: '2020-01-15',
-    description: 'Passport issue date (YYYY-MM-DD). Required when any passport field is provided.',
+    description:
+      'Passport issue date (YYYY-MM-DD). Required when any passport field is provided. Cannot be a future date.',
     required: false,
   })
   @ValidateIf(anyPassportFieldPresent)

--- a/apps/api/src/modules/users/dto/nationality.dto.ts
+++ b/apps/api/src/modules/users/dto/nationality.dto.ts
@@ -12,6 +12,7 @@ import {
 import { PassportStatus } from '@chamuco/shared-types';
 import { DOCUMENT_ID_FORMAT_REGEX } from '@chamuco/shared-utils';
 import { IsDateAfter } from './date-after.validator';
+import { IsNotFutureDate } from './not-future-date.validator';
 
 // Condition: any passport field present in the payload
 const anyPassportFieldPresent = (o: {
@@ -114,6 +115,7 @@ export class CreateNationalityDto {
   @ValidateIf(anyPassportFieldPresent)
   @IsDefined({ message: 'passportIssueDate is required when any passport field is provided' })
   @IsDateString({}, { message: 'passportIssueDate must be a valid ISO 8601 date (YYYY-MM-DD)' })
+  @IsNotFutureDate({ message: 'passportIssueDate must not be a future date' })
   passportIssueDate?: string;
 
   @ApiProperty({
@@ -181,6 +183,7 @@ export class UpdateNationalityDto {
   @ValidateIf(anyPassportFieldPresent)
   @IsDefined({ message: 'passportIssueDate is required when any passport field is provided' })
   @IsDateString({}, { message: 'passportIssueDate must be a valid ISO 8601 date (YYYY-MM-DD)' })
+  @IsNotFutureDate({ message: 'passportIssueDate must not be a future date' })
   passportIssueDate?: string;
 
   @ApiProperty({

--- a/apps/api/src/modules/users/dto/not-future-date.validator.spec.ts
+++ b/apps/api/src/modules/users/dto/not-future-date.validator.spec.ts
@@ -1,0 +1,48 @@
+import { ValidationArguments } from 'class-validator';
+import { IsNotFutureDateConstraint } from './not-future-date.validator';
+
+function makeArgs(property = 'passportIssueDate'): ValidationArguments {
+  return { object: {}, value: undefined, constraints: [], targetName: '', property };
+}
+
+const today = new Date().toISOString().split('T')[0] as string;
+const yesterday = new Date(Date.now() - 86400000).toISOString().split('T')[0] as string;
+const tomorrow = new Date(Date.now() + 86400000).toISOString().split('T')[0] as string;
+
+describe('IsNotFutureDateConstraint', () => {
+  const constraint = new IsNotFutureDateConstraint();
+
+  describe('skip cases (return true)', () => {
+    it('returns true when value is not a string', () => {
+      expect(constraint.validate(null)).toBe(true);
+    });
+
+    it('returns true when value is an empty string', () => {
+      expect(constraint.validate('')).toBe(true);
+    });
+
+    it('returns true when value is an invalid date string', () => {
+      expect(constraint.validate('not-a-date')).toBe(true);
+    });
+  });
+
+  describe('comparison cases', () => {
+    it('returns true for a past date', () => {
+      expect(constraint.validate(yesterday)).toBe(true);
+    });
+
+    it('returns true for today', () => {
+      expect(constraint.validate(today)).toBe(true);
+    });
+
+    it('returns false for a future date', () => {
+      expect(constraint.validate(tomorrow)).toBe(false);
+    });
+  });
+
+  describe('defaultMessage', () => {
+    it('includes the property name', () => {
+      expect(constraint.defaultMessage(makeArgs())).toContain('passportIssueDate');
+    });
+  });
+});

--- a/apps/api/src/modules/users/dto/not-future-date.validator.ts
+++ b/apps/api/src/modules/users/dto/not-future-date.validator.ts
@@ -1,0 +1,34 @@
+import {
+  registerDecorator,
+  ValidationArguments,
+  ValidationOptions,
+  ValidatorConstraint,
+  ValidatorConstraintInterface,
+} from 'class-validator';
+
+@ValidatorConstraint({ name: 'isNotFutureDate', async: false })
+export class IsNotFutureDateConstraint implements ValidatorConstraintInterface {
+  validate(value: unknown): boolean {
+    if (typeof value !== 'string' || !value) return true;
+    const d = new Date(value);
+    if (isNaN(d.getTime())) return true; // let IsDateString handle invalid format
+    const today = new Date().toISOString().split('T')[0] as string;
+    return value <= today;
+  }
+
+  defaultMessage(args: ValidationArguments): string {
+    return `${args.property} must not be a future date`;
+  }
+}
+
+export function IsNotFutureDate(validationOptions?: ValidationOptions): PropertyDecorator {
+  return function (object: object, propertyName: string | symbol) {
+    registerDecorator({
+      target: object.constructor,
+      propertyName: propertyName as string,
+      options: validationOptions,
+      constraints: [],
+      validator: IsNotFutureDateConstraint,
+    });
+  };
+}

--- a/apps/api/src/modules/users/users.service.spec.ts
+++ b/apps/api/src/modules/users/users.service.spec.ts
@@ -1728,7 +1728,7 @@ describe('UsersService', () => {
       id: 'prog-new-uuid',
       programName: 'Delta SkyMiles',
       memberId: 'DL999',
-      notes: null,
+      notes: 'Gold status',
     };
 
     it('appends the new program and returns it', async () => {
@@ -1743,13 +1743,31 @@ describe('UsersService', () => {
       expect(result).toEqual(newProgram);
     });
 
-    it('appends to existing programs without removing them', async () => {
-      const existing = {
-        id: 'prog-existing',
-        programName: 'LifeMiles',
-        memberId: 'LM1',
+    it('strips null fields before saving (notes: null is omitted)', async () => {
+      const dto = {
+        id: 'prog-new-uuid',
+        programName: 'Delta SkyMiles',
+        memberId: 'DL999',
         notes: null,
       };
+      const stripped = { id: 'prog-new-uuid', programName: 'Delta SkyMiles', memberId: 'DL999' };
+      mockProfileFindFirst.mockResolvedValue({ ...mockHealthProfile, loyaltyPrograms: [] });
+      mockReturning.mockResolvedValue([{ ...mockHealthProfile, loyaltyPrograms: [stripped] }]);
+
+      await service.addLoyaltyProgram('user-uuid', dto);
+
+      expect(mockSet).toHaveBeenCalledWith(
+        expect.objectContaining({ loyaltyPrograms: [stripped] }),
+      );
+      expect(mockSet).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          loyaltyPrograms: expect.arrayContaining([expect.objectContaining({ notes: null })]),
+        }),
+      );
+    });
+
+    it('appends to existing programs without removing them', async () => {
+      const existing = { id: 'prog-existing', programName: 'LifeMiles', memberId: 'LM1' };
       mockProfileFindFirst.mockResolvedValue({
         ...mockHealthProfile,
         loyaltyPrograms: [existing],
@@ -1762,6 +1780,35 @@ describe('UsersService', () => {
 
       expect(mockSet).toHaveBeenCalledWith(
         expect.objectContaining({ loyaltyPrograms: [existing, newProgram] }),
+      );
+    });
+
+    it('throws ConflictException when programName+memberId already exists (exact match)', async () => {
+      const duplicate = { ...newProgram, id: 'prog-other-uuid' };
+      mockProfileFindFirst.mockResolvedValue({
+        ...mockHealthProfile,
+        loyaltyPrograms: [duplicate],
+      });
+
+      await expect(service.addLoyaltyProgram('user-uuid', newProgram)).rejects.toThrow(
+        ConflictException,
+      );
+    });
+
+    it('throws ConflictException when programName+memberId match case-insensitively', async () => {
+      const existing = {
+        ...newProgram,
+        id: 'prog-other-uuid',
+        programName: 'delta skymiles',
+        memberId: 'dl999',
+      };
+      mockProfileFindFirst.mockResolvedValue({
+        ...mockHealthProfile,
+        loyaltyPrograms: [existing],
+      });
+
+      await expect(service.addLoyaltyProgram('user-uuid', newProgram)).rejects.toThrow(
+        ConflictException,
       );
     });
 
@@ -1822,6 +1869,26 @@ describe('UsersService', () => {
         expect.objectContaining({
           loyaltyPrograms: expect.arrayContaining([expect.objectContaining({ id: 'prog-other' })]),
         }),
+      );
+    });
+
+    it('strips null fields from the merged entry (clearing notes removes the key)', async () => {
+      const withNotes = { ...existingProgram, notes: 'Gold' };
+      mockProfileFindFirst.mockResolvedValue({
+        ...mockHealthProfile,
+        loyaltyPrograms: [withNotes],
+      });
+      const stripped = {
+        id: existingProgram.id,
+        programName: existingProgram.programName,
+        memberId: existingProgram.memberId,
+      };
+      mockReturning.mockResolvedValue([{ ...mockHealthProfile, loyaltyPrograms: [stripped] }]);
+
+      await service.updateLoyaltyProgram('user-uuid', 'prog-uuid', { notes: null });
+
+      expect(mockSet).toHaveBeenCalledWith(
+        expect.objectContaining({ loyaltyPrograms: [stripped] }),
       );
     });
 

--- a/apps/api/src/modules/users/users.service.spec.ts
+++ b/apps/api/src/modules/users/users.service.spec.ts
@@ -1728,7 +1728,7 @@ describe('UsersService', () => {
       id: 'prog-new-uuid',
       programName: 'Delta SkyMiles',
       memberId: 'DL999',
-      notes: 'Gold status',
+      notes: null,
     };
 
     it('appends the new program and returns it', async () => {
@@ -1741,29 +1741,6 @@ describe('UsersService', () => {
         expect.objectContaining({ loyaltyPrograms: [newProgram] }),
       );
       expect(result).toEqual(newProgram);
-    });
-
-    it('strips null fields before saving (notes: null is omitted)', async () => {
-      const dto = {
-        id: 'prog-new-uuid',
-        programName: 'Delta SkyMiles',
-        memberId: 'DL999',
-        notes: null,
-      };
-      const stripped = { id: 'prog-new-uuid', programName: 'Delta SkyMiles', memberId: 'DL999' };
-      mockProfileFindFirst.mockResolvedValue({ ...mockHealthProfile, loyaltyPrograms: [] });
-      mockReturning.mockResolvedValue([{ ...mockHealthProfile, loyaltyPrograms: [stripped] }]);
-
-      await service.addLoyaltyProgram('user-uuid', dto);
-
-      expect(mockSet).toHaveBeenCalledWith(
-        expect.objectContaining({ loyaltyPrograms: [stripped] }),
-      );
-      expect(mockSet).not.toHaveBeenCalledWith(
-        expect.objectContaining({
-          loyaltyPrograms: expect.arrayContaining([expect.objectContaining({ notes: null })]),
-        }),
-      );
     });
 
     it('appends to existing programs without removing them', async () => {
@@ -1869,26 +1846,6 @@ describe('UsersService', () => {
         expect.objectContaining({
           loyaltyPrograms: expect.arrayContaining([expect.objectContaining({ id: 'prog-other' })]),
         }),
-      );
-    });
-
-    it('strips null fields from the merged entry (clearing notes removes the key)', async () => {
-      const withNotes = { ...existingProgram, notes: 'Gold' };
-      mockProfileFindFirst.mockResolvedValue({
-        ...mockHealthProfile,
-        loyaltyPrograms: [withNotes],
-      });
-      const stripped = {
-        id: existingProgram.id,
-        programName: existingProgram.programName,
-        memberId: existingProgram.memberId,
-      };
-      mockReturning.mockResolvedValue([{ ...mockHealthProfile, loyaltyPrograms: [stripped] }]);
-
-      await service.updateLoyaltyProgram('user-uuid', 'prog-uuid', { notes: null });
-
-      expect(mockSet).toHaveBeenCalledWith(
-        expect.objectContaining({ loyaltyPrograms: [stripped] }),
       );
     });
 

--- a/apps/api/src/modules/users/users.service.ts
+++ b/apps/api/src/modules/users/users.service.ts
@@ -568,9 +568,22 @@ export class UsersService {
   async addLoyaltyProgram(userId: string, dto: LoyaltyProgramDto): Promise<LoyaltyProgramDto> {
     const { programs } = await this.fetchLoyaltyPrograms(userId);
 
+    const nameNorm = dto.programName.trim().toLowerCase();
+    const memberNorm = dto.memberId.trim().toLowerCase();
+    const duplicate = programs.some(
+      (p) =>
+        p.programName.trim().toLowerCase() === nameNorm &&
+        p.memberId.trim().toLowerCase() === memberNorm,
+    );
+    if (duplicate) {
+      throw new ConflictException('Loyalty program with this name and member ID already exists');
+    }
+
+    const entry = Object.fromEntries(Object.entries(dto).filter(([, v]) => v != null));
+
     const [saved] = await this.db
       .update(userProfiles)
-      .set({ loyaltyPrograms: [...programs, dto] })
+      .set({ loyaltyPrograms: [...programs, entry] })
       .where(eq(userProfiles.userId, userId))
       .returning();
 
@@ -594,11 +607,14 @@ export class UsersService {
       throw new NotFoundException('Loyalty program not found');
     }
 
-    const updated = programs.map((p: LoyaltyProgramDto, i: number) =>
-      i === index
-        ? { ...p, ...Object.fromEntries(Object.entries(dto).filter(([, v]) => v !== undefined)) }
-        : p,
-    );
+    const updated = programs.map((p: LoyaltyProgramDto, i: number) => {
+      if (i !== index) return p;
+      const merged = {
+        ...p,
+        ...Object.fromEntries(Object.entries(dto).filter(([, v]) => v !== undefined)),
+      };
+      return Object.fromEntries(Object.entries(merged).filter(([, v]) => v != null));
+    });
 
     const [saved] = await this.db
       .update(userProfiles)

--- a/apps/api/src/modules/users/users.service.ts
+++ b/apps/api/src/modules/users/users.service.ts
@@ -579,11 +579,9 @@ export class UsersService {
       throw new ConflictException('Loyalty program with this name and member ID already exists');
     }
 
-    const entry = Object.fromEntries(Object.entries(dto).filter(([, v]) => v != null));
-
     const [saved] = await this.db
       .update(userProfiles)
-      .set({ loyaltyPrograms: [...programs, entry] })
+      .set({ loyaltyPrograms: [...programs, dto] })
       .where(eq(userProfiles.userId, userId))
       .returning();
 
@@ -609,11 +607,10 @@ export class UsersService {
 
     const updated = programs.map((p: LoyaltyProgramDto, i: number) => {
       if (i !== index) return p;
-      const merged = {
+      return {
         ...p,
         ...Object.fromEntries(Object.entries(dto).filter(([, v]) => v !== undefined)),
-      };
-      return Object.fromEntries(Object.entries(merged).filter(([, v]) => v != null));
+      } as LoyaltyProgramDto;
     });
 
     const [saved] = await this.db

--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -227,3 +227,25 @@ import { FileUploadButton, UploadType } from '@/components/ui/file-upload-button
 - `upload.retry` — retry button label
 - `upload.errorDefault` — user-facing error message
 - `upload.progressLabel` — ARIA label for the progress bar (`Upload progress: {{progress}}%`)
+
+### 4. React event types — use the React 19 replacements, not FormEvent
+
+`FormEvent` and `FormEventHandler` are **deprecated** in React 19 (`@deprecated FormEvent doesn't actually exist`). Use the specific React event types instead.
+
+| Deprecated                          | Replacement                           |
+| ----------------------------------- | ------------------------------------- |
+| `FormEvent<HTMLFormElement>`        | `SubmitEvent<HTMLFormElement>`        |
+| `FormEventHandler<HTMLFormElement>` | `SubmitEventHandler<HTMLFormElement>` |
+
+```tsx
+// ✅ Correct — React 19 SubmitEvent
+import { type SubmitEvent } from 'react';
+async function handleSave(e: SubmitEvent<HTMLFormElement>) { e.preventDefault(); }
+onSubmit: (e: SubmitEvent<HTMLFormElement>) => void;
+
+// ❌ Wrong — FormEvent is deprecated in React 19
+import { type FormEvent } from 'react';
+async function handleSave(e: FormEvent<HTMLFormElement>) { ... }
+```
+
+React's `SubmitEvent<T>` extends `SyntheticEvent<T, NativeSubmitEvent>` and is what `onSubmit` prop now expects (`SubmitEventHandler<T>`). Import from `'react'`, not from `lib.dom.d.ts`.

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -75,8 +75,8 @@ export default function RootLayout({ children }: { children: ReactNode }) {
                   <AppShell>{children}</AppShell>
                 </UserProvider>
               </AuthProvider>
+              <IosPwaPrompt />
             </ToastProvider>
-            <IosPwaPrompt />
           </ThemeProvider>
         </I18nProvider>
       </body>

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -11,6 +11,7 @@ import { PreferencesSync } from '@/components/PreferencesSync';
 import { IosPwaPrompt } from '@/components/IosPwaPrompt';
 import { AuthProvider } from '@/store/auth';
 import { UserProvider } from '@/store/user';
+import { ToastProvider } from '@/components/ui/toast';
 import { cn } from '@/lib/utils';
 import { SIDEBAR_STORAGE_KEY, SIDEBAR_COLLAPSED_WIDTH } from '@/lib/sidebar-constants';
 
@@ -67,12 +68,14 @@ export default function RootLayout({ children }: { children: ReactNode }) {
             storageKey="chamuco-theme"
             scriptProps={{ async: true }}
           >
-            <AuthProvider>
-              <UserProvider>
-                <PreferencesSync />
-                <AppShell>{children}</AppShell>
-              </UserProvider>
-            </AuthProvider>
+            <ToastProvider>
+              <AuthProvider>
+                <UserProvider>
+                  <PreferencesSync />
+                  <AppShell>{children}</AppShell>
+                </UserProvider>
+              </AuthProvider>
+            </ToastProvider>
             <IosPwaPrompt />
           </ThemeProvider>
         </I18nProvider>

--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -261,6 +261,15 @@ export default function ProfilePage() {
           role="tablist"
           aria-label={t('title')}
           onScroll={handleTablistScroll}
+          style={
+            showScrollHint
+              ? {
+                  WebkitMaskImage:
+                    'linear-gradient(to right, black calc(100% - 3rem), transparent 100%)',
+                  maskImage: 'linear-gradient(to right, black calc(100% - 3rem), transparent 100%)',
+                }
+              : undefined
+          }
           className="flex gap-1 overflow-x-auto border-b border-border scrollbar-none [&::-webkit-scrollbar]:hidden"
         >
           {tabs.map(({ key, label }) => (
@@ -287,9 +296,6 @@ export default function ProfilePage() {
             </button>
           ))}
         </div>
-        {showScrollHint && (
-          <div className="pointer-events-none absolute right-0 top-0 h-[calc(100%-1px)] w-12 bg-linear-to-r from-transparent to-background" />
-        )}
       </div>
 
       <div

--- a/apps/web/src/components/groups/members/InviteMemberModal.tsx
+++ b/apps/web/src/components/groups/members/InviteMemberModal.tsx
@@ -26,7 +26,7 @@ export function InviteMemberModal({ groupId, onSuccess }: InviteMemberModalProps
   const [isSending, setIsSending] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.SubmitEvent) => {
     e.preventDefault();
     if (!username.trim()) return;
 

--- a/apps/web/src/components/profile/BasicInfoSection.tsx
+++ b/apps/web/src/components/profile/BasicInfoSection.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, type FormEvent } from 'react';
+import { useState, type SubmitEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ProfileVisibility } from '@chamuco/shared-types';
 
@@ -51,7 +51,7 @@ export function BasicInfoSection({ user, userProfile, onRefresh }: BasicInfoSect
     timezone !== user.timezone ||
     visibility !== user.profileVisibility;
 
-  async function handleSave(e: FormEvent) {
+  async function handleSave(e: SubmitEvent) {
     e.preventDefault();
     const trimmedName = displayName.trim();
     if (!trimmedName || trimmedName.length > 100) {

--- a/apps/web/src/components/profile/EmergencyContactsSection.tsx
+++ b/apps/web/src/components/profile/EmergencyContactsSection.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, type FormEvent } from 'react';
+import { useState, type SubmitEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 import { isValidPhoneNumber, type CountryCode } from 'libphonenumber-js';
 import { getCountryDataList } from 'countries-list';
@@ -85,7 +85,7 @@ interface ContactFormProps {
   isSaving: boolean;
   isDirty: boolean;
   onChange: (patch: Partial<FormState>) => void;
-  onSubmit: (e: FormEvent) => void;
+  onSubmit: (e: SubmitEvent) => void;
   onCancel: () => void;
   saveLabel: string;
 }
@@ -299,7 +299,7 @@ export function EmergencyContactsSection({ contacts, onRefresh }: EmergencyConta
     setAddErrors(EMPTY_ERRORS);
   }
 
-  async function handleAdd(e: FormEvent) {
+  async function handleAdd(e: SubmitEvent) {
     e.preventDefault();
     const normalized = {
       ...addForm,
@@ -330,7 +330,7 @@ export function EmergencyContactsSection({ contacts, onRefresh }: EmergencyConta
     }
   }
 
-  async function handleUpdate(e: FormEvent) {
+  async function handleUpdate(e: SubmitEvent) {
     e.preventDefault();
     if (!editingId) return;
     const normalized = {

--- a/apps/web/src/components/profile/EtasSubsection.tsx
+++ b/apps/web/src/components/profile/EtasSubsection.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState, type FormEvent } from 'react';
+import { useEffect, useState, type SubmitEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 import { getEmojiFlag, type TCountryCode } from 'countries-list';
 import { DocumentStatus, EtaType, VisaEntries } from '@chamuco/shared-types';
@@ -92,7 +92,7 @@ interface EtaFormProps {
   isDirty: boolean;
   isEdit?: boolean;
   onChange: (patch: Partial<FormState>) => void;
-  onSubmit: (e: FormEvent) => void;
+  onSubmit: (e: SubmitEvent) => void;
   onCancel: () => void;
   saveLabel: string;
 }
@@ -396,7 +396,7 @@ export function EtasSubsection({ nationalityId, passportNumber }: EtasSubsection
     setAddErrors(EMPTY_ERRORS);
   }
 
-  async function handleAdd(e: FormEvent) {
+  async function handleAdd(e: SubmitEvent) {
     e.preventDefault();
     if (!validate(addForm, setAddErrors)) return;
     setIsSaving(true);
@@ -421,7 +421,7 @@ export function EtasSubsection({ nationalityId, passportNumber }: EtasSubsection
     }
   }
 
-  async function handleUpdate(e: FormEvent) {
+  async function handleUpdate(e: SubmitEvent) {
     e.preventDefault();
     if (!editingId) return;
     if (!validateEdit(editForm, setEditErrors)) return;

--- a/apps/web/src/components/profile/HealthSection.tsx
+++ b/apps/web/src/components/profile/HealthSection.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useMemo, type FormEvent } from 'react';
+import { useState, useMemo, type SubmitEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { Input } from '@/components/ui/input';
@@ -244,7 +244,7 @@ export function HealthSection({ health, onRefresh }: HealthSectionProps) {
     return !hasError;
   }
 
-  async function handleSave(e: FormEvent) {
+  async function handleSave(e: SubmitEvent) {
     e.preventDefault();
 
     if (!validateArrays()) return;

--- a/apps/web/src/components/profile/LoyaltyProgramsSection.tsx
+++ b/apps/web/src/components/profile/LoyaltyProgramsSection.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, type FormEvent } from 'react';
+import { useState, type SubmitEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { Button } from '@/components/ui/button';
@@ -41,7 +41,7 @@ interface ProgramFormProps {
   onChangeProgramName: (v: string) => void;
   onChangeMemberId: (v: string) => void;
   onChangeNotes: (v: string) => void;
-  onSubmit: (e: FormEvent) => void;
+  onSubmit: (e: SubmitEvent) => void;
   onCancel: () => void;
   saveLabel: string;
 }
@@ -148,8 +148,17 @@ export function LoyaltyProgramsSection({ programs, onRefresh }: LoyaltyProgramsS
     setAddForm(EMPTY_FORM);
   }
 
-  async function handleAdd(e: FormEvent) {
+  async function handleAdd(e: SubmitEvent) {
     e.preventDefault();
+    const nameNorm = addForm.programName.trim().toLowerCase();
+    const memberNorm = addForm.memberId.trim().toLowerCase();
+    const isDuplicate = programs.some(
+      (p) => p.programName.toLowerCase() === nameNorm && p.memberId.toLowerCase() === memberNorm,
+    );
+    if (isDuplicate) {
+      toast.error(t('loyaltyPrograms.duplicateError'));
+      return;
+    }
     setIsSaving(true);
     try {
       await apiClient.post('/v1/users/me/loyalty-programs', {
@@ -169,7 +178,7 @@ export function LoyaltyProgramsSection({ programs, onRefresh }: LoyaltyProgramsS
     }
   }
 
-  async function handleUpdate(e: FormEvent) {
+  async function handleUpdate(e: SubmitEvent) {
     e.preventDefault();
     if (!editingId) return;
     setIsSaving(true);

--- a/apps/web/src/components/profile/NationalitiesSection.tsx
+++ b/apps/web/src/components/profile/NationalitiesSection.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, type SubmitEvent } from 'react';
+import axios from 'axios';
 import { useTranslation } from 'react-i18next';
 import { getCountryDataList, getEmojiFlag, type TCountryCode } from 'countries-list';
 import { CaretDownIcon, GlobeIcon, IdentificationCardIcon } from '@phosphor-icons/react';
@@ -383,16 +384,7 @@ export function NationalitiesSection({ data, onRefresh }: NationalitiesSectionPr
       setAddErrors(EMPTY_ERRORS);
       onRefresh();
     } catch (err: unknown) {
-      const status =
-        err &&
-        typeof err === 'object' &&
-        'response' in err &&
-        err.response &&
-        typeof err.response === 'object' &&
-        'status' in err.response
-          ? (err.response as { status: number }).status
-          : null;
-      if (status === 409) {
+      if (axios.isAxiosError(err) && err.response?.status === 409) {
         toast.error(t('nationalities.duplicateError'));
       } else {
         toast.error(t('nationalities.saveError'));

--- a/apps/web/src/components/profile/NationalitiesSection.tsx
+++ b/apps/web/src/components/profile/NationalitiesSection.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, type FormEvent } from 'react';
+import { useState, type SubmitEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 import { getCountryDataList, getEmojiFlag, type TCountryCode } from 'countries-list';
 import { CaretDownIcon, GlobeIcon, IdentificationCardIcon } from '@phosphor-icons/react';
@@ -93,7 +93,7 @@ interface NationalityFormProps {
   isDirty: boolean;
   readOnlyCountry?: boolean;
   onChange: (patch: Partial<FormState>) => void;
-  onSubmit: (e: FormEvent) => void;
+  onSubmit: (e: SubmitEvent) => void;
   onCancel: () => void;
   saveLabel: string;
 }
@@ -299,9 +299,15 @@ export function NationalitiesSection({ data, onRefresh }: NationalitiesSectionPr
       if (!DOCUMENT_ID_FORMAT_REGEX.test(form.passportNumber.trim())) {
         errors.passportNumber = t('nationalities.errors.passportFormat');
         hasError = true;
-      } else if (form.passportExpiryDate <= form.passportIssueDate) {
-        errors.passportDates = t('nationalities.errors.expiryBeforeIssue');
-        hasError = true;
+      } else {
+        const today = new Date().toISOString().split('T')[0] as string;
+        if (form.passportIssueDate > today) {
+          errors.passportDates = t('nationalities.errors.issueDateFuture');
+          hasError = true;
+        } else if (form.passportExpiryDate <= form.passportIssueDate) {
+          errors.passportDates = t('nationalities.errors.expiryBeforeIssue');
+          hasError = true;
+        }
       }
     }
 
@@ -362,7 +368,7 @@ export function NationalitiesSection({ data, onRefresh }: NationalitiesSectionPr
     setAddErrors(EMPTY_ERRORS);
   }
 
-  async function handleAdd(e: FormEvent) {
+  async function handleAdd(e: SubmitEvent) {
     e.preventDefault();
     if (!validate(addForm, setAddErrors)) return;
     setIsSaving(true);
@@ -376,14 +382,27 @@ export function NationalitiesSection({ data, onRefresh }: NationalitiesSectionPr
       setAddForm(makeEmptyForm());
       setAddErrors(EMPTY_ERRORS);
       onRefresh();
-    } catch {
-      toast.error(t('nationalities.saveError'));
+    } catch (err: unknown) {
+      const status =
+        err &&
+        typeof err === 'object' &&
+        'response' in err &&
+        err.response &&
+        typeof err.response === 'object' &&
+        'status' in err.response
+          ? (err.response as { status: number }).status
+          : null;
+      if (status === 409) {
+        toast.error(t('nationalities.duplicateError'));
+      } else {
+        toast.error(t('nationalities.saveError'));
+      }
     } finally {
       setIsSaving(false);
     }
   }
 
-  async function handleUpdate(e: FormEvent) {
+  async function handleUpdate(e: SubmitEvent) {
     e.preventDefault();
     if (!editingId) return;
     if (!validate(editForm, setEditErrors)) return;

--- a/apps/web/src/components/profile/PersonalDetailsSection.tsx
+++ b/apps/web/src/components/profile/PersonalDetailsSection.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, type FormEvent } from 'react';
+import { useState, type SubmitEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 import { isValidPhoneNumber, type CountryCode } from 'libphonenumber-js';
 import { getCountryDataList } from 'countries-list';
@@ -89,7 +89,7 @@ export function PersonalDetailsSection({ profile, onRefresh }: PersonalDetailsSe
     (homeCity.trim() || null) !== profile.homeCity ||
     email.trim() !== profile.email;
 
-  async function handleSave(e: FormEvent) {
+  async function handleSave(e: SubmitEvent) {
     e.preventDefault();
 
     const normalizedFirst = normalizeName(firstName);

--- a/apps/web/src/components/profile/VisasSubsection.tsx
+++ b/apps/web/src/components/profile/VisasSubsection.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState, type FormEvent } from 'react';
+import { useEffect, useState, type SubmitEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 import { getEmojiFlag, type TCountryCode } from 'countries-list';
 import {
@@ -100,7 +100,7 @@ interface VisaFormProps {
   isDirty: boolean;
   isEdit?: boolean;
   onChange: (patch: Partial<FormState>) => void;
-  onSubmit: (e: FormEvent) => void;
+  onSubmit: (e: SubmitEvent) => void;
   onCancel: () => void;
   saveLabel: string;
 }
@@ -447,7 +447,7 @@ export function VisasSubsection({ nationalityId }: VisasSubsectionProps) {
     setAddErrors(EMPTY_ERRORS);
   }
 
-  async function handleAdd(e: FormEvent) {
+  async function handleAdd(e: SubmitEvent) {
     e.preventDefault();
     if (!validate(addForm, setAddErrors)) return;
     setIsSaving(true);
@@ -468,7 +468,7 @@ export function VisasSubsection({ nationalityId }: VisasSubsectionProps) {
     }
   }
 
-  async function handleUpdate(e: FormEvent) {
+  async function handleUpdate(e: SubmitEvent) {
     e.preventDefault();
     if (!editingId) return;
     if (!validateEdit(editForm, setEditErrors)) return;

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -476,6 +476,7 @@
       "updateSuccess": "Program updated",
       "deleteSuccess": "Program deleted",
       "saveError": "Failed to save",
+      "duplicateError": "You already have this program with the same member ID.",
       "categories": {
         "airline": "Airline",
         "hotel": "Hotel",
@@ -657,13 +658,15 @@
       "updateSuccess": "Nationality updated.",
       "deleteSuccess": "Nationality removed.",
       "saveError": "Could not save. Please try again.",
+      "duplicateError": "You already have a nationality for that country.",
       "deleteError": "Could not delete. Please try again.",
       "deletePrimaryError": "Cannot delete the primary nationality while others exist.",
       "errors": {
         "nationalIdFormat": "National ID may only contain uppercase letters, numbers, and hyphens.",
         "passportIncomplete": "Provide all three passport fields or leave them all empty.",
         "passportFormat": "Passport number may only contain uppercase letters, numbers, and hyphens.",
-        "expiryBeforeIssue": "Expiry date must be after issue date."
+        "expiryBeforeIssue": "Expiry date must be after issue date.",
+        "issueDateFuture": "Passport issue date cannot be in the future."
       },
       "documentStatus": {
         "ACTIVE": "Active",

--- a/apps/web/src/locales/es.json
+++ b/apps/web/src/locales/es.json
@@ -476,6 +476,7 @@
       "updateSuccess": "Programa actualizado",
       "deleteSuccess": "Programa eliminado",
       "saveError": "Error al guardar",
+      "duplicateError": "Ya tienes este programa con el mismo número de socio.",
       "categories": {
         "airline": "Aerolínea",
         "hotel": "Hotel",
@@ -657,13 +658,15 @@
       "updateSuccess": "Nacionalidad actualizada.",
       "deleteSuccess": "Nacionalidad eliminada.",
       "saveError": "No se pudo guardar. Intenta de nuevo.",
+      "duplicateError": "Ya tienes una nacionalidad registrada para ese país.",
       "deleteError": "No se pudo eliminar. Intenta de nuevo.",
       "deletePrimaryError": "No se puede eliminar la nacionalidad principal mientras existan otras.",
       "errors": {
         "nationalIdFormat": "El número de identificación solo puede contener letras mayúsculas, números y guiones.",
         "passportIncomplete": "Completa los tres campos del pasaporte o déjalos todos vacíos.",
         "passportFormat": "El número de pasaporte solo puede contener letras mayúsculas, números y guiones.",
-        "expiryBeforeIssue": "La fecha de vencimiento debe ser posterior a la fecha de expedición."
+        "expiryBeforeIssue": "La fecha de vencimiento debe ser posterior a la fecha de expedición.",
+        "issueDateFuture": "La fecha de expedición del pasaporte no puede ser futura."
       },
       "documentStatus": {
         "ACTIVE": "Activo",


### PR DESCRIPTION
## Summary

- **ToastProvider missing** — montado en el root layout; los toasts no renderizaban en ninguna parte de la app
- **Nationality 409 handling** — el frontend ahora detecta `ConflictException` al agregar una nacionalidad duplicada y muestra el mensaje correcto en lugar del genérico
- **Passport issue date** — nueva validación (frontend + backend) que rechaza fechas de expedición futuras; nuevo validator `IsNotFutureDate` con tests
- **Loyalty program duplicates** — rechaza crear un programa idéntico (nombre + ID de socio, case-insensitive) tanto en frontend (antes del request) como en backend (`ConflictException`)
- **Mobile tab scroll affordance** — `mask-image` CSS en el tablist de perfil garantiza que siempre se vea el borde derecho cortado, señalando que hay más tabs, independientemente del ancho de pantalla o largo de labels (multilenguaje)
- **React 19 event types** — migración de `FormEvent` → `SubmitEvent` en componentes de perfil e `InviteMemberModal`

## Test plan

- [ ] Agregar nacionalidad duplicada → toast "Ya tienes una nacionalidad registrada para ese país"
- [ ] Agregar pasaporte con fecha de expedición futura → error inline en frontend; 400 en backend
- [ ] Agregar programa de fidelidad duplicado → toast de error sin llamada al API
- [ ] Vista móvil del perfil → el borde derecho del tablist siempre muestra un tab parcialmente cortado
- [ ] Cualquier operación que dispare un toast (éxito o error) → toast aparece correctamente

🤖 Generated with [Claude Code](https://claude.ai/claude-code)