### PR TITLE
feat(profile): generic PhoneInput with smart paste and space stripping

### DIFF
--- a/apps/web/src/app/onboarding/page.test.tsx
+++ b/apps/web/src/app/onboarding/page.test.tsx
@@ -480,7 +480,7 @@ describe('OnboardingPage', () => {
     async function renderFormWithAvailableUsername(
       authOverrides: Partial<AuthContextValue> = {},
       username = 'newuser',
-      step2: { firstName?: string; lastName?: string } = {},
+      step2: { firstName?: string; lastName?: string; phone?: string } = {},
     ) {
       vi.mocked(useAuth).mockReturnValue(makeAuth(authOverrides));
       mockGetByUrl(); // /username-available → { available: true }
@@ -517,7 +517,7 @@ describe('OnboardingPage', () => {
       await user.type(screen.getByTestId('dob-day-input'), '15');
       await user.type(screen.getByTestId('dob-month-input'), '6');
       await user.type(screen.getByTestId('dob-year-input'), '1990');
-      await user.type(screen.getByTestId('phone-number-input'), '3001234567');
+      await user.type(screen.getByTestId('phone-number-input'), step2.phone ?? '3001234567');
 
       // Step 2 → Step 3
       await user.click(screen.getByTestId('next-btn'));
@@ -699,6 +699,27 @@ describe('OnboardingPage', () => {
           phoneLocalNumber: '3001234567',
           email: 'test@example.com',
         }),
+      );
+    });
+
+    it('strips internal spaces from phone number before registration POST', async () => {
+      mocks.mockApiPost.mockResolvedValue({ status: 201 });
+      const user = await renderFormWithAvailableUsername(
+        { currentUser: makeUser({ displayName: 'Test User' }) },
+        'newuser',
+        { phone: '300 123 4567' },
+      );
+
+      await user.click(screen.getByTestId('submit-btn'));
+
+      await waitFor(() =>
+        expect(mocks.mockApiPost).toHaveBeenCalledWith(
+          '/v1/auth/register',
+          expect.objectContaining({
+            phoneCountryCode: '+57',
+            phoneLocalNumber: '3001234567',
+          }),
+        ),
       );
     });
 

--- a/apps/web/src/app/onboarding/page.tsx
+++ b/apps/web/src/app/onboarding/page.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { Trans, useTranslation } from 'react-i18next';
 import { isAxiosError } from 'axios';
-import { isValidPhoneNumber, type CountryCode } from 'libphonenumber-js';
+import { PhoneInput, cleanPhoneNumber, isPhoneValid } from '@/components/ui/phone-input';
 import type { TFunction } from 'i18next';
 import { useTheme } from 'next-themes';
 import { getCountryData, type TCountryCode } from 'countries-list';
@@ -133,7 +133,7 @@ function validateStep2(
   else if (d < 1 || d > 31 || m < 1 || m > 12 || y < 1900 || !isValidCalendarDay(d, m, y))
     errors.dob = t('onboarding.validation.invalidDob');
   else if (computeAge(d, m, y) < 16) errors.dob = t('onboarding.validation.minAge');
-  if (!isValidPhoneNumber(phoneNumber, phoneCountry as CountryCode))
+  if (!isPhoneValid(phoneNumber, phoneCountry))
     errors.phone = t('onboarding.validation.invalidPhone');
   const trimmedEmail = email.trim();
   if (trimmedEmail && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(trimmedEmail))
@@ -347,7 +347,7 @@ export default function OnboardingPage() {
         homeCountry,
         homeCity: homeCity.trim() || undefined,
         phoneCountryCode: getCallingCode(phoneCountry),
-        phoneLocalNumber: phoneNumber,
+        phoneLocalNumber: cleanPhoneNumber(phoneNumber),
         email: email.trim() || null,
         timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
       });
@@ -788,28 +788,17 @@ function Step2({
 
       <div className="flex flex-col gap-1.5">
         <Label id="phone-country-label">{t('onboarding.phone.label')}</Label>
-        <div className="grid grid-cols-[auto_1fr] gap-2">
-          <CountryCombobox
-            value={phoneCountry}
-            onChange={onPhoneCountryChange}
-            displayMode="phone"
-            placeholder={t('onboarding.phone.countryPlaceholder')}
-            searchPlaceholder={t('onboarding.phone.search')}
-            noResultsText={t('onboarding.phone.noResults')}
-            aria-invalid={!!stepErrors.phone}
-            aria-labelledby="phone-country-label"
-            data-testid="phone-code-input"
-          />
-          <Input
-            type="tel"
-            value={phoneNumber}
-            onChange={(e) => onPhoneNumberChange(e.target.value)}
-            placeholder={t('onboarding.phone.number')}
-            aria-invalid={!!stepErrors.phone}
-            data-testid="phone-number-input"
-          />
-        </div>
-        <FieldMessage error={stepErrors.phone} className="text-xs" />
+        <PhoneInput
+          countryIso={phoneCountry}
+          localNumber={phoneNumber}
+          onCountryChange={onPhoneCountryChange}
+          onNumberChange={onPhoneNumberChange}
+          error={stepErrors.phone ?? null}
+          labelId="phone-country-label"
+          inputTestId="phone-number-input"
+          countryTestId="phone-code-input"
+          placeholder={t('onboarding.phone.number')}
+        />
       </div>
     </div>
   );

--- a/apps/web/src/components/profile/EmergencyContactsSection.test.tsx
+++ b/apps/web/src/components/profile/EmergencyContactsSection.test.tsx
@@ -183,6 +183,25 @@ describe('EmergencyContactsSection', () => {
       );
     });
 
+    it('strips internal spaces from phone number before POST', async () => {
+      const { user } = setup([]);
+      await user.click(screen.getByRole('button', { name: 'emergencyContacts.add' }));
+      await user.type(screen.getByLabelText('emergencyContacts.fullName'), 'Ana López');
+      await user.type(screen.getByLabelText('emergencyContacts.phoneNumber'), '300 987 6543');
+      await user.type(screen.getByLabelText('emergencyContacts.relationship'), 'Sister');
+      await user.click(screen.getByRole('button', { name: 'emergencyContacts.save' }));
+      await waitFor(() =>
+        expect(mocks.mockPost).toHaveBeenCalledWith('/v1/users/me/emergency-contacts', {
+          id: 'test-uuid-1234',
+          fullName: 'ANA LÓPEZ',
+          phoneCountryCode: '+57',
+          phoneLocalNumber: '3009876543',
+          relationship: 'SISTER',
+          isPrimary: true,
+        }),
+      );
+    });
+
     it('defaults isPrimary to true when list is empty', async () => {
       const { user } = setup([]);
       await user.click(screen.getByRole('button', { name: 'emergencyContacts.add' }));
@@ -372,6 +391,25 @@ describe('EmergencyContactsSection', () => {
       await waitFor(() =>
         expect(mocks.mockPatch).toHaveBeenCalledWith('/v1/users/me/emergency-contacts/contact-1', {
           fullName: 'MARÍA LÓPEZ',
+          phoneCountryCode: '+57',
+          phoneLocalNumber: '3001234567',
+          relationship: 'MOTHER',
+          isPrimary: true,
+        }),
+      );
+    });
+
+    it('strips internal spaces from phone before PATCH', async () => {
+      const { user } = setup();
+      const editButtons = screen.getAllByRole('button', { name: 'actions.edit' });
+      await user.click(editButtons[0]!);
+      const phoneInput = screen.getByLabelText('emergencyContacts.phoneNumber');
+      await user.clear(phoneInput);
+      await user.type(phoneInput, '300 123 4567');
+      await user.click(screen.getByRole('button', { name: 'emergencyContacts.save' }));
+      await waitFor(() =>
+        expect(mocks.mockPatch).toHaveBeenCalledWith('/v1/users/me/emergency-contacts/contact-1', {
+          fullName: 'MARÍA GARCÍA',
           phoneCountryCode: '+57',
           phoneLocalNumber: '3001234567',
           relationship: 'MOTHER',

--- a/apps/web/src/components/profile/EmergencyContactsSection.tsx
+++ b/apps/web/src/components/profile/EmergencyContactsSection.tsx
@@ -2,14 +2,14 @@
 
 import { useState, type SubmitEvent } from 'react';
 import { useTranslation } from 'react-i18next';
-import { isValidPhoneNumber, type CountryCode } from 'libphonenumber-js';
 import { getCountryDataList } from 'countries-list';
 
 import { Button } from '@/components/ui/button';
 import { EditDeleteActions } from '@/components/ui/edit-delete-actions';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { CountryCombobox, getCallingCode } from '@/components/ui/country-combobox';
+import { getCallingCode } from '@/components/ui/country-combobox';
+import { PhoneInput, cleanPhoneNumber, isPhoneValid } from '@/components/ui/phone-input';
 import { SaveButton } from '@/components/ui/save-button';
 import { toast } from '@/components/ui/toast';
 import { FieldMessage } from '@/components/ui/field-message';
@@ -127,35 +127,17 @@ function ContactForm({
 
       <div className="space-y-1.5">
         <Label id={`${idPrefix}-phone-label`}>{t('emergencyContacts.phoneNumber')}</Label>
-        <div className="flex gap-2">
-          <div className="w-40 shrink-0">
-            <Label htmlFor={`${idPrefix}-phoneCountry`} className="sr-only">
-              {t('emergencyContacts.phoneNumber')}
-            </Label>
-            <CountryCombobox
-              value={form.phoneCountryIso}
-              onChange={handleCountryChange}
-              displayMode="phone"
-              aria-labelledby={`${idPrefix}-phone-label`}
-              aria-invalid={errors.phone !== null}
-              data-testid={`${idPrefix}-phone-country`}
-            />
-          </div>
-          <div className="flex-1">
-            <Label htmlFor={`${idPrefix}-phoneLocalNumber`} className="sr-only">
-              {t('emergencyContacts.phoneNumber')}
-            </Label>
-            <Input
-              id={`${idPrefix}-phoneLocalNumber`}
-              type="tel"
-              value={form.phoneLocalNumber}
-              onChange={(e) => onChange({ phoneLocalNumber: e.target.value })}
-              aria-invalid={errors.phone !== null}
-              disabled={isSaving}
-            />
-          </div>
-        </div>
-        <FieldMessage error={errors.phone} />
+        <PhoneInput
+          countryIso={form.phoneCountryIso}
+          localNumber={form.phoneLocalNumber}
+          onCountryChange={handleCountryChange}
+          onNumberChange={(v) => onChange({ phoneLocalNumber: v })}
+          error={errors.phone}
+          disabled={isSaving}
+          labelId={`${idPrefix}-phone-label`}
+          numberLabel={t('emergencyContacts.phoneNumber')}
+          countryTestId={`${idPrefix}-phone-country`}
+        />
       </div>
 
       <div className="space-y-1.5">
@@ -242,10 +224,10 @@ export function EmergencyContactsSection({ contacts, onRefresh }: EmergencyConta
       hasError = true;
     }
 
-    if (!form.phoneLocalNumber.trim()) {
+    if (!cleanPhoneNumber(form.phoneLocalNumber)) {
       errors.phone = t('emergencyContacts.errors.phoneRequired');
       hasError = true;
-    } else if (!isValidPhoneNumber(form.phoneLocalNumber, form.phoneCountryIso as CountryCode)) {
+    } else if (!isPhoneValid(form.phoneLocalNumber, form.phoneCountryIso)) {
       errors.phone = t('emergencyContacts.errors.invalidPhone');
       hasError = true;
     }
@@ -314,7 +296,7 @@ export function EmergencyContactsSection({ contacts, onRefresh }: EmergencyConta
         id: globalThis.crypto.randomUUID(),
         fullName: normalized.fullName,
         phoneCountryCode: normalized.phoneCountryCode,
-        phoneLocalNumber: normalized.phoneLocalNumber.trim(),
+        phoneLocalNumber: cleanPhoneNumber(normalized.phoneLocalNumber),
         relationship: normalized.relationship,
         isPrimary: normalized.isPrimary,
       });
@@ -345,7 +327,7 @@ export function EmergencyContactsSection({ contacts, onRefresh }: EmergencyConta
       await apiClient.patch(`/v1/users/me/emergency-contacts/${editingId}`, {
         fullName: normalized.fullName,
         phoneCountryCode: normalized.phoneCountryCode,
-        phoneLocalNumber: normalized.phoneLocalNumber.trim(),
+        phoneLocalNumber: cleanPhoneNumber(normalized.phoneLocalNumber),
         relationship: normalized.relationship,
         isPrimary: normalized.isPrimary,
       });

--- a/apps/web/src/components/profile/PersonalDetailsSection.tsx
+++ b/apps/web/src/components/profile/PersonalDetailsSection.tsx
@@ -2,7 +2,6 @@
 
 import { useState, type SubmitEvent } from 'react';
 import { useTranslation } from 'react-i18next';
-import { isValidPhoneNumber, type CountryCode } from 'libphonenumber-js';
 import { getCountryDataList } from 'countries-list';
 
 import { Input } from '@/components/ui/input';
@@ -10,6 +9,7 @@ import { Label } from '@/components/ui/label';
 import { SaveButton } from '@/components/ui/save-button';
 import { CountryCombobox, getCallingCode } from '@/components/ui/country-combobox';
 import { CityCombobox } from '@/components/ui/city-combobox';
+import { PhoneInput, cleanPhoneNumber, isPhoneValid } from '@/components/ui/phone-input';
 import { toast } from '@/components/ui/toast';
 import { FieldMessage } from '@/components/ui/field-message';
 import { apiClient } from '@/services/api-client';
@@ -145,7 +145,7 @@ export function PersonalDetailsSection({ profile, onRefresh }: PersonalDetailsSe
       setDobError(null);
     }
 
-    if (!isValidPhoneNumber(phoneLocalNumber, phoneCountryIso as CountryCode)) {
+    if (!isPhoneValid(phoneLocalNumber, phoneCountryIso)) {
       setPhoneError(t('personalDetails.errors.invalidPhone'));
       hasError = true;
     } else {
@@ -179,7 +179,7 @@ export function PersonalDetailsSection({ profile, onRefresh }: PersonalDetailsSe
         lastName: normalizedLast,
         dateOfBirth: { day, month, year, yearVisible },
         phoneCountryCode: getCallingCode(phoneCountryIso),
-        phoneLocalNumber,
+        phoneLocalNumber: cleanPhoneNumber(phoneLocalNumber),
         birthCountry: birthCountry || null,
         birthCity: birthCity.trim() || null,
         homeCountry,
@@ -313,39 +313,18 @@ export function PersonalDetailsSection({ profile, onRefresh }: PersonalDetailsSe
 
       <div className="space-y-1.5">
         <Label id="phone-label">{t('personalDetails.phone')}</Label>
-        <div className="flex gap-2">
-          <div className="w-40 shrink-0">
-            <Label htmlFor="phoneCountry" className="sr-only">
-              {t('personalDetails.phoneCountry')}
-            </Label>
-            <CountryCombobox
-              value={phoneCountryIso}
-              onChange={setPhoneCountryIso}
-              displayMode="phone"
-              placeholder={t('personalDetails.phoneCountryPlaceholder')}
-              searchPlaceholder={t('personalDetails.phoneCountrySearch')}
-              noResultsText={t('personalDetails.phoneCountryNoResults')}
-              aria-labelledby="phone-label"
-              aria-invalid={phoneError !== null}
-              data-testid="phone-country"
-            />
-          </div>
-          <div className="flex-1">
-            <Label htmlFor="phoneLocalNumber" className="sr-only">
-              {t('personalDetails.phoneNumber')}
-            </Label>
-            <Input
-              id="phoneLocalNumber"
-              type="tel"
-              value={phoneLocalNumber}
-              onChange={(e) => setPhoneLocalNumber(e.target.value)}
-              placeholder={t('personalDetails.phoneNumberPlaceholder')}
-              aria-invalid={phoneError !== null}
-              disabled={isSaving}
-            />
-          </div>
-        </div>
-        <FieldMessage error={phoneError} />
+        <PhoneInput
+          countryIso={phoneCountryIso}
+          localNumber={phoneLocalNumber}
+          onCountryChange={setPhoneCountryIso}
+          onNumberChange={setPhoneLocalNumber}
+          error={phoneError}
+          disabled={isSaving}
+          labelId="phone-label"
+          numberLabel={t('personalDetails.phoneNumber')}
+          countryTestId="phone-country"
+          placeholder={t('personalDetails.phoneNumberPlaceholder')}
+        />
       </div>
 
       <div className="space-y-1.5">

--- a/apps/web/src/components/ui/phone-input.test.tsx
+++ b/apps/web/src/components/ui/phone-input.test.tsx
@@ -1,0 +1,265 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+const mocks = vi.hoisted(() => ({
+  mockIsValidPhoneNumber: vi.fn(() => true),
+}));
+
+vi.mock('libphonenumber-js', () => ({
+  isValidPhoneNumber: mocks.mockIsValidPhoneNumber,
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('countries-list', () => ({
+  getCountryDataList: () => [
+    { iso2: 'CO', name: 'Colombia', phone: [57] },
+    { iso2: 'US', name: 'United States', phone: [1] },
+    { iso2: 'TT', name: 'Trinidad and Tobago', phone: [1868] },
+    { iso2: 'MX', name: 'Mexico', phone: [52] },
+  ],
+}));
+
+vi.mock('@/components/ui/country-combobox', () => ({
+  CountryCombobox: ({
+    value,
+    onChange,
+    'data-testid': testId,
+    'aria-invalid': ariaInvalid,
+    'aria-labelledby': ariaLabelledBy,
+  }: {
+    value: string;
+    onChange: (iso: string) => void;
+    'data-testid'?: string;
+    'aria-invalid'?: boolean;
+    'aria-labelledby'?: string;
+  }) => (
+    <select
+      data-testid={testId ?? 'country-combobox'}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      aria-invalid={ariaInvalid}
+      aria-labelledby={ariaLabelledBy}
+    >
+      <option value="CO">+57</option>
+      <option value="US">+1</option>
+    </select>
+  ),
+}));
+
+import { PhoneInput, cleanPhoneNumber, isPhoneValid, parsePastedPhoneNumber } from './phone-input';
+
+// ---------------------------------------------------------------------------
+// cleanPhoneNumber
+// ---------------------------------------------------------------------------
+
+describe('cleanPhoneNumber', () => {
+  it('removes leading spaces', () => {
+    expect(cleanPhoneNumber('  3001234567')).toBe('3001234567');
+  });
+
+  it('removes trailing spaces', () => {
+    expect(cleanPhoneNumber('3001234567  ')).toBe('3001234567');
+  });
+
+  it('removes internal spaces', () => {
+    expect(cleanPhoneNumber('300 123 4567')).toBe('3001234567');
+  });
+
+  it('removes tabs and multiple consecutive spaces', () => {
+    expect(cleanPhoneNumber('300\t123  4567')).toBe('3001234567');
+  });
+
+  it('returns the value unchanged when no spaces', () => {
+    expect(cleanPhoneNumber('3001234567')).toBe('3001234567');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isPhoneValid
+// ---------------------------------------------------------------------------
+
+describe('isPhoneValid', () => {
+  beforeEach(() => {
+    mocks.mockIsValidPhoneNumber.mockReturnValue(true);
+  });
+
+  it('returns true when isValidPhoneNumber returns true', () => {
+    expect(isPhoneValid('3001234567', 'CO')).toBe(true);
+  });
+
+  it('returns false when isValidPhoneNumber returns false', () => {
+    mocks.mockIsValidPhoneNumber.mockReturnValue(false);
+    expect(isPhoneValid('123', 'CO')).toBe(false);
+  });
+
+  it('strips spaces before calling isValidPhoneNumber', () => {
+    isPhoneValid('300 123 4567', 'CO');
+    expect(mocks.mockIsValidPhoneNumber).toHaveBeenCalledWith('3001234567', 'CO');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PhoneInput component
+// ---------------------------------------------------------------------------
+
+function setup(props: Partial<Parameters<typeof PhoneInput>[0]> = {}) {
+  const defaults = {
+    countryIso: 'CO',
+    localNumber: '',
+    onCountryChange: vi.fn(),
+    onNumberChange: vi.fn(),
+  };
+  const merged = { ...defaults, ...props };
+  const user = userEvent.setup();
+  render(<PhoneInput {...merged} />);
+  return { user, ...merged };
+}
+
+describe('PhoneInput', () => {
+  it('renders country combobox and number input', () => {
+    setup();
+    expect(screen.getByTestId('country-combobox')).toBeInTheDocument();
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
+  });
+
+  it('number input reflects localNumber prop', () => {
+    setup({ localNumber: '3001234567' });
+    expect(screen.getByRole('textbox')).toHaveValue('3001234567');
+  });
+
+  it('country combobox reflects countryIso prop', () => {
+    setup({ countryIso: 'US' });
+    expect(screen.getByTestId('country-combobox')).toHaveValue('US');
+  });
+
+  it('calls onNumberChange when number input changes', async () => {
+    const { user, onNumberChange } = setup();
+    await user.type(screen.getByRole('textbox'), '300');
+    expect(onNumberChange).toHaveBeenCalled();
+  });
+
+  it('calls onCountryChange when country combobox changes', async () => {
+    const { user, onCountryChange } = setup();
+    await user.selectOptions(screen.getByTestId('country-combobox'), 'US');
+    expect(onCountryChange).toHaveBeenCalledWith('US');
+  });
+
+  it('sets aria-invalid on both controls when error is provided', () => {
+    setup({ error: 'Invalid phone' });
+    expect(screen.getByTestId('country-combobox')).toHaveAttribute('aria-invalid', 'true');
+    expect(screen.getByRole('textbox')).toHaveAttribute('aria-invalid', 'true');
+  });
+
+  it('does not set aria-invalid when no error', () => {
+    setup({ error: null });
+    expect(screen.getByTestId('country-combobox')).not.toHaveAttribute('aria-invalid', 'true');
+    expect(screen.getByRole('textbox')).not.toHaveAttribute('aria-invalid', 'true');
+  });
+
+  it('renders sr-only label connected to number input when numberLabel provided', () => {
+    setup({ numberLabel: 'Phone number' });
+    expect(screen.getByLabelText('Phone number')).toBeInTheDocument();
+  });
+
+  it('does not render sr-only label when numberLabel is omitted', () => {
+    setup();
+    expect(screen.queryByText('Phone number')).not.toBeInTheDocument();
+  });
+
+  it('renders FieldMessage with error text', () => {
+    setup({ error: 'Invalid phone number' });
+    expect(screen.getByText('Invalid phone number')).toBeInTheDocument();
+  });
+
+  it('does not render FieldMessage when error is null', () => {
+    setup({ error: null });
+    expect(screen.queryByRole('paragraph')).not.toBeInTheDocument();
+  });
+
+  it('passes countryTestId to country combobox', () => {
+    setup({ countryTestId: 'my-country' });
+    expect(screen.getByTestId('my-country')).toBeInTheDocument();
+  });
+
+  it('passes inputTestId to number input', () => {
+    setup({ inputTestId: 'my-phone' });
+    expect(screen.getByTestId('my-phone')).toBeInTheDocument();
+  });
+
+  it('renders placeholder on number input', () => {
+    setup({ placeholder: 'Enter number' });
+    expect(screen.getByPlaceholderText('Enter number')).toBeInTheDocument();
+  });
+
+  it('disables number input when disabled prop is true', () => {
+    setup({ disabled: true });
+    expect(screen.getByRole('textbox')).toBeDisabled();
+  });
+
+  it('splits international number on paste and updates both fields', async () => {
+    const { user, onCountryChange, onNumberChange } = setup();
+    await user.click(screen.getByRole('textbox'));
+    await user.paste('+57 311 5467389');
+    expect(onCountryChange).toHaveBeenCalledWith('CO');
+    expect(onNumberChange).toHaveBeenCalledWith('3115467389');
+  });
+
+  it('does not intercept paste when number has no country prefix', async () => {
+    const { user, onCountryChange } = setup();
+    await user.click(screen.getByRole('textbox'));
+    await user.paste('3115467389');
+    expect(onCountryChange).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parsePastedPhoneNumber
+// ---------------------------------------------------------------------------
+
+describe('parsePastedPhoneNumber', () => {
+  it('parses a Colombian WA number with spaces', () => {
+    expect(parsePastedPhoneNumber('+57 311 5467389')).toEqual({
+      iso2: 'CO',
+      nationalNumber: '3115467389',
+    });
+  });
+
+  it('parses a number without spaces after the prefix', () => {
+    expect(parsePastedPhoneNumber('+573115467389')).toEqual({
+      iso2: 'CO',
+      nationalNumber: '3115467389',
+    });
+  });
+
+  it('matches longer prefix first (+1868 before +1)', () => {
+    expect(parsePastedPhoneNumber('+1868 123 4567')).toEqual({
+      iso2: 'TT',
+      nationalNumber: '1234567',
+    });
+  });
+
+  it('strips parentheses, dashes, and spaces from national number', () => {
+    expect(parsePastedPhoneNumber('+57 (311) 546-7389')).toEqual({
+      iso2: 'CO',
+      nationalNumber: '3115467389',
+    });
+  });
+
+  it('returns null for a number without + prefix', () => {
+    expect(parsePastedPhoneNumber('3115467389')).toBeNull();
+  });
+
+  it('returns null when only the prefix is present with no national number', () => {
+    expect(parsePastedPhoneNumber('+57')).toBeNull();
+  });
+
+  it('trims leading/trailing whitespace before parsing', () => {
+    expect(parsePastedPhoneNumber('  +52 55 1234 5678  ')).toEqual({
+      iso2: 'MX',
+      nationalNumber: '5512345678',
+    });
+  });
+});

--- a/apps/web/src/components/ui/phone-input.tsx
+++ b/apps/web/src/components/ui/phone-input.tsx
@@ -1,0 +1,124 @@
+'use client';
+
+import { useId, type ClipboardEvent } from 'react';
+import { useTranslation } from 'react-i18next';
+import { isValidPhoneNumber, type CountryCode } from 'libphonenumber-js';
+import { getCountryDataList } from 'countries-list';
+
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { CountryCombobox } from '@/components/ui/country-combobox';
+import { FieldMessage } from '@/components/ui/field-message';
+
+// ---------------------------------------------------------------------------
+// Utilities
+// ---------------------------------------------------------------------------
+
+export function cleanPhoneNumber(value: string): string {
+  return value.replace(/\s+/g, '');
+}
+
+export function isPhoneValid(localNumber: string, countryIso: string): boolean {
+  return isValidPhoneNumber(cleanPhoneNumber(localNumber), countryIso as CountryCode);
+}
+
+export function parsePastedPhoneNumber(
+  pasted: string,
+): { iso2: string; nationalNumber: string } | null {
+  const text = pasted.trim();
+  if (!text.startsWith('+')) return null;
+
+  // Sort longest prefix first so +1868 matches before +1
+  const prefixes = getCountryDataList()
+    .map((c) => ({ iso2: c.iso2, prefix: `+${c.phone[0]}` }))
+    .sort((a, b) => b.prefix.length - a.prefix.length);
+
+  for (const { iso2, prefix } of prefixes) {
+    if (text.startsWith(prefix)) {
+      const nationalNumber = text.slice(prefix.length).replace(/\D/g, '');
+      if (nationalNumber.length > 0) return { iso2, nationalNumber };
+    }
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+interface PhoneInputProps {
+  countryIso: string;
+  localNumber: string;
+  onCountryChange: (iso2: string) => void;
+  onNumberChange: (value: string) => void;
+  error?: string | null;
+  disabled?: boolean;
+  labelId?: string;
+  numberLabel?: string;
+  countryTestId?: string;
+  inputTestId?: string;
+  placeholder?: string;
+}
+
+export function PhoneInput({
+  countryIso,
+  localNumber,
+  onCountryChange,
+  onNumberChange,
+  error,
+  disabled,
+  labelId,
+  numberLabel,
+  countryTestId,
+  inputTestId,
+  placeholder,
+}: PhoneInputProps) {
+  const { t } = useTranslation();
+  const inputId = useId();
+
+  function handlePaste(e: ClipboardEvent<HTMLInputElement>) {
+    const result = parsePastedPhoneNumber(e.clipboardData.getData('text'));
+    if (result) {
+      e.preventDefault();
+      onCountryChange(result.iso2);
+      onNumberChange(result.nationalNumber);
+    }
+  }
+
+  return (
+    <div>
+      <div className="grid grid-cols-[auto_1fr] gap-2">
+        <CountryCombobox
+          value={countryIso}
+          onChange={onCountryChange}
+          displayMode="phone"
+          searchPlaceholder={t('phoneInput.searchCountry')}
+          noResultsText={t('phoneInput.noCountries')}
+          aria-labelledby={labelId}
+          aria-invalid={error != null}
+          data-testid={countryTestId}
+        />
+        <div>
+          {numberLabel && (
+            <Label htmlFor={inputId} className="sr-only">
+              {numberLabel}
+            </Label>
+          )}
+          <Input
+            id={inputId}
+            type="tel"
+            value={localNumber}
+            onChange={(e) => onNumberChange(e.target.value)}
+            onPaste={handlePaste}
+            placeholder={placeholder}
+            aria-invalid={error != null}
+            aria-labelledby={!numberLabel ? labelId : undefined}
+            disabled={disabled}
+            data-testid={inputTestId}
+          />
+        </div>
+      </div>
+      <FieldMessage error={error} />
+    </div>
+  );
+}

--- a/apps/web/src/components/ui/phone-input.tsx
+++ b/apps/web/src/components/ui/phone-input.tsx
@@ -14,9 +14,15 @@ import { FieldMessage } from '@/components/ui/field-message';
 // Utilities
 // ---------------------------------------------------------------------------
 
+// Strips only whitespace — not dashes or parentheses. Use /\D/g for full digit extraction.
 export function cleanPhoneNumber(value: string): string {
   return value.replace(/\s+/g, '');
 }
+
+// Sorted longest-first so +1868 (TT) matches before +1 (US/CA).
+const PHONE_PREFIXES = getCountryDataList()
+  .map((c) => ({ iso2: c.iso2, prefix: `+${c.phone[0]}` }))
+  .sort((a, b) => b.prefix.length - a.prefix.length);
 
 export function isPhoneValid(localNumber: string, countryIso: string): boolean {
   return isValidPhoneNumber(cleanPhoneNumber(localNumber), countryIso as CountryCode);
@@ -28,12 +34,7 @@ export function parsePastedPhoneNumber(
   const text = pasted.trim();
   if (!text.startsWith('+')) return null;
 
-  // Sort longest prefix first so +1868 matches before +1
-  const prefixes = getCountryDataList()
-    .map((c) => ({ iso2: c.iso2, prefix: `+${c.phone[0]}` }))
-    .sort((a, b) => b.prefix.length - a.prefix.length);
-
-  for (const { iso2, prefix } of prefixes) {
+  for (const { iso2, prefix } of PHONE_PREFIXES) {
     if (text.startsWith(prefix)) {
       const nationalNumber = text.slice(prefix.length).replace(/\D/g, '');
       if (nationalNumber.length > 0) return { iso2, nationalNumber };
@@ -111,6 +112,7 @@ export function PhoneInput({
             onChange={(e) => onNumberChange(e.target.value)}
             onPaste={handlePaste}
             placeholder={placeholder}
+            autoComplete="tel-national"
             aria-invalid={error != null}
             aria-labelledby={!numberLabel ? labelId : undefined}
             disabled={disabled}

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -153,11 +153,7 @@
       },
       "phone": {
         "label": "Phone number",
-        "countryCode": "Country code",
-        "number": "Local number",
-        "countryPlaceholder": "Country",
-        "search": "Search countries…",
-        "noResults": "No countries found."
+        "number": "Local number"
       },
       "homeCountry": {
         "label": "Home country",

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -69,6 +69,10 @@
       "errorDefault": "Upload failed. Please try again.",
       "progressLabel": "Upload progress: {{progress}}%"
     },
+    "phoneInput": {
+      "searchCountry": "Search country...",
+      "noCountries": "No countries found."
+    },
     "profileIncomplete": {
       "title": "Complete your profile",
       "description": "Add your nationalities and emergency contacts to access all features.",

--- a/apps/web/src/locales/es.json
+++ b/apps/web/src/locales/es.json
@@ -153,11 +153,7 @@
       },
       "phone": {
         "label": "Número de teléfono",
-        "countryCode": "Código de país",
-        "number": "Número local",
-        "countryPlaceholder": "País",
-        "search": "Buscar países…",
-        "noResults": "No se encontraron países."
+        "number": "Número local"
       },
       "homeCountry": {
         "label": "País de residencia",

--- a/apps/web/src/locales/es.json
+++ b/apps/web/src/locales/es.json
@@ -69,6 +69,10 @@
       "errorDefault": "Error al subir. Inténtalo de nuevo.",
       "progressLabel": "Progreso de subida: {{progress}}%"
     },
+    "phoneInput": {
+      "searchCountry": "Buscar país...",
+      "noCountries": "No se encontraron países."
+    },
     "profileIncomplete": {
       "title": "Completa tu perfil",
       "description": "Agrega tus nacionalidades y contactos de emergencia para acceder a todas las funciones.",


### PR DESCRIPTION
## Summary

User feedback reported that phone number fields were not stripping internal spaces before saving (e.g. "300 123 4567" was stored as-is instead of "3001234567"). The fix goes beyond the original report: we extracted a reusable `PhoneInput` component to eliminate duplicated phone markup across three entry points (onboarding, personal details, emergency contacts) and centralised all sanitisation logic. `PersonalDetailsSection` was also missing the space-strip entirely.

## Changes

**New `PhoneInput` component (`components/ui/phone-input.tsx`)**
- `cleanPhoneNumber(value)` — strips all whitespace from a phone string
- `isPhoneValid(localNumber, countryIso)` — strips before calling `isValidPhoneNumber`
- `parsePastedPhoneNumber(pasted)` — smart paste: detects international format (e.g. `+57 (311) 546-7389`), matches the calling-code prefix (longest-first to avoid `+1` beating `+1868`), and returns `{ iso2, nationalNumber }` with all non-digit chars stripped
- `PhoneInput` component — controlled, renders `CountryCombobox` + `Input` with `onPaste` handler that auto-splits pasted international numbers into the country selector and number field

**Consumers updated**
- `EmergencyContactsSection` — replaces inline markup, uses `isPhoneValid` + `cleanPhoneNumber` in validate and submit
- `PersonalDetailsSection` — same; also adds the previously missing `cleanPhoneNumber` call before the API payload
- `onboarding/page.tsx` (Step2) — replaces inline markup, uses `isPhoneValid` + `cleanPhoneNumber`

**i18n**
- Added `common.phoneInput.searchCountry` and `common.phoneInput.noCountries` to `en.json` and `es.json`

## Testing

- `phone-input.test.tsx` — 35 unit tests covering `cleanPhoneNumber`, `isPhoneValid`, `parsePastedPhoneNumber` (spaces, parentheses, dashes, longest-prefix disambiguation, empty/no-prefix cases), and the `PhoneInput` component (render, events, aria, paste integration)
- `EmergencyContactsSection.test.tsx` — added tests verifying spaces are stripped before POST and PATCH
- `onboarding/page.test.tsx` — added test verifying spaces are stripped before registration POST
- All 1205 tests pass

## Notes

The smart paste specifically handles the WhatsApp number copy format (`+57 311 5467389`) and contact-app formats with punctuation (`+34 (408) 102-1436`). For ambiguous calling codes like `+1`, the longest prefix wins (e.g. `+1868` → Trinidad and Tobago before `+1` → US). If no match is found or the pasted value has no `+` prefix, the paste falls through to default browser behaviour.

Closes #278