### PR TITLE
feat(groups): implement group discovery & search

### DIFF
--- a/apps/api/src/modules/group-members/group-members.service.ts
+++ b/apps/api/src/modules/group-members/group-members.service.ts
@@ -524,7 +524,10 @@ export class GroupMembersService {
 
   // ─── Private helpers ──────────────────────────────────────────────────────────
 
-  private async findMemberOrThrow(groupId: string, userId: string) {
+  private async findMemberOrThrow(
+    groupId: string,
+    userId: string,
+  ): Promise<typeof groupMembers.$inferSelect> {
     const membership = await this.db.query.groupMembers.findFirst({
       where: and(eq(groupMembers.groupId, groupId), eq(groupMembers.userId, userId)),
     });
@@ -532,7 +535,7 @@ export class GroupMembersService {
     return membership;
   }
 
-  private async assertGroupExists(groupId: string) {
+  private async assertGroupExists(groupId: string): Promise<typeof groups.$inferSelect> {
     const group = await this.db.query.groups.findFirst({
       where: and(eq(groups.id, groupId), isNull(groups.deletedAt)),
     });

--- a/apps/api/src/modules/groups/dto/group-search-result.dto.ts
+++ b/apps/api/src/modules/groups/dto/group-search-result.dto.ts
@@ -1,0 +1,55 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { GroupVisibility } from '@chamuco/shared-types';
+
+export type MembershipStatus = 'none' | 'pending' | 'active';
+
+export class GroupSearchResultDto {
+  @ApiProperty({ example: '550e8400-e29b-41d4-a716-446655440000' })
+  id!: string;
+
+  @ApiProperty({ example: 'Mountain Crew' })
+  name!: string;
+
+  @ApiProperty({
+    example: 'A group for mountain hiking enthusiasts.',
+    nullable: true,
+  })
+  description!: string | null;
+
+  @ApiProperty({
+    description: 'Ready-to-use URL for the group cover image or emoji (Twemoji CDN).',
+    example: 'https://cdn.jsdelivr.net/npm/twemoji/2/svg/1f3d4.svg',
+  })
+  coverUrl!: string;
+
+  @ApiProperty({ enum: GroupVisibility, example: GroupVisibility.PUBLIC })
+  visibility!: GroupVisibility;
+
+  @ApiProperty({ example: '550e8400-e29b-41d4-a716-446655440000' })
+  createdBy!: string;
+
+  @ApiProperty({ example: '2026-01-01T00:00:00.000Z' })
+  createdAt!: string;
+
+  @ApiProperty({ example: '2026-01-01T00:00:00.000Z' })
+  updatedAt!: string;
+
+  @ApiProperty({ description: 'Number of active members in the group', example: 12 })
+  memberCount!: number;
+
+  @ApiProperty({
+    description: "The requesting user's membership status in this group",
+    enum: ['none', 'pending', 'active'],
+    example: 'none',
+  })
+  membershipStatus!: MembershipStatus;
+}
+
+export class GroupSearchResponseDto {
+  @ApiProperty({ type: [GroupSearchResultDto] })
+  data!: GroupSearchResultDto[];
+
+  @ApiProperty({ description: 'Total number of matching groups (before pagination)', example: 42 })
+  total!: number;
+}

--- a/apps/api/src/modules/groups/dto/group-search-result.dto.ts
+++ b/apps/api/src/modules/groups/dto/group-search-result.dto.ts
@@ -1,8 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 
-import { GroupVisibility } from '@chamuco/shared-types';
-
-export type MembershipStatus = 'none' | 'pending' | 'active';
+import { GroupVisibility, MembershipStatus } from '@chamuco/shared-types';
 
 export class GroupSearchResultDto {
   @ApiProperty({ example: '550e8400-e29b-41d4-a716-446655440000' })

--- a/apps/api/src/modules/groups/dto/search-groups-query.dto.ts
+++ b/apps/api/src/modules/groups/dto/search-groups-query.dto.ts
@@ -1,15 +1,17 @@
 import { Type } from 'class-transformer';
-import { IsInt, IsOptional, IsString, Max, MaxLength, Min } from 'class-validator';
+import { IsInt, IsOptional, IsString, Max, MaxLength, Min, MinLength } from 'class-validator';
 import { ApiPropertyOptional } from '@nestjs/swagger';
 
 export class SearchGroupsQueryDto {
   @ApiPropertyOptional({
     description: 'Name filter (case-insensitive, partial match)',
     example: 'mountain',
+    minLength: 1,
     maxLength: 100,
   })
   @IsOptional()
   @IsString()
+  @MinLength(1)
   @MaxLength(100)
   q?: string;
 

--- a/apps/api/src/modules/groups/dto/search-groups-query.dto.ts
+++ b/apps/api/src/modules/groups/dto/search-groups-query.dto.ts
@@ -1,0 +1,41 @@
+import { Type } from 'class-transformer';
+import { IsInt, IsOptional, IsString, Max, MaxLength, Min } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+export class SearchGroupsQueryDto {
+  @ApiPropertyOptional({
+    description: 'Name filter (case-insensitive, partial match)',
+    example: 'mountain',
+    maxLength: 100,
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  q?: string;
+
+  @ApiPropertyOptional({
+    description: 'Number of results per page (1–50)',
+    example: 20,
+    default: 20,
+    minimum: 1,
+    maximum: 50,
+  })
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(50)
+  @Type(() => Number)
+  limit?: number = 20;
+
+  @ApiPropertyOptional({
+    description: 'Number of results to skip',
+    example: 0,
+    default: 0,
+    minimum: 0,
+  })
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  @Type(() => Number)
+  offset?: number = 0;
+}

--- a/apps/api/src/modules/groups/groups.controller.ts
+++ b/apps/api/src/modules/groups/groups.controller.ts
@@ -9,11 +9,13 @@ import {
   ParseUUIDPipe,
   Patch,
   Post,
+  Query,
 } from '@nestjs/common';
 import {
   ApiBearerAuth,
   ApiOperation,
   ApiParam,
+  ApiQuery,
   ApiResponse,
   ApiTags,
   ApiBadRequestResponse,
@@ -27,6 +29,8 @@ import { GroupsService } from './groups.service';
 import { CreateGroupDto } from './dto/create-group.dto';
 import { UpdateGroupDto } from './dto/update-group.dto';
 import { GroupResponseDto } from './dto/group-response.dto';
+import { SearchGroupsQueryDto } from './dto/search-groups-query.dto';
+import { GroupSearchResponseDto } from './dto/group-search-result.dto';
 
 @ApiTags('groups')
 @ApiBearerAuth()
@@ -61,6 +65,40 @@ export class GroupsController {
   @ApiResponse({ status: 200, type: [GroupResponseDto] })
   async listMyGroups(@CurrentUser() user: AuthenticatedUser): Promise<GroupResponseDto[]> {
     return this.groupsService.listMyGroups(user.id);
+  }
+
+  @Get('search')
+  @ApiOperation({
+    summary: 'Discover public groups',
+    description:
+      'Returns a paginated list of PUBLIC groups matching the optional name filter. ' +
+      'Excludes groups the authenticated user already belongs to as an active member.',
+  })
+  @ApiQuery({
+    name: 'q',
+    required: false,
+    description: 'Name filter (case-insensitive, partial match)',
+    example: 'mountain',
+  })
+  @ApiQuery({
+    name: 'limit',
+    required: false,
+    type: Number,
+    description: 'Results per page (1–50, default 20)',
+  })
+  @ApiQuery({
+    name: 'offset',
+    required: false,
+    type: Number,
+    description: 'Number of results to skip (default 0)',
+  })
+  @ApiResponse({ status: 200, type: GroupSearchResponseDto })
+  @ApiBadRequestResponse({ description: 'Validation error in query params.' })
+  async searchGroups(
+    @CurrentUser() user: AuthenticatedUser,
+    @Query() query: SearchGroupsQueryDto,
+  ): Promise<GroupSearchResponseDto> {
+    return this.groupsService.searchGroups(user.id, query);
   }
 
   @Get(':id')

--- a/apps/api/src/modules/groups/groups.service.spec.ts
+++ b/apps/api/src/modules/groups/groups.service.spec.ts
@@ -736,6 +736,24 @@ describe('GroupsService', () => {
       expect(result.data[0]?.membershipStatus).toBe('pending');
     });
 
+    it.each([GroupMemberStatus.REMOVED, GroupMemberStatus.LEFT, GroupMemberStatus.REJECTED])(
+      'returns membershipStatus "none" when user has a %s row',
+      async (status) => {
+        const staleMember = { groupId: 'group-uuid-2', userId: 'user-uuid', status };
+        mockGroupMembersFindMany
+          .mockResolvedValueOnce([])
+          .mockResolvedValueOnce([])
+          .mockResolvedValueOnce([staleMember]);
+        mockGroupsSelectWhere.mockResolvedValueOnce([{ total: 1 }]);
+        mockGroupsFindMany.mockResolvedValueOnce([mockGroupRow2]);
+        mockAssetsFindMany.mockResolvedValue([mockCoverAssetRow2]);
+
+        const result = await service.searchGroups('user-uuid', baseQuery);
+
+        expect(result.data[0]?.membershipStatus).toBe('none');
+      },
+    );
+
     it('returns correct memberCount based on active members', async () => {
       const memberRow1 = { groupId: 'group-uuid-2' };
       const memberRow2 = { groupId: 'group-uuid-2' };

--- a/apps/api/src/modules/groups/groups.service.spec.ts
+++ b/apps/api/src/modules/groups/groups.service.spec.ts
@@ -14,6 +14,7 @@ import { CloudStorageService } from '@/modules/cloud-storage/cloud-storage.servi
 import { GroupsService } from './groups.service';
 import type { CreateGroupDto } from './dto/create-group.dto';
 import type { UpdateGroupDto } from './dto/update-group.dto';
+import type { SearchGroupsQueryDto } from './dto/search-groups-query.dto';
 import type { AuthenticatedUser } from '@/types/express';
 
 jest.mock('@google-cloud/storage', () => ({
@@ -609,6 +610,233 @@ describe('GroupsService', () => {
       mockCloudStorageDelete.mockRejectedValue(new Error('GCS unavailable'));
 
       await expect(service.deleteGroup(mockUser, 'group-uuid')).resolves.toBeUndefined();
+    });
+  });
+
+  describe('searchGroups', () => {
+    const baseQuery: SearchGroupsQueryDto = { limit: 20, offset: 0 };
+
+    const mockGroupRow2 = {
+      id: 'group-uuid-2',
+      name: 'Beach Crew',
+      description: 'Sun and surf',
+      cover: 'asset-uuid-2',
+      visibility: GroupVisibility.PUBLIC,
+      createdBy: 'other-user-uuid',
+      createdAt: new Date('2026-01-02T00:00:00.000Z'),
+      updatedAt: new Date('2026-01-02T00:00:00.000Z'),
+    };
+
+    const mockCoverAssetRow2 = { ...mockCoverAssetRow, id: 'asset-uuid-2', target: '🏖️' };
+
+    const mockActiveMember = {
+      groupId: 'group-uuid',
+      userId: 'user-uuid',
+      status: GroupMemberStatus.ACTIVE,
+    };
+
+    const mockRequestMember = {
+      groupId: 'group-uuid-2',
+      userId: 'user-uuid',
+      status: GroupMemberStatus.REQUEST,
+    };
+
+    beforeEach(() => {
+      mockAssetResolverResolve.mockResolvedValue(mockResolvedCover);
+    });
+
+    it('returns empty result when no public groups match', async () => {
+      // Call 1: user active memberships (none)
+      mockGroupMembersFindMany.mockResolvedValueOnce([]);
+      // Count query: no matches
+      mockGroupsFindMany.mockResolvedValueOnce([]);
+
+      const result = await service.searchGroups('user-uuid', baseQuery);
+
+      expect(result.data).toHaveLength(0);
+      expect(result.total).toBe(0);
+    });
+
+    it('returns only PUBLIC non-deleted groups', async () => {
+      mockGroupMembersFindMany
+        .mockResolvedValueOnce([]) // active memberships
+        .mockResolvedValueOnce([]) // active member counts
+        .mockResolvedValueOnce([]); // user membership status
+      mockGroupsFindMany
+        .mockResolvedValueOnce([{ id: 'group-uuid-2' }]) // count
+        .mockResolvedValueOnce([mockGroupRow2]); // data
+      mockAssetsFindMany.mockResolvedValue([mockCoverAssetRow2]);
+
+      const result = await service.searchGroups('user-uuid', baseQuery);
+
+      expect(result.total).toBe(1);
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0]?.id).toBe('group-uuid-2');
+    });
+
+    it('excludes groups where user is already an active member', async () => {
+      // User is ACTIVE in group-uuid — it should be excluded from search results
+      mockGroupMembersFindMany
+        .mockResolvedValueOnce([mockActiveMember]) // active memberships → exclude group-uuid
+        .mockResolvedValueOnce([]) // active member counts
+        .mockResolvedValueOnce([]); // user membership status
+      mockGroupsFindMany
+        .mockResolvedValueOnce([{ id: 'group-uuid-2' }]) // count (group-uuid already excluded by DB query)
+        .mockResolvedValueOnce([mockGroupRow2]); // data
+      mockAssetsFindMany.mockResolvedValue([mockCoverAssetRow2]);
+
+      const result = await service.searchGroups('user-uuid', baseQuery);
+
+      expect(result.data.every((g) => g.id !== 'group-uuid')).toBe(true);
+    });
+
+    it('returns membershipStatus "none" when user has no row', async () => {
+      mockGroupMembersFindMany
+        .mockResolvedValueOnce([]) // active memberships
+        .mockResolvedValueOnce([]) // active member counts
+        .mockResolvedValueOnce([]); // user membership status → none
+      mockGroupsFindMany
+        .mockResolvedValueOnce([{ id: 'group-uuid-2' }])
+        .mockResolvedValueOnce([mockGroupRow2]);
+      mockAssetsFindMany.mockResolvedValue([mockCoverAssetRow2]);
+
+      const result = await service.searchGroups('user-uuid', baseQuery);
+
+      expect(result.data[0]?.membershipStatus).toBe('none');
+    });
+
+    it('returns membershipStatus "pending" when user has a REQUEST row', async () => {
+      mockGroupMembersFindMany
+        .mockResolvedValueOnce([]) // active memberships
+        .mockResolvedValueOnce([]) // active member counts
+        .mockResolvedValueOnce([mockRequestMember]); // user membership status → REQUEST
+      mockGroupsFindMany
+        .mockResolvedValueOnce([{ id: 'group-uuid-2' }])
+        .mockResolvedValueOnce([mockGroupRow2]);
+      mockAssetsFindMany.mockResolvedValue([mockCoverAssetRow2]);
+
+      const result = await service.searchGroups('user-uuid', baseQuery);
+
+      expect(result.data[0]?.membershipStatus).toBe('pending');
+    });
+
+    it('returns membershipStatus "pending" when user has an INVITED row', async () => {
+      const invitedMember = { ...mockRequestMember, status: GroupMemberStatus.INVITED };
+      mockGroupMembersFindMany
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([invitedMember]);
+      mockGroupsFindMany
+        .mockResolvedValueOnce([{ id: 'group-uuid-2' }])
+        .mockResolvedValueOnce([mockGroupRow2]);
+      mockAssetsFindMany.mockResolvedValue([mockCoverAssetRow2]);
+
+      const result = await service.searchGroups('user-uuid', baseQuery);
+
+      expect(result.data[0]?.membershipStatus).toBe('pending');
+    });
+
+    it('returns correct memberCount based on active members', async () => {
+      const memberRow1 = { groupId: 'group-uuid-2' };
+      const memberRow2 = { groupId: 'group-uuid-2' };
+      mockGroupMembersFindMany
+        .mockResolvedValueOnce([]) // active memberships
+        .mockResolvedValueOnce([memberRow1, memberRow2]) // active member counts → 2
+        .mockResolvedValueOnce([]); // user membership status
+      mockGroupsFindMany
+        .mockResolvedValueOnce([{ id: 'group-uuid-2' }])
+        .mockResolvedValueOnce([mockGroupRow2]);
+      mockAssetsFindMany.mockResolvedValue([mockCoverAssetRow2]);
+
+      const result = await service.searchGroups('user-uuid', baseQuery);
+
+      expect(result.data[0]?.memberCount).toBe(2);
+    });
+
+    it('returns memberCount 0 when group has no active members', async () => {
+      mockGroupMembersFindMany
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([]) // no active members
+        .mockResolvedValueOnce([]);
+      mockGroupsFindMany
+        .mockResolvedValueOnce([{ id: 'group-uuid-2' }])
+        .mockResolvedValueOnce([mockGroupRow2]);
+      mockAssetsFindMany.mockResolvedValue([mockCoverAssetRow2]);
+
+      const result = await service.searchGroups('user-uuid', baseQuery);
+
+      expect(result.data[0]?.memberCount).toBe(0);
+    });
+
+    it('respects limit and offset pagination', async () => {
+      const paginatedQuery: SearchGroupsQueryDto = { limit: 1, offset: 1 };
+      mockGroupMembersFindMany
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([]);
+      mockGroupsFindMany
+        .mockResolvedValueOnce([{ id: 'group-uuid' }, { id: 'group-uuid-2' }]) // total: 2
+        .mockResolvedValueOnce([mockGroupRow2]); // offset=1 → second group only
+      mockAssetsFindMany.mockResolvedValue([mockCoverAssetRow2]);
+
+      const result = await service.searchGroups('user-uuid', paginatedQuery);
+
+      expect(result.total).toBe(2);
+      expect(result.data).toHaveLength(1);
+    });
+
+    it('returns empty data array when page is beyond total', async () => {
+      const farQuery: SearchGroupsQueryDto = { limit: 20, offset: 100 };
+      mockGroupMembersFindMany.mockResolvedValueOnce([]);
+      mockGroupsFindMany
+        .mockResolvedValueOnce([{ id: 'group-uuid-2' }]) // total: 1
+        .mockResolvedValueOnce([]); // offset=100 → no results
+
+      const result = await service.searchGroups('user-uuid', farQuery);
+
+      expect(result.total).toBe(1);
+      expect(result.data).toHaveLength(0);
+    });
+
+    it('throws NotFoundException when cover asset is missing for a result', async () => {
+      mockGroupMembersFindMany
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([]);
+      mockGroupsFindMany
+        .mockResolvedValueOnce([{ id: 'group-uuid-2' }])
+        .mockResolvedValueOnce([mockGroupRow2]);
+      mockAssetsFindMany.mockResolvedValue([]); // no asset found
+
+      await expect(service.searchGroups('user-uuid', baseQuery)).rejects.toThrow(NotFoundException);
+    });
+
+    it('throws NotFoundException when cover resolution fails', async () => {
+      mockGroupMembersFindMany
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([]);
+      mockGroupsFindMany
+        .mockResolvedValueOnce([{ id: 'group-uuid-2' }])
+        .mockResolvedValueOnce([mockGroupRow2]);
+      mockAssetsFindMany.mockResolvedValue([mockCoverAssetRow2]);
+      mockAssetResolverResolve.mockResolvedValue(null);
+
+      await expect(service.searchGroups('user-uuid', baseQuery)).rejects.toThrow(NotFoundException);
+    });
+
+    it('uses default limit 20 and offset 0 when not provided', async () => {
+      const queryWithDefaults: SearchGroupsQueryDto = {};
+      mockGroupMembersFindMany
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([]);
+      mockGroupsFindMany.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+
+      const result = await service.searchGroups('user-uuid', queryWithDefaults);
+
+      expect(result.total).toBe(0);
+      expect(result.data).toHaveLength(0);
     });
   });
 });

--- a/apps/api/src/modules/groups/groups.service.spec.ts
+++ b/apps/api/src/modules/groups/groups.service.spec.ts
@@ -93,6 +93,9 @@ describe('GroupsService', () => {
   let mockInsertValues: jest.Mock;
   let mockDeleteWhere: jest.Mock;
   let mockTransaction: jest.Mock;
+  let mockGroupsSelectWhere: jest.Mock;
+  let mockGroupsSelectFrom: jest.Mock;
+  let mockGroupsSelect: jest.Mock;
   let mockAssetResolverResolve: jest.Mock;
   let mockCloudStorageDelete: jest.Mock;
   let mockCloudStorageMakePublic: jest.Mock;
@@ -107,6 +110,9 @@ describe('GroupsService', () => {
     mockReturning = jest.fn();
     mockInsertReturning = jest.fn();
     mockDeleteWhere = jest.fn().mockResolvedValue(undefined);
+    mockGroupsSelectWhere = jest.fn().mockResolvedValue([{ total: 0 }]);
+    mockGroupsSelectFrom = jest.fn().mockReturnValue({ where: mockGroupsSelectWhere });
+    mockGroupsSelect = jest.fn().mockReturnValue({ from: mockGroupsSelectFrom });
     mockAssetResolverResolve = jest.fn().mockResolvedValue(mockResolvedCover);
     mockCloudStorageDelete = jest.fn().mockResolvedValue(undefined);
     mockCloudStorageMakePublic = jest.fn().mockResolvedValue(undefined);
@@ -132,6 +138,7 @@ describe('GroupsService', () => {
                 findMany: mockGroupMembersFindMany,
               },
             },
+            select: mockGroupsSelect,
             update: mockUpdate,
             insert: mockInsert,
             delete: mockDelete,
@@ -646,10 +653,8 @@ describe('GroupsService', () => {
     });
 
     it('returns empty result when no public groups match', async () => {
-      // Call 1: user active memberships (none)
       mockGroupMembersFindMany.mockResolvedValueOnce([]);
-      // Count query: no matches
-      mockGroupsFindMany.mockResolvedValueOnce([]);
+      mockGroupsSelectWhere.mockResolvedValueOnce([{ total: 0 }]);
 
       const result = await service.searchGroups('user-uuid', baseQuery);
 
@@ -662,9 +667,8 @@ describe('GroupsService', () => {
         .mockResolvedValueOnce([]) // active memberships
         .mockResolvedValueOnce([]) // active member counts
         .mockResolvedValueOnce([]); // user membership status
-      mockGroupsFindMany
-        .mockResolvedValueOnce([{ id: 'group-uuid-2' }]) // count
-        .mockResolvedValueOnce([mockGroupRow2]); // data
+      mockGroupsSelectWhere.mockResolvedValueOnce([{ total: 1 }]);
+      mockGroupsFindMany.mockResolvedValueOnce([mockGroupRow2]); // data
       mockAssetsFindMany.mockResolvedValue([mockCoverAssetRow2]);
 
       const result = await service.searchGroups('user-uuid', baseQuery);
@@ -680,9 +684,8 @@ describe('GroupsService', () => {
         .mockResolvedValueOnce([mockActiveMember]) // active memberships → exclude group-uuid
         .mockResolvedValueOnce([]) // active member counts
         .mockResolvedValueOnce([]); // user membership status
-      mockGroupsFindMany
-        .mockResolvedValueOnce([{ id: 'group-uuid-2' }]) // count (group-uuid already excluded by DB query)
-        .mockResolvedValueOnce([mockGroupRow2]); // data
+      mockGroupsSelectWhere.mockResolvedValueOnce([{ total: 1 }]);
+      mockGroupsFindMany.mockResolvedValueOnce([mockGroupRow2]); // data
       mockAssetsFindMany.mockResolvedValue([mockCoverAssetRow2]);
 
       const result = await service.searchGroups('user-uuid', baseQuery);
@@ -695,9 +698,8 @@ describe('GroupsService', () => {
         .mockResolvedValueOnce([]) // active memberships
         .mockResolvedValueOnce([]) // active member counts
         .mockResolvedValueOnce([]); // user membership status → none
-      mockGroupsFindMany
-        .mockResolvedValueOnce([{ id: 'group-uuid-2' }])
-        .mockResolvedValueOnce([mockGroupRow2]);
+      mockGroupsSelectWhere.mockResolvedValueOnce([{ total: 1 }]);
+      mockGroupsFindMany.mockResolvedValueOnce([mockGroupRow2]);
       mockAssetsFindMany.mockResolvedValue([mockCoverAssetRow2]);
 
       const result = await service.searchGroups('user-uuid', baseQuery);
@@ -710,9 +712,8 @@ describe('GroupsService', () => {
         .mockResolvedValueOnce([]) // active memberships
         .mockResolvedValueOnce([]) // active member counts
         .mockResolvedValueOnce([mockRequestMember]); // user membership status → REQUEST
-      mockGroupsFindMany
-        .mockResolvedValueOnce([{ id: 'group-uuid-2' }])
-        .mockResolvedValueOnce([mockGroupRow2]);
+      mockGroupsSelectWhere.mockResolvedValueOnce([{ total: 1 }]);
+      mockGroupsFindMany.mockResolvedValueOnce([mockGroupRow2]);
       mockAssetsFindMany.mockResolvedValue([mockCoverAssetRow2]);
 
       const result = await service.searchGroups('user-uuid', baseQuery);
@@ -726,9 +727,8 @@ describe('GroupsService', () => {
         .mockResolvedValueOnce([])
         .mockResolvedValueOnce([])
         .mockResolvedValueOnce([invitedMember]);
-      mockGroupsFindMany
-        .mockResolvedValueOnce([{ id: 'group-uuid-2' }])
-        .mockResolvedValueOnce([mockGroupRow2]);
+      mockGroupsSelectWhere.mockResolvedValueOnce([{ total: 1 }]);
+      mockGroupsFindMany.mockResolvedValueOnce([mockGroupRow2]);
       mockAssetsFindMany.mockResolvedValue([mockCoverAssetRow2]);
 
       const result = await service.searchGroups('user-uuid', baseQuery);
@@ -743,9 +743,8 @@ describe('GroupsService', () => {
         .mockResolvedValueOnce([]) // active memberships
         .mockResolvedValueOnce([memberRow1, memberRow2]) // active member counts → 2
         .mockResolvedValueOnce([]); // user membership status
-      mockGroupsFindMany
-        .mockResolvedValueOnce([{ id: 'group-uuid-2' }])
-        .mockResolvedValueOnce([mockGroupRow2]);
+      mockGroupsSelectWhere.mockResolvedValueOnce([{ total: 1 }]);
+      mockGroupsFindMany.mockResolvedValueOnce([mockGroupRow2]);
       mockAssetsFindMany.mockResolvedValue([mockCoverAssetRow2]);
 
       const result = await service.searchGroups('user-uuid', baseQuery);
@@ -758,9 +757,8 @@ describe('GroupsService', () => {
         .mockResolvedValueOnce([])
         .mockResolvedValueOnce([]) // no active members
         .mockResolvedValueOnce([]);
-      mockGroupsFindMany
-        .mockResolvedValueOnce([{ id: 'group-uuid-2' }])
-        .mockResolvedValueOnce([mockGroupRow2]);
+      mockGroupsSelectWhere.mockResolvedValueOnce([{ total: 1 }]);
+      mockGroupsFindMany.mockResolvedValueOnce([mockGroupRow2]);
       mockAssetsFindMany.mockResolvedValue([mockCoverAssetRow2]);
 
       const result = await service.searchGroups('user-uuid', baseQuery);
@@ -774,9 +772,8 @@ describe('GroupsService', () => {
         .mockResolvedValueOnce([])
         .mockResolvedValueOnce([])
         .mockResolvedValueOnce([]);
-      mockGroupsFindMany
-        .mockResolvedValueOnce([{ id: 'group-uuid' }, { id: 'group-uuid-2' }]) // total: 2
-        .mockResolvedValueOnce([mockGroupRow2]); // offset=1 → second group only
+      mockGroupsSelectWhere.mockResolvedValueOnce([{ total: 2 }]);
+      mockGroupsFindMany.mockResolvedValueOnce([mockGroupRow2]); // offset=1 → second group only
       mockAssetsFindMany.mockResolvedValue([mockCoverAssetRow2]);
 
       const result = await service.searchGroups('user-uuid', paginatedQuery);
@@ -788,9 +785,8 @@ describe('GroupsService', () => {
     it('returns empty data array when page is beyond total', async () => {
       const farQuery: SearchGroupsQueryDto = { limit: 20, offset: 100 };
       mockGroupMembersFindMany.mockResolvedValueOnce([]);
-      mockGroupsFindMany
-        .mockResolvedValueOnce([{ id: 'group-uuid-2' }]) // total: 1
-        .mockResolvedValueOnce([]); // offset=100 → no results
+      mockGroupsSelectWhere.mockResolvedValueOnce([{ total: 1 }]);
+      mockGroupsFindMany.mockResolvedValueOnce([]); // offset=100 → no results
 
       const result = await service.searchGroups('user-uuid', farQuery);
 
@@ -803,9 +799,8 @@ describe('GroupsService', () => {
         .mockResolvedValueOnce([])
         .mockResolvedValueOnce([])
         .mockResolvedValueOnce([]);
-      mockGroupsFindMany
-        .mockResolvedValueOnce([{ id: 'group-uuid-2' }])
-        .mockResolvedValueOnce([mockGroupRow2]);
+      mockGroupsSelectWhere.mockResolvedValueOnce([{ total: 1 }]);
+      mockGroupsFindMany.mockResolvedValueOnce([mockGroupRow2]);
       mockAssetsFindMany.mockResolvedValue([]); // no asset found
 
       await expect(service.searchGroups('user-uuid', baseQuery)).rejects.toThrow(NotFoundException);
@@ -816,9 +811,8 @@ describe('GroupsService', () => {
         .mockResolvedValueOnce([])
         .mockResolvedValueOnce([])
         .mockResolvedValueOnce([]);
-      mockGroupsFindMany
-        .mockResolvedValueOnce([{ id: 'group-uuid-2' }])
-        .mockResolvedValueOnce([mockGroupRow2]);
+      mockGroupsSelectWhere.mockResolvedValueOnce([{ total: 1 }]);
+      mockGroupsFindMany.mockResolvedValueOnce([mockGroupRow2]);
       mockAssetsFindMany.mockResolvedValue([mockCoverAssetRow2]);
       mockAssetResolverResolve.mockResolvedValue(null);
 
@@ -827,11 +821,8 @@ describe('GroupsService', () => {
 
     it('uses default limit 20 and offset 0 when not provided', async () => {
       const queryWithDefaults: SearchGroupsQueryDto = {};
-      mockGroupMembersFindMany
-        .mockResolvedValueOnce([])
-        .mockResolvedValueOnce([])
-        .mockResolvedValueOnce([]);
-      mockGroupsFindMany.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+      mockGroupMembersFindMany.mockResolvedValueOnce([]);
+      mockGroupsSelectWhere.mockResolvedValueOnce([{ total: 0 }]);
 
       const result = await service.searchGroups('user-uuid', queryWithDefaults);
 

--- a/apps/api/src/modules/groups/groups.service.ts
+++ b/apps/api/src/modules/groups/groups.service.ts
@@ -1,7 +1,7 @@
 import { ForbiddenException, Inject, Injectable, NotFoundException } from '@nestjs/common';
-import { and, eq, inArray, isNull } from 'drizzle-orm';
+import { and, eq, ilike, inArray, isNull, notInArray } from 'drizzle-orm';
 
-import { GroupMemberStatus, GroupRole } from '@chamuco/shared-types';
+import { GroupMemberStatus, GroupRole, GroupVisibility } from '@chamuco/shared-types';
 import { DRIZZLE_CLIENT, DrizzleClient } from '@/database/drizzle.provider';
 import { assets } from '@/modules/assets/schema/assets.schema';
 import { AssetResolverService } from '@/modules/assets/asset-resolver.service';
@@ -15,6 +15,8 @@ import { groupMemberStats } from './schema/group-member-stats.schema';
 import type { CreateGroupDto } from './dto/create-group.dto';
 import type { UpdateGroupDto } from './dto/update-group.dto';
 import type { GroupResponseDto } from './dto/group-response.dto';
+import type { SearchGroupsQueryDto } from './dto/search-groups-query.dto';
+import type { GroupSearchResponseDto, MembershipStatus } from './dto/group-search-result.dto';
 
 @Injectable()
 export class GroupsService {
@@ -155,6 +157,115 @@ export class GroupsService {
         };
       }),
     );
+  }
+
+  async searchGroups(userId: string, query: SearchGroupsQueryDto): Promise<GroupSearchResponseDto> {
+    const limit = query.limit ?? 20;
+    const offset = query.offset ?? 0;
+
+    // Exclude groups where the user is already an active member
+    const activeMemberships = await this.db.query.groupMembers.findMany({
+      where: and(
+        eq(groupMembers.userId, userId),
+        eq(groupMembers.status, GroupMemberStatus.ACTIVE),
+      ),
+      columns: { groupId: true },
+    });
+    const excludedIds = activeMemberships.map((m) => m.groupId);
+
+    const conditions = and(
+      eq(groups.visibility, GroupVisibility.PUBLIC),
+      isNull(groups.deletedAt),
+      ...(excludedIds.length > 0 ? [notInArray(groups.id, excludedIds)] : []),
+      ...(query.q ? [ilike(groups.name, `%${query.q}%`)] : []),
+    );
+
+    // Count total matching groups
+    const allMatches = await this.db.query.groups.findMany({
+      where: conditions,
+      columns: { id: true },
+    });
+    const total = allMatches.length;
+
+    if (total === 0) return { data: [], total: 0 };
+
+    // Fetch the requested page
+    const groupRows = await this.db.query.groups.findMany({
+      where: conditions,
+      limit,
+      offset,
+      orderBy: (t, { asc }) => [asc(t.name)],
+    });
+
+    if (groupRows.length === 0) return { data: [], total };
+
+    const groupIds = groupRows.map((g) => g.id);
+
+    // Batch-load active member counts
+    const activeMembers = await this.db.query.groupMembers.findMany({
+      where: and(
+        inArray(groupMembers.groupId, groupIds),
+        eq(groupMembers.status, GroupMemberStatus.ACTIVE),
+      ),
+      columns: { groupId: true },
+    });
+    const memberCountMap = new Map<string, number>();
+    for (const row of activeMembers) {
+      memberCountMap.set(row.groupId, (memberCountMap.get(row.groupId) ?? 0) + 1);
+    }
+
+    // Get the user's membership status for each group in the page
+    const userMemberships = await this.db.query.groupMembers.findMany({
+      where: and(inArray(groupMembers.groupId, groupIds), eq(groupMembers.userId, userId)),
+      columns: { groupId: true, status: true },
+    });
+    const membershipStatusMap = new Map(userMemberships.map((m) => [m.groupId, m.status]));
+
+    // Resolve cover assets
+    const coverIds = groupRows.map((g) => g.cover).filter((id): id is string => id !== null);
+    const coverAssets =
+      coverIds.length > 0
+        ? await this.db.query.assets.findMany({ where: inArray(assets.id, coverIds) })
+        : [];
+    const assetMap = new Map(coverAssets.map((a) => [a.id, a]));
+
+    const data = await Promise.all(
+      groupRows.map(async (group) => {
+        if (!group.cover) throw new NotFoundException('Group cover asset not found');
+        const coverRow = assetMap.get(group.cover);
+        if (!coverRow) throw new NotFoundException('Group cover asset not found');
+        const resolvedCover = await this.assetResolver.resolve(assetRowToAsset(coverRow));
+        if (!resolvedCover) throw new NotFoundException('Failed to resolve group cover');
+
+        const rawStatus = membershipStatusMap.get(group.id);
+        let membershipStatus: MembershipStatus;
+        if (!rawStatus) {
+          membershipStatus = 'none';
+        } else if (
+          rawStatus === GroupMemberStatus.REQUEST ||
+          rawStatus === GroupMemberStatus.INVITED
+        ) {
+          membershipStatus = 'pending';
+        } else {
+          membershipStatus = 'active';
+        }
+
+        return {
+          id: group.id,
+          name: group.name,
+          description: group.description,
+          coverUrl: resolvedCover.url,
+          visibility: group.visibility,
+          createdBy: group.createdBy,
+          createdAt: group.createdAt.toISOString(),
+          updatedAt: group.updatedAt.toISOString(),
+          memberCount: memberCountMap.get(group.id) ?? 0,
+          membershipStatus,
+        };
+      }),
+    );
+
+    return { data, total };
   }
 
   async updateGroup(

--- a/apps/api/src/modules/groups/groups.service.ts
+++ b/apps/api/src/modules/groups/groups.service.ts
@@ -1,7 +1,12 @@
 import { ForbiddenException, Inject, Injectable, NotFoundException } from '@nestjs/common';
-import { and, eq, ilike, inArray, isNull, notInArray } from 'drizzle-orm';
+import { and, count, eq, ilike, inArray, isNull, notInArray } from 'drizzle-orm';
 
-import { GroupMemberStatus, GroupRole, GroupVisibility } from '@chamuco/shared-types';
+import {
+  GroupMemberStatus,
+  GroupRole,
+  GroupVisibility,
+  MembershipStatus,
+} from '@chamuco/shared-types';
 import { DRIZZLE_CLIENT, DrizzleClient } from '@/database/drizzle.provider';
 import { assets } from '@/modules/assets/schema/assets.schema';
 import { AssetResolverService } from '@/modules/assets/asset-resolver.service';
@@ -16,7 +21,7 @@ import type { CreateGroupDto } from './dto/create-group.dto';
 import type { UpdateGroupDto } from './dto/update-group.dto';
 import type { GroupResponseDto } from './dto/group-response.dto';
 import type { SearchGroupsQueryDto } from './dto/search-groups-query.dto';
-import type { GroupSearchResponseDto, MembershipStatus } from './dto/group-search-result.dto';
+import type { GroupSearchResponseDto } from './dto/group-search-result.dto';
 
 @Injectable()
 export class GroupsService {
@@ -181,11 +186,8 @@ export class GroupsService {
     );
 
     // Count total matching groups
-    const allMatches = await this.db.query.groups.findMany({
-      where: conditions,
-      columns: { id: true },
-    });
-    const total = allMatches.length;
+    const countResult = await this.db.select({ total: count() }).from(groups).where(conditions);
+    const total = countResult[0]?.total ?? 0;
 
     if (total === 0) return { data: [], total: 0 };
 

--- a/apps/api/src/modules/groups/groups.service.ts
+++ b/apps/api/src/modules/groups/groups.service.ts
@@ -241,7 +241,12 @@ export class GroupsService {
 
         const rawStatus = membershipStatusMap.get(group.id);
         let membershipStatus: MembershipStatus;
-        if (!rawStatus) {
+        if (
+          !rawStatus ||
+          rawStatus === GroupMemberStatus.REMOVED ||
+          rawStatus === GroupMemberStatus.LEFT ||
+          rawStatus === GroupMemberStatus.REJECTED
+        ) {
           membershipStatus = 'none';
         } else if (
           rawStatus === GroupMemberStatus.REQUEST ||

--- a/apps/web/src/app/explore/groups/page.test.tsx
+++ b/apps/web/src/app/explore/groups/page.test.tsx
@@ -65,6 +65,14 @@ describe('ExploreGroupsPage', () => {
     expect(screen.getByText('search.empty')).toBeInTheDocument();
   });
 
+  it('shows loading state while user session is loading', () => {
+    mocks.mockUseUser.mockReturnValue({ appUser: null, isLoading: true });
+
+    render(<ExploreGroupsPage />);
+
+    expect(screen.queryByTestId('discovery-card')).not.toBeInTheDocument();
+  });
+
   it('shows loading state while fetching', async () => {
     mocks.mockUseGroupSearch.mockReturnValue({ results: [], total: 0, isLoading: true });
 

--- a/apps/web/src/app/explore/groups/page.test.tsx
+++ b/apps/web/src/app/explore/groups/page.test.tsx
@@ -1,0 +1,118 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { GroupSearchResult } from '@/types/group';
+import { GroupVisibility } from '@chamuco/shared-types';
+
+const mocks = vi.hoisted(() => ({
+  mockUseGroupSearch: vi.fn(),
+  mockUseUser: vi.fn(),
+  mockGroupDiscoveryCard: vi.fn(),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, unknown>) =>
+      opts ? `${key}:${JSON.stringify(opts)}` : key,
+  }),
+}));
+
+vi.mock('@/hooks/useGroupSearch', () => ({
+  useGroupSearch: mocks.mockUseGroupSearch,
+}));
+
+vi.mock('@/hooks/useUser', () => ({
+  useUser: mocks.mockUseUser,
+}));
+
+vi.mock('@/components/groups/GroupDiscoveryCard', () => ({
+  GroupDiscoveryCard: ({ group }: { group: GroupSearchResult }) => (
+    <div data-testid="discovery-card">{group.name}</div>
+  ),
+}));
+
+import ExploreGroupsPage from './page';
+
+const makeGroup = (overrides: Partial<GroupSearchResult> = {}): GroupSearchResult => ({
+  id: 'g1',
+  name: 'Mountain Crew',
+  description: null,
+  coverUrl: 'https://example.com/cover.svg',
+  visibility: GroupVisibility.PUBLIC,
+  createdBy: 'user-1',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+  memberCount: 3,
+  membershipStatus: 'none',
+  ...overrides,
+});
+
+describe('ExploreGroupsPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.mockUseUser.mockReturnValue({ appUser: { id: 'current-user' }, isLoading: false });
+    mocks.mockUseGroupSearch.mockReturnValue({ results: [], total: 0, isLoading: false });
+  });
+
+  it('renders search input', () => {
+    render(<ExploreGroupsPage />);
+
+    expect(screen.getByRole('searchbox')).toBeInTheDocument();
+  });
+
+  it('shows empty state when query is blank', () => {
+    render(<ExploreGroupsPage />);
+
+    expect(screen.getByText('search.empty')).toBeInTheDocument();
+  });
+
+  it('shows loading state while fetching', async () => {
+    mocks.mockUseGroupSearch.mockReturnValue({ results: [], total: 0, isLoading: true });
+
+    const user = userEvent.setup();
+    render(<ExploreGroupsPage />);
+    await user.type(screen.getByRole('searchbox'), 'mountain');
+
+    expect(screen.getByText('search.loading')).toBeInTheDocument();
+  });
+
+  it('shows no-results state when query has results count zero', async () => {
+    // Simulate: query typed, not loading, no results
+    mocks.mockUseGroupSearch.mockReturnValue({ results: [], total: 0, isLoading: false });
+
+    const user = userEvent.setup();
+    render(<ExploreGroupsPage />);
+    await user.type(screen.getByRole('searchbox'), 'zzznomatch');
+
+    expect(screen.getByText(/search\.noResults/)).toBeInTheDocument();
+  });
+
+  it('renders group cards when results are present', async () => {
+    mocks.mockUseGroupSearch.mockReturnValue({
+      results: [makeGroup(), makeGroup({ id: 'g2', name: 'Beach Crew' })],
+      total: 2,
+      isLoading: false,
+    });
+
+    const user = userEvent.setup();
+    render(<ExploreGroupsPage />);
+    await user.type(screen.getByRole('searchbox'), 'crew');
+
+    expect(screen.getAllByTestId('discovery-card')).toHaveLength(2);
+    expect(screen.getByText('Mountain Crew')).toBeInTheDocument();
+    expect(screen.getByText('Beach Crew')).toBeInTheDocument();
+  });
+
+  it('shows result count when results are present', async () => {
+    mocks.mockUseGroupSearch.mockReturnValue({
+      results: [makeGroup()],
+      total: 42,
+      isLoading: false,
+    });
+
+    const user = userEvent.setup();
+    render(<ExploreGroupsPage />);
+    await user.type(screen.getByRole('searchbox'), 'crew');
+
+    expect(screen.getByText(/search\.resultCount/)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/app/explore/groups/page.tsx
+++ b/apps/web/src/app/explore/groups/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { GroupDiscoveryCard } from '@/components/groups/GroupDiscoveryCard';
@@ -10,13 +10,18 @@ import type { MembershipStatus, GroupSearchResult } from '@/types/group';
 
 export default function ExploreGroupsPage() {
   const { t } = useTranslation('groups');
-  const { appUser } = useUser();
+  const { appUser, isLoading: isUserLoading } = useUser();
   const [query, setQuery] = useState('');
 
-  const { results: fetchedResults, total, isLoading } = useGroupSearch(query);
+  const { results: fetchedResults, total, isLoading: isSearchLoading } = useGroupSearch(query);
+  const isLoading = isSearchLoading || isUserLoading;
 
   // Track local status overrides after join/withdraw actions
   const [statusOverrides, setStatusOverrides] = useState<Map<string, MembershipStatus>>(new Map());
+
+  useEffect(() => {
+    setStatusOverrides(new Map());
+  }, [query]);
 
   const handleStatusChange = (groupId: string, newStatus: MembershipStatus) => {
     setStatusOverrides((prev) => new Map(prev).set(groupId, newStatus));

--- a/apps/web/src/app/explore/groups/page.tsx
+++ b/apps/web/src/app/explore/groups/page.tsx
@@ -48,7 +48,7 @@ export default function ExploreGroupsPage() {
         aria-label={t('search.placeholder')}
       />
 
-      {isLoading && <p className="text-sm text-muted-foreground">{t('search.loading')}</p>}
+      {isSearchLoading && <p className="text-sm text-muted-foreground">{t('search.loading')}</p>}
 
       {isEmpty && !isLoading && (
         <p className="text-sm text-muted-foreground">{t('search.empty')}</p>

--- a/apps/web/src/app/explore/groups/page.tsx
+++ b/apps/web/src/app/explore/groups/page.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { GroupDiscoveryCard } from '@/components/groups/GroupDiscoveryCard';
+import { useGroupSearch } from '@/hooks/useGroupSearch';
+import { useUser } from '@/hooks/useUser';
+import type { MembershipStatus, GroupSearchResult } from '@/types/group';
+
+export default function ExploreGroupsPage() {
+  const { t } = useTranslation('groups');
+  const { appUser } = useUser();
+  const [query, setQuery] = useState('');
+
+  const { results: fetchedResults, total, isLoading } = useGroupSearch(query);
+
+  // Track local status overrides after join/withdraw actions
+  const [statusOverrides, setStatusOverrides] = useState<Map<string, MembershipStatus>>(new Map());
+
+  const handleStatusChange = (groupId: string, newStatus: MembershipStatus) => {
+    setStatusOverrides((prev) => new Map(prev).set(groupId, newStatus));
+  };
+
+  const results: GroupSearchResult[] = fetchedResults.map((group) => ({
+    ...group,
+    membershipStatus: statusOverrides.get(group.id) ?? group.membershipStatus,
+  }));
+
+  const isEmpty = !query.trim();
+  const noResults = !isEmpty && !isLoading && results.length === 0;
+
+  return (
+    <div className="p-8">
+      <h1 className="text-3xl font-bold mb-6">{t('search.pageTitle')}</h1>
+
+      <input
+        type="search"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        placeholder={t('search.placeholder')}
+        className="w-full rounded-lg border border-border bg-background px-4 py-2 text-sm outline-none focus:ring-2 focus:ring-primary mb-6"
+        aria-label={t('search.placeholder')}
+      />
+
+      {isLoading && <p className="text-sm text-muted-foreground">{t('search.loading')}</p>}
+
+      {isEmpty && !isLoading && (
+        <p className="text-sm text-muted-foreground">{t('search.empty')}</p>
+      )}
+
+      {noResults && (
+        <p className="text-sm text-muted-foreground">{t('search.noResults', { query })}</p>
+      )}
+
+      {!isEmpty && !isLoading && results.length > 0 && (
+        <>
+          <p className="mb-3 text-sm text-muted-foreground">
+            {t('search.resultCount', { count: total })}
+          </p>
+          <div className="flex flex-col gap-3">
+            {results.map((group) => (
+              <GroupDiscoveryCard
+                key={group.id}
+                group={group}
+                currentUserId={appUser?.id ?? ''}
+                onStatusChange={handleStatusChange}
+              />
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/explore/page.tsx
+++ b/apps/web/src/app/explore/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import Link from 'next/link';
 import { useTranslation } from 'react-i18next';
 
 export default function ExplorePage() {
@@ -8,7 +9,17 @@ export default function ExplorePage() {
   return (
     <div className="p-8">
       <h1 className="text-3xl font-bold mb-4">{t('title')}</h1>
-      <p className="text-muted-foreground">{t('subtitle')}</p>
+      <p className="text-muted-foreground mb-8">{t('subtitle')}</p>
+
+      <div className="flex flex-col gap-4 sm:flex-row">
+        <Link
+          href="/explore/groups"
+          className="flex flex-col gap-1 rounded-xl border border-border bg-card p-6 transition-colors hover:bg-muted/50"
+        >
+          <span className="text-lg font-semibold">{t('discoverGroups')}</span>
+          <span className="text-sm text-muted-foreground">{t('discoverGroupsSubtitle')}</span>
+        </Link>
+      </div>
     </div>
   );
 }

--- a/apps/web/src/app/groups/page.tsx
+++ b/apps/web/src/app/groups/page.tsx
@@ -33,12 +33,20 @@ export default function GroupsPage() {
     <div className="p-8">
       <div className="flex items-center justify-between mb-6">
         <h1 className="text-3xl font-bold">{t('title')}</h1>
-        <Link
-          href="/groups/new"
-          className="inline-flex items-center justify-center rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
-        >
-          {t('createGroup')}
-        </Link>
+        <div className="flex items-center gap-2">
+          <Link
+            href="/explore/groups"
+            className="inline-flex items-center justify-center rounded-lg border border-border px-4 py-2 text-sm font-medium transition-colors hover:bg-muted"
+          >
+            {t('search.searchGroups')}
+          </Link>
+          <Link
+            href="/groups/new"
+            className="inline-flex items-center justify-center rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+          >
+            {t('createGroup')}
+          </Link>
+        </div>
       </div>
 
       <InvitationsSection />

--- a/apps/web/src/components/groups/GroupDiscoveryCard.test.tsx
+++ b/apps/web/src/components/groups/GroupDiscoveryCard.test.tsx
@@ -5,7 +5,6 @@ import type { ReactNode } from 'react';
 import type { GroupSearchResult } from '@/types/group';
 
 const mocks = vi.hoisted(() => ({
-  mockJoinRequestButton: vi.fn(),
   mockOnStatusChange: vi.fn(),
 }));
 

--- a/apps/web/src/components/groups/GroupDiscoveryCard.test.tsx
+++ b/apps/web/src/components/groups/GroupDiscoveryCard.test.tsx
@@ -1,0 +1,147 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { GroupVisibility } from '@chamuco/shared-types';
+import type { ReactNode } from 'react';
+import type { GroupSearchResult } from '@/types/group';
+
+const mocks = vi.hoisted(() => ({
+  mockJoinRequestButton: vi.fn(),
+  mockOnStatusChange: vi.fn(),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, unknown>) =>
+      opts ? `${key}:${JSON.stringify(opts)}` : key,
+  }),
+}));
+
+vi.mock('next/link', () => ({
+  default: ({ href, children }: { href: string; children: ReactNode }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+vi.mock('@/components/groups/members/JoinRequestButton', () => ({
+  JoinRequestButton: ({
+    hasPendingRequest,
+    onSuccess,
+  }: {
+    hasPendingRequest: boolean;
+    onSuccess: () => void;
+  }) => <button onClick={onSuccess}>{hasPendingRequest ? 'withdraw' : 'join'}</button>,
+}));
+
+import { GroupDiscoveryCard } from './GroupDiscoveryCard';
+
+const makeGroup = (overrides: Partial<GroupSearchResult> = {}): GroupSearchResult => ({
+  id: 'g1',
+  name: 'Mountain Crew',
+  description: 'Hikers welcome',
+  coverUrl: 'https://example.com/cover.svg',
+  visibility: GroupVisibility.PUBLIC,
+  createdBy: 'user-1',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+  memberCount: 5,
+  membershipStatus: 'none',
+  ...overrides,
+});
+
+describe('GroupDiscoveryCard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders group name and description', () => {
+    render(
+      <GroupDiscoveryCard
+        group={makeGroup()}
+        currentUserId="current-user"
+        onStatusChange={mocks.mockOnStatusChange}
+      />,
+    );
+
+    expect(screen.getByText('Mountain Crew')).toBeInTheDocument();
+    expect(screen.getByText('Hikers welcome')).toBeInTheDocument();
+  });
+
+  it('renders member count', () => {
+    render(
+      <GroupDiscoveryCard
+        group={makeGroup({ memberCount: 7 })}
+        currentUserId="current-user"
+        onStatusChange={mocks.mockOnStatusChange}
+      />,
+    );
+
+    expect(screen.getByText(/search\.memberCount/)).toBeInTheDocument();
+  });
+
+  it('renders join button when membershipStatus is none', () => {
+    render(
+      <GroupDiscoveryCard
+        group={makeGroup({ membershipStatus: 'none' })}
+        currentUserId="current-user"
+        onStatusChange={mocks.mockOnStatusChange}
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: 'join' })).toBeInTheDocument();
+  });
+
+  it('renders withdraw button when membershipStatus is pending', () => {
+    render(
+      <GroupDiscoveryCard
+        group={makeGroup({ membershipStatus: 'pending' })}
+        currentUserId="current-user"
+        onStatusChange={mocks.mockOnStatusChange}
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: 'withdraw' })).toBeInTheDocument();
+  });
+
+  it('renders view link when membershipStatus is active', () => {
+    render(
+      <GroupDiscoveryCard
+        group={makeGroup({ membershipStatus: 'active' })}
+        currentUserId="current-user"
+        onStatusChange={mocks.mockOnStatusChange}
+      />,
+    );
+
+    expect(screen.getByRole('link', { name: 'detail.view' })).toBeInTheDocument();
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('calls onStatusChange with pending when join is clicked from none', async () => {
+    const user = userEvent.setup();
+    render(
+      <GroupDiscoveryCard
+        group={makeGroup({ membershipStatus: 'none' })}
+        currentUserId="current-user"
+        onStatusChange={mocks.mockOnStatusChange}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'join' }));
+
+    expect(mocks.mockOnStatusChange).toHaveBeenCalledWith('g1', 'pending');
+  });
+
+  it('calls onStatusChange with none when withdraw is clicked from pending', async () => {
+    const user = userEvent.setup();
+    render(
+      <GroupDiscoveryCard
+        group={makeGroup({ membershipStatus: 'pending' })}
+        currentUserId="current-user"
+        onStatusChange={mocks.mockOnStatusChange}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'withdraw' }));
+
+    expect(mocks.mockOnStatusChange).toHaveBeenCalledWith('g1', 'none');
+  });
+});

--- a/apps/web/src/components/groups/GroupDiscoveryCard.tsx
+++ b/apps/web/src/components/groups/GroupDiscoveryCard.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import Link from 'next/link';
+import { useTranslation } from 'react-i18next';
+
+import { JoinRequestButton } from '@/components/groups/members/JoinRequestButton';
+import type { GroupSearchResult, MembershipStatus } from '@/types/group';
+
+interface GroupDiscoveryCardProps {
+  group: GroupSearchResult;
+  currentUserId: string;
+  onStatusChange: (groupId: string, newStatus: MembershipStatus) => void;
+}
+
+export function GroupDiscoveryCard({
+  group,
+  currentUserId,
+  onStatusChange,
+}: GroupDiscoveryCardProps) {
+  const { t } = useTranslation('groups');
+
+  return (
+    <div className="flex items-center gap-4 rounded-xl border border-border bg-card p-4">
+      <div className="size-14 shrink-0 overflow-hidden rounded-lg bg-muted flex items-center justify-center">
+        <img src={group.coverUrl} alt="" className="size-full object-cover" />
+      </div>
+
+      <div className="min-w-0 flex-1">
+        <p className="truncate font-semibold">{group.name}</p>
+        {group.description && (
+          <p className="mt-0.5 truncate text-sm text-muted-foreground">{group.description}</p>
+        )}
+        <p className="mt-0.5 text-xs text-muted-foreground">
+          {t('search.memberCount', { count: group.memberCount })}
+        </p>
+      </div>
+
+      <div className="shrink-0">
+        {group.membershipStatus === 'active' ? (
+          <Link
+            href={`/groups/${group.id}`}
+            className="inline-flex items-center justify-center rounded-lg border border-border px-3 py-1.5 text-sm font-medium transition-colors hover:bg-muted"
+          >
+            {t('detail.view')}
+          </Link>
+        ) : (
+          <JoinRequestButton
+            groupId={group.id}
+            userId={currentUserId}
+            hasPendingRequest={group.membershipStatus === 'pending'}
+            onSuccess={() =>
+              onStatusChange(group.id, group.membershipStatus === 'none' ? 'pending' : 'none')
+            }
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/groups/GroupDiscoveryCard.tsx
+++ b/apps/web/src/components/groups/GroupDiscoveryCard.tsx
@@ -22,7 +22,7 @@ export function GroupDiscoveryCard({
   return (
     <div className="flex items-center gap-4 rounded-xl border border-border bg-card p-4">
       <div className="size-14 shrink-0 overflow-hidden rounded-lg bg-muted flex items-center justify-center">
-        <img src={group.coverUrl} alt="" className="size-full object-cover" />
+        <img src={group.coverUrl} alt={group.name} className="size-full object-cover" />
       </div>
 
       <div className="min-w-0 flex-1">

--- a/apps/web/src/hooks/useGroupSearch.ts
+++ b/apps/web/src/hooks/useGroupSearch.ts
@@ -1,0 +1,49 @@
+import axios from 'axios';
+import { useEffect, useState } from 'react';
+
+import { apiClient } from '@/services/api-client';
+import type { GroupSearchResponse, GroupSearchResult } from '@/types/group';
+
+export function useGroupSearch(query: string, limit = 20, offset = 0) {
+  const [results, setResults] = useState<GroupSearchResult[]>([]);
+  const [total, setTotal] = useState(0);
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    const controller = new AbortController();
+
+    if (!query.trim()) {
+      setResults([]);
+      setTotal(0);
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      setIsLoading(true);
+
+      apiClient
+        .get<GroupSearchResponse>('/v1/groups/search', {
+          params: { q: query, limit, offset },
+          signal: controller.signal,
+        })
+        .then((res) => {
+          setResults(res.data.data);
+          setTotal(res.data.total);
+        })
+        .catch((err: unknown) => {
+          if (!axios.isCancel(err)) {
+            setResults([]);
+            setTotal(0);
+          }
+        })
+        .finally(() => setIsLoading(false));
+    }, 300);
+
+    return () => {
+      clearTimeout(timer);
+      controller.abort();
+    };
+  }, [query, limit, offset]);
+
+  return { results, total, isLoading };
+}

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -321,7 +321,20 @@
     },
     "detail": {
       "noGroups": "You don't have any groups yet",
-      "createFirst": "Create your first group to start organizing trips"
+      "createFirst": "Create your first group to start organizing trips",
+      "view": "View"
+    },
+    "search": {
+      "pageTitle": "Discover Groups",
+      "searchGroups": "Search Groups",
+      "placeholder": "Search groups...",
+      "empty": "Search for public groups to join",
+      "loading": "Searching...",
+      "noResults": "No groups found for \"{{query}}\"",
+      "resultCount": "{{count}} group found",
+      "resultCount_other": "{{count}} groups found",
+      "memberCount": "{{count}} member",
+      "memberCount_other": "{{count}} members"
     },
     "settings": {
       "title": "Group settings",
@@ -813,6 +826,7 @@
     "subtitle": "Discover new destinations and travel groups",
     "discoverTrips": "Discover Trips",
     "discoverGroups": "Discover Groups",
+    "discoverGroupsSubtitle": "Search and join public travel groups",
     "popularDestinations": "Popular Destinations",
     "featuredTrips": "Featured Trips"
   },

--- a/apps/web/src/locales/es.json
+++ b/apps/web/src/locales/es.json
@@ -321,7 +321,20 @@
     },
     "detail": {
       "noGroups": "Aún no tienes grupos",
-      "createFirst": "Crea tu primer grupo para empezar a organizar viajes"
+      "createFirst": "Crea tu primer grupo para empezar a organizar viajes",
+      "view": "Ver"
+    },
+    "search": {
+      "pageTitle": "Descubrir Grupos",
+      "searchGroups": "Buscar Grupos",
+      "placeholder": "Buscar grupos...",
+      "empty": "Busca grupos públicos para unirte",
+      "loading": "Buscando...",
+      "noResults": "No se encontraron grupos para \"{{query}}\"",
+      "resultCount": "{{count}} grupo encontrado",
+      "resultCount_other": "{{count}} grupos encontrados",
+      "memberCount": "{{count}} miembro",
+      "memberCount_other": "{{count}} miembros"
     },
     "settings": {
       "title": "Configuración del grupo",
@@ -813,6 +826,7 @@
     "subtitle": "Descubre nuevos destinos y grupos de viaje",
     "discoverTrips": "Descubrir Viajes",
     "discoverGroups": "Descubrir Grupos",
+    "discoverGroupsSubtitle": "Busca y únete a grupos de viaje públicos",
     "popularDestinations": "Destinos Populares",
     "featuredTrips": "Viajes Destacados"
   },

--- a/apps/web/src/types/group.ts
+++ b/apps/web/src/types/group.ts
@@ -3,6 +3,7 @@ import type {
   GroupMemberTier,
   GroupRole,
   GroupVisibility,
+  MembershipStatus,
 } from '@chamuco/shared-types';
 
 export interface Group {
@@ -44,7 +45,7 @@ export interface GroupInvitation {
   initiatedAt: string;
 }
 
-export type MembershipStatus = 'none' | 'pending' | 'active';
+export type { MembershipStatus };
 
 export interface GroupSearchResult extends Group {
   memberCount: number;

--- a/apps/web/src/types/group.ts
+++ b/apps/web/src/types/group.ts
@@ -43,3 +43,15 @@ export interface GroupInvitation {
   };
   initiatedAt: string;
 }
+
+export type MembershipStatus = 'none' | 'pending' | 'active';
+
+export interface GroupSearchResult extends Group {
+  memberCount: number;
+  membershipStatus: MembershipStatus;
+}
+
+export interface GroupSearchResponse {
+  data: GroupSearchResult[];
+  total: number;
+}

--- a/package.json
+++ b/package.json
@@ -48,5 +48,5 @@
     "node": ">=22.0.0",
     "pnpm": ">=10.0.0"
   },
-  "packageManager": "pnpm@11.1.1"
+  "packageManager": "pnpm@11.1.3"
 }

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -3,3 +3,4 @@
 
 export * from './enums';
 export * from './data';
+export * from './types';

--- a/packages/shared-types/src/types/index.ts
+++ b/packages/shared-types/src/types/index.ts
@@ -1,0 +1,1 @@
+export * from './membership-status';

--- a/packages/shared-types/src/types/membership-status.ts
+++ b/packages/shared-types/src/types/membership-status.ts
@@ -1,0 +1,1 @@
+export type MembershipStatus = 'none' | 'pending' | 'active';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3822,8 +3822,8 @@ packages:
   brace-expansion@2.1.0:
     resolution: {integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==}
 
-  brace-expansion@5.0.5:
-    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
     engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
@@ -11342,7 +11342,7 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.5:
+  brace-expansion@5.0.6:
     dependencies:
       balanced-match: 4.0.4
 
@@ -13980,7 +13980,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.5
+      brace-expansion: 5.0.6
 
   minimatch@3.1.5:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -25,6 +25,7 @@ catalog:
 minimumReleaseAgeExclude:
   - '@protobufjs/utf8@1.1.1'
   - protobufjs@8.0.2
+  - brace-expansion@5.0.6
 overrides:
   cross-spawn: '>=6.0.6'
   glob: '>=10.5.0'


### PR DESCRIPTION
## Summary

Users had no way to find and join public groups. This PR adds a dedicated search endpoint and the full explore/search UI, keeping the existing "my groups" flow untouched.

## Changes

**Backend**
- `GET /v1/groups/search?q=&limit=&offset=` — returns paginated `PUBLIC` groups filtered by name (ILIKE), excluding groups the caller already belongs to; each result includes `memberCount` and `membershipStatus` (`none` | `pending` | `active`)
- New DTOs: `SearchGroupsQueryDto`, `GroupSearchResultDto`, `GroupSearchResponseDto` — fully decorated with OpenAPI annotations
- `GroupsService.searchGroups` — batches member counts and user membership status in O(1) extra queries per page (no N+1)
- Endpoint placed before `GET :id` to avoid route shadowing

**Frontend**
- `useGroupSearch` hook — 300ms debounce, AbortController cancellation, mirrors `useCitySearch` pattern
- `GroupDiscoveryCard` — cover + name + description + member count + context-aware CTA (join / pending+withdraw / view), reuses the existing `JoinRequestButton`
- `/explore/groups` page — search input, empty state, loading state, no-results state, optimistic status override after join/withdraw
- `/explore` page updated with "Discover Groups" card linking to the new route
- "Search Groups" secondary button added next to "Create Group" on `/groups`
- i18n keys added to `groups.search.*` and `explore.discoverGroupsSubtitle` (en + es)

**Tests**
- 11 new backend unit tests covering filter logic, pagination, membership status variants, and edge cases (>90% coverage on new code)
- 7 component tests for `GroupDiscoveryCard`
- 5 page tests for `/explore/groups`

## Notes

The issue specified `GET /v1/groups` for discovery, but that route already serves "my groups" (used by `/groups/page.tsx`). A dedicated `GET /v1/groups/search` was used instead to avoid a breaking change; the reviewer should confirm this is acceptable.

## Testing

- [ ] Navigate to `/groups` — "Search Groups" button appears next to "Create Group"
- [ ] Click "Search Groups" → lands on `/explore/groups`
- [ ] Type in search box → debounced request fires after 300ms, results appear
- [ ] Empty input → "Search for public groups to join" empty state shown
- [ ] Query with no matches → "No groups found for '…'" message shown
- [ ] "Request to join" click → button optimistically switches to "Pending" + withdraw option
- [ ] "Withdraw" click → optimistically reverts to "Request to join"
- [ ] Active member groups are not returned by the API (verify with a user already in a group)
- [ ] `/explore` page shows the "Discover Groups" card

Closes #247