### PR TITLE
feat(groups): add user autocomplete and bulk member invitation

### DIFF
--- a/apps/api/src/modules/group-members/dto/bulk-invitation-response.dto.ts
+++ b/apps/api/src/modules/group-members/dto/bulk-invitation-response.dto.ts
@@ -1,0 +1,33 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export const INVITATION_RESULT_STATUSES = [
+  'INVITED',
+  'ALREADY_MEMBER',
+  'ALREADY_INVITED',
+  'HAS_PENDING_REQUEST',
+  'NOT_FOUND',
+] as const;
+
+export type InvitationResultStatus = (typeof INVITATION_RESULT_STATUSES)[number];
+
+export class InvitationResultDto {
+  @ApiProperty({ example: 'john_doe' })
+  username!: string;
+
+  @ApiProperty({
+    enum: INVITATION_RESULT_STATUSES,
+    example: 'INVITED',
+    description:
+      'INVITED — sent successfully. ' +
+      'ALREADY_MEMBER — active member. ' +
+      'ALREADY_INVITED — pending invitation. ' +
+      'HAS_PENDING_REQUEST — has an active join request. ' +
+      'NOT_FOUND — username does not exist.',
+  })
+  status!: InvitationResultStatus;
+}
+
+export class BulkInvitationResponseDto {
+  @ApiProperty({ type: [InvitationResultDto] })
+  results!: InvitationResultDto[];
+}

--- a/apps/api/src/modules/group-members/dto/bulk-invitation-response.dto.ts
+++ b/apps/api/src/modules/group-members/dto/bulk-invitation-response.dto.ts
@@ -16,6 +16,7 @@ export class InvitationResultDto {
 
   @ApiProperty({
     enum: INVITATION_RESULT_STATUSES,
+    enumName: 'InvitationResultStatus',
     example: 'INVITED',
     description:
       'INVITED — sent successfully. ' +

--- a/apps/api/src/modules/group-members/dto/create-invitation.dto.ts
+++ b/apps/api/src/modules/group-members/dto/create-invitation.dto.ts
@@ -1,18 +1,31 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsString, Matches, MaxLength, MinLength } from 'class-validator';
+import {
+  ArrayMaxSize,
+  ArrayMinSize,
+  IsArray,
+  IsString,
+  Matches,
+  MaxLength,
+  MinLength,
+} from 'class-validator';
 
 export class CreateInvitationDto {
   @ApiProperty({
-    description: 'Username of the user to invite (without @)',
-    example: 'juan_viajero',
+    description: 'Usernames to invite (without @). 1–20 per request.',
+    example: ['juan_viajero', 'maria_explorer'],
+    type: [String],
     minLength: 3,
     maxLength: 30,
   })
-  @IsString()
-  @MinLength(3)
-  @MaxLength(30)
+  @IsArray()
+  @ArrayMinSize(1)
+  @ArrayMaxSize(20)
+  @IsString({ each: true })
+  @MinLength(3, { each: true })
+  @MaxLength(30, { each: true })
   @Matches(/^[a-z0-9_-]+$/, {
-    message: 'username must contain only lowercase letters, digits, underscores, and dashes',
+    each: true,
+    message: 'each username must contain only lowercase letters, digits, underscores, and dashes',
   })
-  targetUsername!: string;
+  usernames!: string[];
 }

--- a/apps/api/src/modules/group-members/group-members.controller.spec.ts
+++ b/apps/api/src/modules/group-members/group-members.controller.spec.ts
@@ -10,6 +10,7 @@ import {
 import { GroupMembersController } from './group-members.controller';
 import { GroupMembersService } from './group-members.service';
 import type { CreateInvitationDto } from './dto/create-invitation.dto';
+import type { BulkInvitationResponseDto } from './dto/bulk-invitation-response.dto';
 import type { UpdateMemberRoleDto } from './dto/update-member-role.dto';
 import type { MemberResponseDto } from './dto/member-response.dto';
 import type { PendingItemResponseDto } from './dto/pending-item-response.dto';
@@ -59,7 +60,7 @@ const mockPendingResponse: PendingItemResponseDto = {
 let mockSubmitJoinRequest: jest.Mock;
 let mockAcceptJoinRequest: jest.Mock;
 let mockRejectJoinRequest: jest.Mock;
-let mockSendInvitation: jest.Mock;
+let mockSendInvitations: jest.Mock;
 let mockAcceptInvitation: jest.Mock;
 let mockDeclineInvitation: jest.Mock;
 let mockRevokeInvitation: jest.Mock;
@@ -75,7 +76,7 @@ describe('GroupMembersController', () => {
     mockSubmitJoinRequest = jest.fn().mockResolvedValue(undefined);
     mockAcceptJoinRequest = jest.fn().mockResolvedValue(undefined);
     mockRejectJoinRequest = jest.fn().mockResolvedValue(undefined);
-    mockSendInvitation = jest.fn().mockResolvedValue(undefined);
+    mockSendInvitations = jest.fn().mockResolvedValue({ results: [] } as BulkInvitationResponseDto);
     mockAcceptInvitation = jest.fn().mockResolvedValue(undefined);
     mockDeclineInvitation = jest.fn().mockResolvedValue(undefined);
     mockRevokeInvitation = jest.fn().mockResolvedValue(undefined);
@@ -93,7 +94,7 @@ describe('GroupMembersController', () => {
             submitJoinRequest: mockSubmitJoinRequest,
             acceptJoinRequest: mockAcceptJoinRequest,
             rejectJoinRequest: mockRejectJoinRequest,
-            sendInvitation: mockSendInvitation,
+            sendInvitations: mockSendInvitations,
             acceptInvitation: mockAcceptInvitation,
             declineInvitation: mockDeclineInvitation,
             revokeInvitation: mockRevokeInvitation,
@@ -142,12 +143,17 @@ describe('GroupMembersController', () => {
   });
 
   describe('POST /v1/groups/:id/invitations', () => {
-    it('delegates to GroupMembersService.sendInvitation', async () => {
-      const dto: CreateInvitationDto = { targetUsername: 'target_user' };
+    it('delegates to GroupMembersService.sendInvitations and returns result', async () => {
+      const dto: CreateInvitationDto = { usernames: ['target_user'] };
+      const mockResult: BulkInvitationResponseDto = {
+        results: [{ username: 'target_user', status: 'INVITED' }],
+      };
+      mockSendInvitations.mockResolvedValueOnce(mockResult);
 
-      await controller.sendInvitation(mockAuthUser, 'group-uuid', dto);
+      const result = await controller.sendInvitations(mockAuthUser, 'group-uuid', dto);
 
-      expect(mockSendInvitation).toHaveBeenCalledWith('group-uuid', dto, mockAuthUser.id);
+      expect(mockSendInvitations).toHaveBeenCalledWith('group-uuid', dto, mockAuthUser.id);
+      expect(result).toEqual(mockResult);
     });
   });
 

--- a/apps/api/src/modules/group-members/group-members.controller.ts
+++ b/apps/api/src/modules/group-members/group-members.controller.ts
@@ -12,6 +12,7 @@ import {
 } from '@nestjs/common';
 import {
   ApiBearerAuth,
+  ApiBody,
   ApiConflictResponse,
   ApiForbiddenResponse,
   ApiNotFoundResponse,
@@ -113,6 +114,7 @@ export class GroupMembersController {
       'Returns a per-user result for each username in the request.',
   })
   @ApiParam({ name: 'id', type: String, description: 'Group UUID' })
+  @ApiBody({ type: CreateInvitationDto })
   @ApiResponse({
     status: 200,
     type: BulkInvitationResponseDto,

--- a/apps/api/src/modules/group-members/group-members.controller.ts
+++ b/apps/api/src/modules/group-members/group-members.controller.ts
@@ -26,6 +26,7 @@ import { CurrentUser } from '@/common/decorators/current-user.decorator';
 import type { AuthenticatedUser } from '@/types/express';
 import { GroupMembersService } from './group-members.service';
 import { CreateInvitationDto } from './dto/create-invitation.dto';
+import { BulkInvitationResponseDto } from './dto/bulk-invitation-response.dto';
 import { UpdateMemberRoleDto } from './dto/update-member-role.dto';
 import { MemberResponseDto } from './dto/member-response.dto';
 import { MyMembershipResponseDto } from './dto/my-membership-response.dto';
@@ -104,25 +105,27 @@ export class GroupMembersController {
   // ─── Invitations ──────────────────────────────────────────────────────────────
 
   @Post('invitations')
-  @HttpCode(HttpStatus.NO_CONTENT)
+  @HttpCode(HttpStatus.OK)
   @ApiOperation({
-    summary: 'Send an invitation',
-    description: 'Sends a membership invitation to a user by @username. Admin only.',
+    summary: 'Send invitations',
+    description:
+      'Sends membership invitations to one or more users by @username. Admin only. ' +
+      'Returns a per-user result for each username in the request.',
   })
   @ApiParam({ name: 'id', type: String, description: 'Group UUID' })
-  @ApiResponse({ status: 204, description: 'Invitation sent.' })
+  @ApiResponse({
+    status: 200,
+    type: BulkInvitationResponseDto,
+    description: 'Per-user invitation results.',
+  })
   @ApiUnauthorizedResponse({ description: 'Unauthenticated.' })
   @ApiForbiddenResponse({ description: 'Caller is not a group admin.' })
-  @ApiConflictResponse({
-    description: 'User is already a member, has a pending invitation, or a pending join request.',
-  })
-  @ApiNotFoundResponse({ description: 'Group or target user not found.' })
-  async sendInvitation(
+  async sendInvitations(
     @CurrentUser() user: AuthenticatedUser,
     @Param('id', ParseUUIDPipe) id: string,
     @Body() dto: CreateInvitationDto,
-  ): Promise<void> {
-    return this.groupMembersService.sendInvitation(id, dto, user.id);
+  ): Promise<BulkInvitationResponseDto> {
+    return this.groupMembersService.sendInvitations(id, dto, user.id);
   }
 
   @Patch('invitations/accept')

--- a/apps/api/src/modules/group-members/group-members.service.spec.ts
+++ b/apps/api/src/modules/group-members/group-members.service.spec.ts
@@ -340,84 +340,120 @@ describe('GroupMembersService', () => {
     });
   });
 
-  // ─── sendInvitation ──────────────────────────────────────────────────────────
+  // ─── sendInvitations ─────────────────────────────────────────────────────────
 
-  describe('sendInvitation', () => {
-    const dto: CreateInvitationDto = { targetUsername: 'target_user' };
+  describe('sendInvitations', () => {
+    const dto: CreateInvitationDto = { usernames: ['target_user'] };
 
-    it('inserts new INVITED membership when no existing record', async () => {
+    it('inserts new INVITED membership and returns INVITED status', async () => {
       mockGroupMembersFindFirst
         .mockResolvedValueOnce(ownerMembership) // admin check
         .mockResolvedValueOnce(undefined); // no existing membership
 
-      await service.sendInvitation(GROUP_ID, dto, ADMIN_ID);
+      const result = await service.sendInvitations(GROUP_ID, dto, ADMIN_ID);
 
       expect(mockInsert).toHaveBeenCalled();
       expect(mockInsertValues).toHaveBeenCalledWith(
         expect.objectContaining({ status: GroupMemberStatus.INVITED }),
       );
+      expect(result).toEqual({ results: [{ username: 'target_user', status: 'INVITED' }] });
     });
 
     it('throws ForbiddenException when caller is not an admin', async () => {
       mockGroupMembersFindFirst.mockResolvedValueOnce(undefined); // no admin membership
 
-      await expect(service.sendInvitation(GROUP_ID, dto, USER_ID)).rejects.toThrow(
+      await expect(service.sendInvitations(GROUP_ID, dto, USER_ID)).rejects.toThrow(
         ForbiddenException,
       );
     });
 
-    it('throws NotFoundException when target user does not exist', async () => {
+    it('returns NOT_FOUND when target user does not exist', async () => {
       mockGroupMembersFindFirst.mockResolvedValueOnce(ownerMembership);
       mockUsersFindFirst.mockResolvedValue(undefined);
 
-      await expect(service.sendInvitation(GROUP_ID, dto, ADMIN_ID)).rejects.toThrow(
-        NotFoundException,
-      );
+      const result = await service.sendInvitations(GROUP_ID, dto, ADMIN_ID);
+
+      expect(result).toEqual({ results: [{ username: 'target_user', status: 'NOT_FOUND' }] });
+      expect(mockInsert).not.toHaveBeenCalled();
     });
 
-    it('throws ConflictException when target is already ACTIVE', async () => {
+    it('returns ALREADY_MEMBER when target is already ACTIVE', async () => {
       mockGroupMembersFindFirst
         .mockResolvedValueOnce(ownerMembership)
         .mockResolvedValueOnce(activeMembership);
 
-      await expect(service.sendInvitation(GROUP_ID, dto, ADMIN_ID)).rejects.toThrow(
-        ConflictException,
-      );
+      const result = await service.sendInvitations(GROUP_ID, dto, ADMIN_ID);
+
+      expect(result).toEqual({
+        results: [{ username: 'target_user', status: 'ALREADY_MEMBER' }],
+      });
     });
 
-    it('throws ConflictException when target already has INVITED status', async () => {
+    it('returns ALREADY_INVITED when target already has INVITED status', async () => {
       mockGroupMembersFindFirst
         .mockResolvedValueOnce(ownerMembership)
         .mockResolvedValueOnce(invitedMembership);
 
-      await expect(service.sendInvitation(GROUP_ID, dto, ADMIN_ID)).rejects.toThrow(
-        ConflictException,
-      );
+      const result = await service.sendInvitations(GROUP_ID, dto, ADMIN_ID);
+
+      expect(result).toEqual({
+        results: [{ username: 'target_user', status: 'ALREADY_INVITED' }],
+      });
     });
 
-    it('throws ConflictException when target already has REQUEST status', async () => {
+    it('returns HAS_PENDING_REQUEST when target has a pending join request', async () => {
       mockGroupMembersFindFirst
         .mockResolvedValueOnce(ownerMembership)
         .mockResolvedValueOnce(requestMembership);
 
-      await expect(service.sendInvitation(GROUP_ID, dto, ADMIN_ID)).rejects.toThrow(
-        ConflictException,
-      );
+      const result = await service.sendInvitations(GROUP_ID, dto, ADMIN_ID);
+
+      expect(result).toEqual({
+        results: [{ username: 'target_user', status: 'HAS_PENDING_REQUEST' }],
+      });
     });
 
-    it('updates row when re-inviting after REJECTED and resets role to MEMBER', async () => {
+    it('re-invites after REJECTED, resets role to MEMBER, returns INVITED', async () => {
       const formerAdmin = makeMembership(USER_ID, GroupMemberStatus.REJECTED, GroupRole.ADMIN);
       mockGroupMembersFindFirst
         .mockResolvedValueOnce(ownerMembership)
         .mockResolvedValueOnce(formerAdmin);
 
-      await service.sendInvitation(GROUP_ID, dto, ADMIN_ID);
+      const result = await service.sendInvitations(GROUP_ID, dto, ADMIN_ID);
 
       expect(mockUpdate).toHaveBeenCalled();
       expect(mockUpdateSet).toHaveBeenCalledWith(
         expect.objectContaining({ status: GroupMemberStatus.INVITED, role: GroupRole.MEMBER }),
       );
       expect(mockInsert).not.toHaveBeenCalled();
+      expect(result).toEqual({ results: [{ username: 'target_user', status: 'INVITED' }] });
+    });
+
+    it('handles multiple usernames and returns per-user results', async () => {
+      const multiDto: CreateInvitationDto = { usernames: ['user_a', 'user_b', 'user_c'] };
+      const userA = { ...mockTargetUser, id: 'id-a', username: 'user_a' };
+      const userB = { ...mockTargetUser, id: 'id-b', username: 'user_b' };
+      const userC = { ...mockTargetUser, id: 'id-c', username: 'user_c' };
+
+      mockGroupMembersFindFirst
+        .mockResolvedValueOnce(ownerMembership) // admin check
+        .mockResolvedValueOnce(undefined) // user_a: no existing
+        .mockResolvedValueOnce(activeMembership) // user_b: already ACTIVE
+        .mockResolvedValueOnce(undefined); // user_c: no existing
+      mockUsersFindFirst
+        .mockResolvedValueOnce(userA)
+        .mockResolvedValueOnce(userB)
+        .mockResolvedValueOnce(userC);
+
+      const result = await service.sendInvitations(GROUP_ID, multiDto, ADMIN_ID);
+
+      expect(result).toEqual({
+        results: [
+          { username: 'user_a', status: 'INVITED' },
+          { username: 'user_b', status: 'ALREADY_MEMBER' },
+          { username: 'user_c', status: 'INVITED' },
+        ],
+      });
     });
   });
 

--- a/apps/api/src/modules/group-members/group-members.service.spec.ts
+++ b/apps/api/src/modules/group-members/group-members.service.spec.ts
@@ -344,11 +344,13 @@ describe('GroupMembersService', () => {
 
   describe('sendInvitations', () => {
     const dto: CreateInvitationDto = { usernames: ['target_user'] };
+    const targetMembership = (status: GroupMemberStatus, role = GroupRole.MEMBER) =>
+      makeMembership(TARGET_ID, status, role);
 
     it('inserts new INVITED membership and returns INVITED status', async () => {
-      mockGroupMembersFindFirst
-        .mockResolvedValueOnce(ownerMembership) // admin check
-        .mockResolvedValueOnce(undefined); // no existing membership
+      mockGroupMembersFindFirst.mockResolvedValueOnce(ownerMembership); // admin check
+      mockUsersFindMany.mockResolvedValueOnce([mockTargetUser]);
+      mockGroupMembersFindMany.mockResolvedValueOnce([]); // no existing membership
 
       const result = await service.sendInvitations(GROUP_ID, dto, ADMIN_ID);
 
@@ -368,8 +370,9 @@ describe('GroupMembersService', () => {
     });
 
     it('returns NOT_FOUND when target user does not exist', async () => {
-      mockGroupMembersFindFirst.mockResolvedValueOnce(ownerMembership);
-      mockUsersFindFirst.mockResolvedValue(undefined);
+      mockGroupMembersFindFirst.mockResolvedValueOnce(ownerMembership); // admin check
+      mockUsersFindMany.mockResolvedValueOnce([]); // user not found
+      mockGroupMembersFindMany.mockResolvedValueOnce([]); // no memberships (no users)
 
       const result = await service.sendInvitations(GROUP_ID, dto, ADMIN_ID);
 
@@ -378,9 +381,9 @@ describe('GroupMembersService', () => {
     });
 
     it('returns ALREADY_MEMBER when target is already ACTIVE', async () => {
-      mockGroupMembersFindFirst
-        .mockResolvedValueOnce(ownerMembership)
-        .mockResolvedValueOnce(activeMembership);
+      mockGroupMembersFindFirst.mockResolvedValueOnce(ownerMembership); // admin check
+      mockUsersFindMany.mockResolvedValueOnce([mockTargetUser]);
+      mockGroupMembersFindMany.mockResolvedValueOnce([targetMembership(GroupMemberStatus.ACTIVE)]);
 
       const result = await service.sendInvitations(GROUP_ID, dto, ADMIN_ID);
 
@@ -390,9 +393,9 @@ describe('GroupMembersService', () => {
     });
 
     it('returns ALREADY_INVITED when target already has INVITED status', async () => {
-      mockGroupMembersFindFirst
-        .mockResolvedValueOnce(ownerMembership)
-        .mockResolvedValueOnce(invitedMembership);
+      mockGroupMembersFindFirst.mockResolvedValueOnce(ownerMembership); // admin check
+      mockUsersFindMany.mockResolvedValueOnce([mockTargetUser]);
+      mockGroupMembersFindMany.mockResolvedValueOnce([targetMembership(GroupMemberStatus.INVITED)]);
 
       const result = await service.sendInvitations(GROUP_ID, dto, ADMIN_ID);
 
@@ -402,9 +405,9 @@ describe('GroupMembersService', () => {
     });
 
     it('returns HAS_PENDING_REQUEST when target has a pending join request', async () => {
-      mockGroupMembersFindFirst
-        .mockResolvedValueOnce(ownerMembership)
-        .mockResolvedValueOnce(requestMembership);
+      mockGroupMembersFindFirst.mockResolvedValueOnce(ownerMembership); // admin check
+      mockUsersFindMany.mockResolvedValueOnce([mockTargetUser]);
+      mockGroupMembersFindMany.mockResolvedValueOnce([targetMembership(GroupMemberStatus.REQUEST)]);
 
       const result = await service.sendInvitations(GROUP_ID, dto, ADMIN_ID);
 
@@ -414,10 +417,11 @@ describe('GroupMembersService', () => {
     });
 
     it('re-invites after REJECTED, resets role to MEMBER, returns INVITED', async () => {
-      const formerAdmin = makeMembership(USER_ID, GroupMemberStatus.REJECTED, GroupRole.ADMIN);
-      mockGroupMembersFindFirst
-        .mockResolvedValueOnce(ownerMembership)
-        .mockResolvedValueOnce(formerAdmin);
+      mockGroupMembersFindFirst.mockResolvedValueOnce(ownerMembership); // admin check
+      mockUsersFindMany.mockResolvedValueOnce([mockTargetUser]);
+      mockGroupMembersFindMany.mockResolvedValueOnce([
+        targetMembership(GroupMemberStatus.REJECTED, GroupRole.ADMIN),
+      ]);
 
       const result = await service.sendInvitations(GROUP_ID, dto, ADMIN_ID);
 
@@ -435,15 +439,12 @@ describe('GroupMembersService', () => {
       const userB = { ...mockTargetUser, id: 'id-b', username: 'user_b' };
       const userC = { ...mockTargetUser, id: 'id-c', username: 'user_c' };
 
-      mockGroupMembersFindFirst
-        .mockResolvedValueOnce(ownerMembership) // admin check
-        .mockResolvedValueOnce(undefined) // user_a: no existing
-        .mockResolvedValueOnce(activeMembership) // user_b: already ACTIVE
-        .mockResolvedValueOnce(undefined); // user_c: no existing
-      mockUsersFindFirst
-        .mockResolvedValueOnce(userA)
-        .mockResolvedValueOnce(userB)
-        .mockResolvedValueOnce(userC);
+      mockGroupMembersFindFirst.mockResolvedValueOnce(ownerMembership); // admin check
+      mockUsersFindMany.mockResolvedValueOnce([userA, userB, userC]);
+      // userB is already an active member
+      mockGroupMembersFindMany.mockResolvedValueOnce([
+        makeMembership('id-b', GroupMemberStatus.ACTIVE),
+      ]);
 
       const result = await service.sendInvitations(GROUP_ID, multiDto, ADMIN_ID);
 

--- a/apps/api/src/modules/group-members/group-members.service.ts
+++ b/apps/api/src/modules/group-members/group-members.service.ts
@@ -142,21 +142,36 @@ export class GroupMembersService {
   ): Promise<BulkInvitationResponseDto> {
     await this.assertGroupAdmin(groupId, adminUserId);
 
+    const targetUsers = await this.db.query.users.findMany({
+      where: inArray(users.username, dto.usernames),
+    });
+    const userByUsername = new Map(targetUsers.map((u) => [u.username, u]));
+
+    const existingMemberships =
+      targetUsers.length > 0
+        ? await this.db.query.groupMembers.findMany({
+            where: and(
+              eq(groupMembers.groupId, groupId),
+              inArray(
+                groupMembers.userId,
+                targetUsers.map((u) => u.id),
+              ),
+            ),
+          })
+        : [];
+    const membershipByUserId = new Map(existingMemberships.map((m) => [m.userId, m]));
+
     const results: InvitationResultDto[] = [];
 
     for (const username of dto.usernames) {
-      const targetUser = await this.db.query.users.findFirst({
-        where: eq(users.username, username),
-      });
+      const targetUser = userByUsername.get(username);
 
       if (!targetUser) {
         results.push({ username, status: 'NOT_FOUND' });
         continue;
       }
 
-      const existing = await this.db.query.groupMembers.findFirst({
-        where: and(eq(groupMembers.groupId, groupId), eq(groupMembers.userId, targetUser.id)),
-      });
+      const existing = membershipByUserId.get(targetUser.id);
 
       if (existing) {
         if (existing.status === GroupMemberStatus.ACTIVE) {

--- a/apps/api/src/modules/group-members/group-members.service.ts
+++ b/apps/api/src/modules/group-members/group-members.service.ts
@@ -21,6 +21,10 @@ import type { MemberResponseDto } from './dto/member-response.dto';
 import type { PendingItemResponseDto } from './dto/pending-item-response.dto';
 import type { MyMembershipResponseDto } from './dto/my-membership-response.dto';
 import type { MyInvitationResponseDto } from './dto/my-invitation-response.dto';
+import type {
+  BulkInvitationResponseDto,
+  InvitationResultDto,
+} from './dto/bulk-invitation-response.dto';
 
 const ADMIN_ROLES = [GroupRole.OWNER, GroupRole.ADMIN] as const;
 
@@ -131,53 +135,68 @@ export class GroupMembersService {
 
   // ─── Invitation ──────────────────────────────────────────────────────────────
 
-  async sendInvitation(
+  async sendInvitations(
     groupId: string,
     dto: CreateInvitationDto,
     adminUserId: string,
-  ): Promise<void> {
+  ): Promise<BulkInvitationResponseDto> {
     await this.assertGroupAdmin(groupId, adminUserId);
 
-    const targetUser = await this.db.query.users.findFirst({
-      where: eq(users.username, dto.targetUsername),
-    });
-    if (!targetUser) throw new NotFoundException(`User @${dto.targetUsername} not found`);
+    const results: InvitationResultDto[] = [];
 
-    const existing = await this.db.query.groupMembers.findFirst({
-      where: and(eq(groupMembers.groupId, groupId), eq(groupMembers.userId, targetUser.id)),
-    });
+    for (const username of dto.usernames) {
+      const targetUser = await this.db.query.users.findFirst({
+        where: eq(users.username, username),
+      });
 
-    if (existing) {
-      if (
-        existing.status === GroupMemberStatus.ACTIVE ||
-        existing.status === GroupMemberStatus.INVITED ||
-        existing.status === GroupMemberStatus.REQUEST
-      ) {
-        throw new ConflictException(
-          'User is already an active member, has a pending invitation, or a pending join request',
-        );
+      if (!targetUser) {
+        results.push({ username, status: 'NOT_FOUND' });
+        continue;
       }
-      // Re-invite after REJECTED / REMOVED / LEFT — always reset to MEMBER role
-      await this.db
-        .update(groupMembers)
-        .set({
+
+      const existing = await this.db.query.groupMembers.findFirst({
+        where: and(eq(groupMembers.groupId, groupId), eq(groupMembers.userId, targetUser.id)),
+      });
+
+      if (existing) {
+        if (existing.status === GroupMemberStatus.ACTIVE) {
+          results.push({ username, status: 'ALREADY_MEMBER' });
+          continue;
+        }
+        if (existing.status === GroupMemberStatus.INVITED) {
+          results.push({ username, status: 'ALREADY_INVITED' });
+          continue;
+        }
+        if (existing.status === GroupMemberStatus.REQUEST) {
+          results.push({ username, status: 'HAS_PENDING_REQUEST' });
+          continue;
+        }
+        // REJECTED / REMOVED / LEFT — re-invite, reset to MEMBER role
+        await this.db
+          .update(groupMembers)
+          .set({
+            status: GroupMemberStatus.INVITED,
+            role: GroupRole.MEMBER,
+            initiatedBy: adminUserId,
+            initiatedAt: new Date(),
+            respondedAt: null,
+            decidedBy: null,
+          })
+          .where(and(eq(groupMembers.groupId, groupId), eq(groupMembers.userId, targetUser.id)));
+      } else {
+        await this.db.insert(groupMembers).values({
+          groupId,
+          userId: targetUser.id,
           status: GroupMemberStatus.INVITED,
           role: GroupRole.MEMBER,
           initiatedBy: adminUserId,
-          initiatedAt: new Date(),
-          respondedAt: null,
-          decidedBy: null,
-        })
-        .where(and(eq(groupMembers.groupId, groupId), eq(groupMembers.userId, targetUser.id)));
-    } else {
-      await this.db.insert(groupMembers).values({
-        groupId,
-        userId: targetUser.id,
-        status: GroupMemberStatus.INVITED,
-        role: GroupRole.MEMBER,
-        initiatedBy: adminUserId,
-      });
+        });
+      }
+
+      results.push({ username, status: 'INVITED' });
     }
+
+    return { results };
   }
 
   async acceptInvitation(groupId: string, requestingUserId: string): Promise<void> {

--- a/apps/api/src/modules/users/dto/search-users-query.dto.ts
+++ b/apps/api/src/modules/users/dto/search-users-query.dto.ts
@@ -1,0 +1,33 @@
+import { Type } from 'class-transformer';
+import { IsInt, IsOptional, IsString, Max, MaxLength, Min, MinLength } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+export class SearchUsersQueryDto {
+  @ApiPropertyOptional({
+    description:
+      'Search query. Prefix with @ to search by username only (prefix match). ' +
+      'Without @, searches both username (prefix) and display name (partial match).',
+    example: '@john',
+    minLength: 1,
+    maxLength: 100,
+  })
+  @IsOptional()
+  @IsString()
+  @MinLength(1)
+  @MaxLength(100)
+  q?: string;
+
+  @ApiPropertyOptional({
+    description: 'Number of results to return (1–20)',
+    example: 10,
+    default: 10,
+    minimum: 1,
+    maximum: 20,
+  })
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(20)
+  @Type(() => Number)
+  limit?: number = 10;
+}

--- a/apps/api/src/modules/users/dto/user-search-result.dto.ts
+++ b/apps/api/src/modules/users/dto/user-search-result.dto.ts
@@ -1,0 +1,25 @@
+import { ApiProperty } from '@nestjs/swagger';
+import type { ResolvedAsset } from '@chamuco/shared-types';
+import { ResolvedAssetDto } from '@/modules/assets/dto/resolved-asset.dto';
+
+export class UserSearchResultDto {
+  @ApiProperty({ example: '550e8400-e29b-41d4-a716-446655440000' })
+  id!: string;
+
+  @ApiProperty({ example: 'john_doe' })
+  username!: string;
+
+  @ApiProperty({ example: 'John Doe' })
+  displayName!: string;
+
+  @ApiProperty({ type: () => ResolvedAssetDto, nullable: true })
+  avatar!: ResolvedAsset | null;
+}
+
+export class UserSearchResponseDto {
+  @ApiProperty({ type: [UserSearchResultDto] })
+  data!: UserSearchResultDto[];
+
+  @ApiProperty({ description: 'Total number of matching users (before pagination)', example: 5 })
+  total!: number;
+}

--- a/apps/api/src/modules/users/users.controller.spec.ts
+++ b/apps/api/src/modules/users/users.controller.spec.ts
@@ -130,6 +130,7 @@ describe('UsersController', () => {
   let mockGetPublicProfile: jest.Mock;
   let mockGetMe: jest.Mock;
   let mockUpdateAvatar: jest.Mock;
+  let mockSearchUsers: jest.Mock;
 
   const mockPublicProfileResponse: PublicProfileResponseDto = {
     username: 'john_doe',
@@ -236,6 +237,7 @@ describe('UsersController', () => {
     mockGetPublicProfile = jest.fn().mockResolvedValue(mockPublicProfileResponse);
     mockGetMe = jest.fn().mockResolvedValue(mockUser);
     mockUpdateAvatar = jest.fn().mockResolvedValue(mockUser);
+    mockSearchUsers = jest.fn().mockResolvedValue({ data: [], total: 0 });
 
     const module: TestingModule = await Test.createTestingModule({
       controllers: [UsersController],
@@ -275,6 +277,7 @@ describe('UsersController', () => {
             updateEta: mockUpdateEta,
             deleteEta: mockDeleteEta,
             getPublicProfile: mockGetPublicProfile,
+            searchUsers: mockSearchUsers,
           },
         },
       ],
@@ -898,6 +901,39 @@ describe('UsersController', () => {
       mockGetPublicProfile.mockRejectedValue(new NotFoundException());
 
       await expect(controller.getPublicProfile('unknown')).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('GET /v1/users/search', () => {
+    const mockSearchResponse = {
+      data: [{ id: 'user-b', username: 'janedoe', displayName: 'Jane Doe', avatar: null }],
+      total: 1,
+    };
+
+    it('delegates to usersService.searchUsers with user id and query', async () => {
+      mockSearchUsers.mockResolvedValue(mockSearchResponse);
+      const query = { q: 'jane', limit: 10 };
+
+      const result = await controller.searchUsers(mockAuthUser, query);
+
+      expect(mockSearchUsers).toHaveBeenCalledWith(mockAuthUser.id, query);
+      expect(result).toEqual(mockSearchResponse);
+    });
+
+    it('returns empty result when no users match', async () => {
+      mockSearchUsers.mockResolvedValue({ data: [], total: 0 });
+
+      const result = await controller.searchUsers(mockAuthUser, { q: 'zzz' });
+
+      expect(result).toEqual({ data: [], total: 0 });
+    });
+
+    it('passes groupId to the service when provided', async () => {
+      const query = { q: 'jane', groupId: 'group-uuid' };
+
+      await controller.searchUsers(mockAuthUser, query);
+
+      expect(mockSearchUsers).toHaveBeenCalledWith(mockAuthUser.id, query);
     });
   });
 });

--- a/apps/api/src/modules/users/users.controller.ts
+++ b/apps/api/src/modules/users/users.controller.ts
@@ -45,6 +45,8 @@ import { UserResponseDto } from './dto/user-response.dto';
 import { UsernameAvailabilityDto } from './dto/username-availability.dto';
 import { CreateVisaDto, UpdateVisaDto, VisaResponseDto } from './dto/visa.dto';
 import { CreateEtaDto, EtaResponseDto, UpdateEtaDto } from './dto/eta.dto';
+import { SearchUsersQueryDto } from './dto/search-users-query.dto';
+import { UserSearchResponseDto } from './dto/user-search-result.dto';
 
 @ApiTags('users')
 @ApiBearerAuth()
@@ -612,6 +614,38 @@ export class UsersController {
     @Param('id') id: string,
   ): Promise<void> {
     return this.usersService.deleteEta(user.id, nationalityId, id);
+  }
+
+  @Get('search')
+  @ApiOperation({
+    summary: 'Search users by username or display name',
+    description:
+      'Returns users matching the search query. ' +
+      'Prefix the query with @ to search by username only (prefix match). ' +
+      'Without @, searches both username (prefix match) and display name (partial match). ' +
+      'The requesting user is always excluded from results.',
+  })
+  @ApiQuery({
+    name: 'q',
+    required: false,
+    description: 'Search query. Prefix with @ to search by username only.',
+    example: '@john',
+  })
+  @ApiQuery({
+    name: 'limit',
+    required: false,
+    type: Number,
+    description: 'Number of results to return (1–20, default 10)',
+    example: 10,
+  })
+  @ApiResponse({ status: 200, type: UserSearchResponseDto })
+  @ApiResponse({ status: 400, description: 'Validation error in query params' })
+  @ApiResponse({ status: 401, description: 'Missing or invalid Firebase ID token' })
+  searchUsers(
+    @CurrentUser() user: AuthenticatedUser,
+    @Query() query: SearchUsersQueryDto,
+  ): Promise<UserSearchResponseDto> {
+    return this.usersService.searchUsers(user.id, query);
   }
 
   @Get(':username/profile')

--- a/apps/api/src/modules/users/users.service.spec.ts
+++ b/apps/api/src/modules/users/users.service.spec.ts
@@ -1,5 +1,6 @@
 import { BadRequestException, ConflictException, NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
+import { plainToInstance } from 'class-transformer';
 import {
   AppCurrency,
   AppLanguage,
@@ -111,6 +112,11 @@ describe('UsersService', () => {
   let mockAssetResolverResolve: jest.Mock;
   let mockCloudStorageDelete: jest.Mock;
   let mockCloudStorageMakePublic: jest.Mock;
+  let mockUsersFindMany: jest.Mock;
+  let mockAssetsFindMany: jest.Mock;
+  let mockSelectWhere: jest.Mock;
+  let mockSelectFrom: jest.Mock;
+  let mockSelect: jest.Mock;
 
   beforeEach(async () => {
     mockFindFirst = jest.fn();
@@ -129,6 +135,11 @@ describe('UsersService', () => {
     mockAssetResolverResolve = jest.fn().mockResolvedValue(null);
     mockCloudStorageDelete = jest.fn().mockResolvedValue(undefined);
     mockCloudStorageMakePublic = jest.fn().mockResolvedValue(undefined);
+    mockUsersFindMany = jest.fn().mockResolvedValue([]);
+    mockAssetsFindMany = jest.fn().mockResolvedValue([]);
+    mockSelectWhere = jest.fn().mockResolvedValue([{ total: 0 }]);
+    mockSelectFrom = jest.fn().mockReturnValue({ where: mockSelectWhere });
+    mockSelect = jest.fn().mockReturnValue({ from: mockSelectFrom });
 
     const mockWhere = jest.fn().mockReturnValue({ returning: mockReturning });
     mockSet = jest.fn().mockReturnValue({ where: mockWhere });
@@ -144,8 +155,8 @@ describe('UsersService', () => {
           provide: DRIZZLE_CLIENT,
           useValue: {
             query: {
-              users: { findFirst: mockFindFirst },
-              assets: { findFirst: mockAssetsFindFirst },
+              users: { findFirst: mockFindFirst, findMany: mockUsersFindMany },
+              assets: { findFirst: mockAssetsFindFirst, findMany: mockAssetsFindMany },
               userProfiles: { findFirst: mockProfileFindFirst },
               userPreferences: { findFirst: mockPrefFindFirst },
               userNationalities: {
@@ -164,6 +175,7 @@ describe('UsersService', () => {
             update: mockUpdate,
             insert: mockInsert,
             delete: mockDelete,
+            select: mockSelect,
             transaction: (mockTransaction = jest
               .fn()
               .mockImplementation(async (callback: (trx: unknown) => Promise<unknown>) =>
@@ -2379,6 +2391,140 @@ describe('UsersService', () => {
 
       // only one update call: the nationality update itself
       expect(mockSet).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('searchUsers', () => {
+    const mockUserRow = {
+      id: 'user-b',
+      username: 'janedoe',
+      displayName: 'Jane Doe',
+      avatar: null,
+      authProvider: AuthProvider.GOOGLE,
+      firebaseUid: 'firebase-uid-b',
+      timezone: 'UTC',
+      platformRole: PlatformRole.USER,
+      profileVisibility: ProfileVisibility.PRIVATE,
+      agencyId: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      lastActiveAt: new Date(),
+    };
+
+    it('returns empty when q is not provided', async () => {
+      const result = await service.searchUsers('user-uuid', {});
+      expect(result).toEqual({ data: [], total: 0 });
+      expect(mockSelectWhere).not.toHaveBeenCalled();
+    });
+
+    it('returns empty when q is just @ with nothing after', async () => {
+      const result = await service.searchUsers('user-uuid', { q: '@' });
+      expect(result).toEqual({ data: [], total: 0 });
+    });
+
+    it('returns empty when total is 0', async () => {
+      mockSelectWhere.mockResolvedValueOnce([{ total: 0 }]);
+      const result = await service.searchUsers('user-uuid', { q: 'jane' });
+      expect(result).toEqual({ data: [], total: 0 });
+    });
+
+    it('returns matched users without avatars', async () => {
+      mockSelectWhere.mockResolvedValueOnce([{ total: 1 }]);
+      mockUsersFindMany.mockResolvedValueOnce([mockUserRow]);
+
+      const result = await service.searchUsers('user-uuid', { q: 'jane' });
+
+      expect(result.total).toBe(1);
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0]).toEqual({
+        id: 'user-b',
+        username: 'janedoe',
+        displayName: 'Jane Doe',
+        avatar: null,
+      });
+    });
+
+    it('resolves avatar assets for matched users', async () => {
+      const mockAvatarRow = {
+        id: 'asset-uuid',
+        source: 'emoji',
+        target: '😀',
+        isPublic: true,
+        createdAt: new Date(),
+      };
+      const resolvedAvatar = {
+        source: 'emoji',
+        url: 'https://cdn.jsdelivr.net/gh/twitter/twemoji/assets/svg/1f600.svg',
+      };
+      mockSelectWhere.mockResolvedValueOnce([{ total: 1 }]);
+      mockUsersFindMany.mockResolvedValueOnce([{ ...mockUserRow, avatar: 'asset-uuid' }]);
+      mockAssetsFindMany.mockResolvedValueOnce([mockAvatarRow]);
+      mockAssetResolverResolve.mockResolvedValueOnce(resolvedAvatar);
+
+      const result = await service.searchUsers('user-uuid', { q: 'jane' });
+
+      expect(mockAssetResolverResolve).toHaveBeenCalled();
+      expect(result.data[0]!.avatar).toEqual(resolvedAvatar);
+    });
+
+    it('@-prefix mode searches only by username prefix', async () => {
+      mockSelectWhere.mockResolvedValueOnce([{ total: 1 }]);
+      mockUsersFindMany.mockResolvedValueOnce([mockUserRow]);
+
+      await service.searchUsers('user-uuid', { q: '@jane' });
+
+      // query should succeed (@ stripped → 'jane' prefix match on username)
+      expect(mockSelectWhere).toHaveBeenCalled();
+    });
+
+    it('respects the limit parameter', async () => {
+      mockSelectWhere.mockResolvedValueOnce([{ total: 5 }]);
+      mockUsersFindMany.mockResolvedValueOnce([mockUserRow]);
+
+      await service.searchUsers('user-uuid', { q: 'j', limit: 3 });
+
+      expect(mockUsersFindMany).toHaveBeenCalledWith(expect.objectContaining({ limit: 3 }));
+    });
+  });
+
+  describe('SearchUsersQueryDto', () => {
+    it('transforms string limit to number via @Type', async () => {
+      const { SearchUsersQueryDto } = await import('./dto/search-users-query.dto');
+      const dto = plainToInstance(SearchUsersQueryDto, { q: 'jane', limit: '5' });
+      expect(dto.limit).toBe(5);
+      expect(typeof dto.limit).toBe('number');
+    });
+
+    it('uses default limit of 10 when not provided', async () => {
+      const { SearchUsersQueryDto } = await import('./dto/search-users-query.dto');
+      const dto = plainToInstance(SearchUsersQueryDto, { q: 'jane' });
+      expect(dto.limit).toBe(10);
+    });
+  });
+
+  describe('UserSearchResultDto / UserSearchResponseDto', () => {
+    it('UserSearchResultDto can be instantiated', async () => {
+      const { UserSearchResultDto } = await import('./dto/user-search-result.dto');
+      const dto = new UserSearchResultDto();
+      dto.id = 'uuid';
+      dto.username = 'janedoe';
+      dto.displayName = 'Jane Doe';
+      dto.avatar = null;
+      expect(dto.username).toBe('janedoe');
+    });
+
+    it('UserSearchResponseDto can be instantiated', async () => {
+      const { UserSearchResponseDto, UserSearchResultDto } =
+        await import('./dto/user-search-result.dto');
+      const result = new UserSearchResultDto();
+      result.id = 'u1';
+      result.username = 'janedoe';
+      result.displayName = 'Jane Doe';
+      result.avatar = null;
+      const dto = new UserSearchResponseDto();
+      dto.data = [result];
+      dto.total = 1;
+      expect(dto.total).toBe(1);
     });
   });
 });

--- a/apps/api/src/modules/users/users.service.ts
+++ b/apps/api/src/modules/users/users.service.ts
@@ -5,7 +5,7 @@ import {
   Injectable,
   NotFoundException,
 } from '@nestjs/common';
-import { and, eq, ne } from 'drizzle-orm';
+import { and, count, eq, ilike, inArray, ne, or } from 'drizzle-orm';
 import { DRIZZLE_CLIENT, DrizzleClient } from '@/database/drizzle.provider';
 import { assets } from '@/modules/assets/schema/assets.schema';
 import { AssetResolverService } from '@/modules/assets/asset-resolver.service';
@@ -44,6 +44,8 @@ import type { UserResponseDto } from './dto/user-response.dto';
 import type { UsernameAvailabilityDto } from './dto/username-availability.dto';
 import type { CreateVisaDto, UpdateVisaDto, VisaResponseDto } from './dto/visa.dto';
 import type { CreateEtaDto, EtaResponseDto, UpdateEtaDto } from './dto/eta.dto';
+import type { SearchUsersQueryDto } from './dto/search-users-query.dto';
+import type { UserSearchResponseDto, UserSearchResultDto } from './dto/user-search-result.dto';
 
 @Injectable()
 export class UsersService {
@@ -68,6 +70,59 @@ export class UsersService {
       where: eq(users.username, username),
     });
     return { available: !existing, username };
+  }
+
+  async searchUsers(
+    requestingUserId: string,
+    dto: SearchUsersQueryDto,
+  ): Promise<UserSearchResponseDto> {
+    const { q, limit = 10 } = dto;
+
+    if (!q) return { data: [], total: 0 };
+
+    let searchCondition;
+    if (q.startsWith('@')) {
+      const stripped = q.slice(1);
+      if (!stripped) return { data: [], total: 0 };
+      searchCondition = ilike(users.username, `${stripped}%`);
+    } else {
+      searchCondition = or(ilike(users.username, `${q}%`), ilike(users.displayName, `%${q}%`));
+    }
+
+    const conditions = and(searchCondition, ne(users.id, requestingUserId));
+
+    const countResult = await this.db.select({ total: count() }).from(users).where(conditions);
+    const total = countResult[0]?.total ?? 0;
+
+    if (total === 0) return { data: [], total: 0 };
+
+    const rows = await this.db.query.users.findMany({
+      where: conditions,
+      limit,
+      orderBy: (t, { asc }) => [asc(t.username)],
+    });
+
+    const avatarIds = rows.map((r) => r.avatar).filter((id): id is string => id !== null);
+    const avatarAssets =
+      avatarIds.length > 0
+        ? await this.db.query.assets.findMany({ where: inArray(assets.id, avatarIds) })
+        : [];
+    const avatarMap = new Map(
+      await Promise.all(
+        avatarAssets.map(
+          async (a) => [a.id, await this.assetResolver.resolve(assetRowToAsset(a))] as const,
+        ),
+      ),
+    );
+
+    const data: UserSearchResultDto[] = rows.map((row) => ({
+      id: row.id,
+      username: row.username,
+      displayName: row.displayName,
+      avatar: row.avatar ? (avatarMap.get(row.avatar) ?? null) : null,
+    }));
+
+    return { data, total };
   }
 
   async updateMe(existingUser: AuthenticatedUser, dto: UpdateUserDto): Promise<UserResponseDto> {

--- a/apps/web/src/app/groups/[id]/members/page.tsx
+++ b/apps/web/src/app/groups/[id]/members/page.tsx
@@ -29,7 +29,7 @@ export default function GroupMembersPage({ params }: MembersPageProps) {
   const { id } = use(params);
   const { t } = useTranslation('groups');
   const { isLoading: isAuthLoading } = useAuth();
-  const { appUser } = useUser();
+  const { appUser, isLoading: isUserLoading } = useUser();
 
   const [pageState, setPageState] = useState<PageState>('loading');
   const [group, setGroup] = useState<Group | null>(null);
@@ -80,10 +80,10 @@ export default function GroupMembersPage({ params }: MembersPageProps) {
   };
 
   useEffect(() => {
-    if (isAuthLoading) return;
+    if (isAuthLoading || isUserLoading) return;
     void loadData();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [id, isAuthLoading]);
+  }, [id, isAuthLoading, isUserLoading]);
 
   if (pageState === 'loading') return null;
 
@@ -145,6 +145,7 @@ export default function GroupMembersPage({ params }: MembersPageProps) {
             members={members}
             currentUserRole={currentUserRole}
             onInviteSuccess={() => void loadData()}
+            excludedIds={[...members.map((m) => m.userId), ...pending.map((p) => p.userId)]}
           />
         </>
       )}

--- a/apps/web/src/components/groups/members/InviteMemberModal.test.tsx
+++ b/apps/web/src/components/groups/members/InviteMemberModal.test.tsx
@@ -1,9 +1,11 @@
+import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 const mocks = vi.hoisted(() => ({
   mockPost: vi.fn(),
   mockOnSuccess: vi.fn(),
+  mockUseUserSearch: vi.fn(),
 }));
 
 vi.mock('react-i18next', () => ({
@@ -14,7 +16,26 @@ vi.mock('@/services/api-client', () => ({
   apiClient: { post: mocks.mockPost },
 }));
 
+vi.mock('@/hooks/useUserSearch', () => ({
+  useUserSearch: mocks.mockUseUserSearch,
+}));
+
+vi.mock('@base-ui/react/avatar', () => ({
+  Avatar: {
+    Root: ({ children, ...props }: React.ComponentProps<'div'>) => <div {...props}>{children}</div>,
+    Image: ({ src, alt }: React.ComponentProps<'img'>) => <img src={src} alt={alt} />,
+    Fallback: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+  },
+}));
+
 import { InviteMemberModal } from './InviteMemberModal';
+
+const janeDoe = {
+  id: 'user-1',
+  username: 'janedoe',
+  displayName: 'Jane Doe',
+  avatar: null,
+};
 
 function setup() {
   const user = userEvent.setup();
@@ -22,10 +43,22 @@ function setup() {
   return { user };
 }
 
+async function openDialog(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(screen.getByText('members.invite.button'));
+}
+
+async function selectUser(user: ReturnType<typeof userEvent.setup>, displayName: string) {
+  const input = screen.getByPlaceholderText('members.invite.usernamePlaceholder');
+  await user.type(input, 'ja');
+  await waitFor(() => screen.getByText(displayName));
+  await user.click(screen.getByText(displayName));
+}
+
 describe('InviteMemberModal', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mocks.mockPost.mockResolvedValue({ data: {} });
+    mocks.mockPost.mockResolvedValue({ data: { results: [] } });
+    mocks.mockUseUserSearch.mockReturnValue({ results: [], isLoading: false });
   });
 
   it('renders trigger button', () => {
@@ -40,57 +73,86 @@ describe('InviteMemberModal', () => {
 
   it('opens dialog when trigger button is clicked', async () => {
     const { user } = setup();
-    await user.click(screen.getByText('members.invite.button'));
+    await openDialog(user);
     expect(screen.getByRole('heading', { name: 'members.invite.title' })).toBeInTheDocument();
   });
 
-  it('submit button is disabled when username is empty', async () => {
+  it('submit button is disabled when no users are selected', async () => {
     const { user } = setup();
-    await user.click(screen.getByText('members.invite.button'));
+    await openDialog(user);
     expect(screen.getByRole('button', { name: 'members.invite.submit' })).toBeDisabled();
   });
 
-  it('submit button is enabled when username has value', async () => {
+  it('submit button is enabled after selecting a user from autocomplete', async () => {
+    mocks.mockUseUserSearch.mockReturnValue({ results: [janeDoe], isLoading: false });
     const { user } = setup();
-    await user.click(screen.getByText('members.invite.button'));
-    await user.type(screen.getByPlaceholderText('members.invite.usernamePlaceholder'), 'johndoe');
+    await openDialog(user);
+    await selectUser(user, 'Jane Doe');
     expect(screen.getByRole('button', { name: 'members.invite.submit' })).not.toBeDisabled();
   });
 
+  it('shows chip after selecting a user', async () => {
+    mocks.mockUseUserSearch.mockReturnValue({ results: [janeDoe], isLoading: false });
+    const { user } = setup();
+    await openDialog(user);
+    await selectUser(user, 'Jane Doe');
+    expect(screen.getByText('@janedoe')).toBeInTheDocument();
+  });
+
+  it('removes chip when × button is clicked', async () => {
+    mocks.mockUseUserSearch.mockReturnValue({ results: [janeDoe], isLoading: false });
+    const { user } = setup();
+    await openDialog(user);
+    await selectUser(user, 'Jane Doe');
+
+    await user.click(screen.getByRole('button', { name: 'members.invite.removeUser' }));
+
+    expect(screen.queryByText('@janedoe')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'members.invite.submit' })).toBeDisabled();
+  });
+
   it('calls POST with correct payload on submit', async () => {
+    mocks.mockUseUserSearch.mockReturnValue({ results: [janeDoe], isLoading: false });
     const { user } = setup();
-    await user.click(screen.getByText('members.invite.button'));
-    await user.type(screen.getByPlaceholderText('members.invite.usernamePlaceholder'), 'johndoe');
+    await openDialog(user);
+    await selectUser(user, 'Jane Doe');
     await user.click(screen.getByRole('button', { name: 'members.invite.submit' }));
 
     await waitFor(() => {
       expect(mocks.mockPost).toHaveBeenCalledWith('/v1/groups/group-1/invitations', {
-        targetUsername: 'johndoe',
+        usernames: ['janedoe'],
       });
     });
   });
 
-  it('trims whitespace from username before submitting', async () => {
+  it('shows results view after successful submission', async () => {
+    mocks.mockUseUserSearch.mockReturnValue({ results: [janeDoe], isLoading: false });
+    mocks.mockPost.mockResolvedValue({
+      data: { results: [{ username: 'janedoe', status: 'INVITED' }] },
+    });
     const { user } = setup();
-    await user.click(screen.getByText('members.invite.button'));
-    await user.type(
-      screen.getByPlaceholderText('members.invite.usernamePlaceholder'),
-      '  johndoe  ',
-    );
+    await openDialog(user);
+    await selectUser(user, 'Jane Doe');
     await user.click(screen.getByRole('button', { name: 'members.invite.submit' }));
 
     await waitFor(() => {
-      expect(mocks.mockPost).toHaveBeenCalledWith('/v1/groups/group-1/invitations', {
-        targetUsername: 'johndoe',
-      });
+      expect(screen.getByText('members.invite.results.title')).toBeInTheDocument();
+      expect(screen.getByText('members.invite.result.INVITED')).toBeInTheDocument();
     });
   });
 
-  it('calls onSuccess and closes dialog after successful submission', async () => {
+  it('calls onSuccess and closes when Done is clicked after any INVITED result', async () => {
+    mocks.mockUseUserSearch.mockReturnValue({ results: [janeDoe], isLoading: false });
+    mocks.mockPost.mockResolvedValue({
+      data: { results: [{ username: 'janedoe', status: 'INVITED' }] },
+    });
     const { user } = setup();
-    await user.click(screen.getByText('members.invite.button'));
-    await user.type(screen.getByPlaceholderText('members.invite.usernamePlaceholder'), 'johndoe');
+    await openDialog(user);
+    await selectUser(user, 'Jane Doe');
     await user.click(screen.getByRole('button', { name: 'members.invite.submit' }));
+
+    await waitFor(() => screen.getByText('members.invite.done'));
+    await user.click(screen.getByRole('button', { name: 'members.invite.done' }));
 
     await waitFor(() => {
       expect(mocks.mockOnSuccess).toHaveBeenCalled();
@@ -98,11 +160,49 @@ describe('InviteMemberModal', () => {
     });
   });
 
+  it('does not call onSuccess when Done is clicked with no INVITED results', async () => {
+    mocks.mockUseUserSearch.mockReturnValue({ results: [janeDoe], isLoading: false });
+    mocks.mockPost.mockResolvedValue({
+      data: { results: [{ username: 'janedoe', status: 'ALREADY_MEMBER' }] },
+    });
+    const { user } = setup();
+    await openDialog(user);
+    await selectUser(user, 'Jane Doe');
+    await user.click(screen.getByRole('button', { name: 'members.invite.submit' }));
+
+    await waitFor(() => screen.getByText('members.invite.done'));
+    await user.click(screen.getByRole('button', { name: 'members.invite.done' }));
+
+    expect(mocks.mockOnSuccess).not.toHaveBeenCalled();
+  });
+
+  it('shows alreadyExcluded error when selecting a user in excludedIds', async () => {
+    mocks.mockUseUserSearch.mockReturnValue({ results: [janeDoe], isLoading: false });
+    const user = userEvent.setup();
+    render(
+      <InviteMemberModal
+        groupId="group-1"
+        onSuccess={mocks.mockOnSuccess}
+        excludedIds={['user-1']}
+      />,
+    );
+    await user.click(screen.getByText('members.invite.button'));
+
+    const input = screen.getByPlaceholderText('members.invite.usernamePlaceholder');
+    await user.type(input, 'ja');
+    await waitFor(() => screen.getByText('Jane Doe'));
+    await user.click(screen.getByText('Jane Doe'));
+
+    expect(screen.getByText('members.invite.alreadyExcluded')).toBeInTheDocument();
+    expect(screen.queryByText('@janedoe')).not.toBeInTheDocument();
+  });
+
   it('shows error message on failed submission', async () => {
     mocks.mockPost.mockRejectedValue(new Error('Server error'));
+    mocks.mockUseUserSearch.mockReturnValue({ results: [janeDoe], isLoading: false });
     const { user } = setup();
-    await user.click(screen.getByText('members.invite.button'));
-    await user.type(screen.getByPlaceholderText('members.invite.usernamePlaceholder'), 'johndoe');
+    await openDialog(user);
+    await selectUser(user, 'Jane Doe');
     await user.click(screen.getByRole('button', { name: 'members.invite.submit' }));
 
     await waitFor(() => {
@@ -112,15 +212,16 @@ describe('InviteMemberModal', () => {
   });
 
   it('shows sending label while request is in flight', async () => {
-    let resolve!: () => void;
-    mocks.mockPost.mockReturnValue(new Promise<void>((r) => (resolve = r)));
+    let resolve!: (val: unknown) => void;
+    mocks.mockPost.mockReturnValue(new Promise((r) => (resolve = r)));
+    mocks.mockUseUserSearch.mockReturnValue({ results: [janeDoe], isLoading: false });
 
     const { user } = setup();
-    await user.click(screen.getByText('members.invite.button'));
-    await user.type(screen.getByPlaceholderText('members.invite.usernamePlaceholder'), 'johndoe');
+    await openDialog(user);
+    await selectUser(user, 'Jane Doe');
     await user.click(screen.getByRole('button', { name: 'members.invite.submit' }));
 
     expect(screen.getByRole('button', { name: 'members.invite.sending' })).toBeDisabled();
-    resolve();
+    resolve({ data: { results: [] } });
   });
 });

--- a/apps/web/src/components/groups/members/InviteMemberModal.tsx
+++ b/apps/web/src/components/groups/members/InviteMemberModal.tsx
@@ -60,12 +60,17 @@ export function InviteMemberModal({ groupId, onSuccess, excludedIds }: InviteMem
       setSelectionError(t('members.invite.alreadyExcluded'));
       return;
     }
+    if (selectedUsers.length >= 20) {
+      setSelectionError(t('members.invite.maxUsers'));
+      return;
+    }
     setSelectionError(null);
     setSelectedUsers((prev) => (prev.some((u) => u.id === user.id) ? prev : [...prev, user]));
   }
 
   function removeUser(id: string) {
     setSelectedUsers((prev) => prev.filter((u) => u.id !== id));
+    setSelectionError(null);
   }
 
   const handleSubmit = async (e: React.SubmitEvent) => {

--- a/apps/web/src/components/groups/members/InviteMemberModal.tsx
+++ b/apps/web/src/components/groups/members/InviteMemberModal.tsx
@@ -13,33 +13,74 @@ import {
   DialogDescription,
   DialogClose,
 } from '@/components/ui/dialog';
+import { UserAutocomplete } from '@/components/ui/user-autocomplete';
+import type { UserSearchResult } from '@/types/user';
+
+type InvitationResultStatus =
+  | 'INVITED'
+  | 'ALREADY_MEMBER'
+  | 'ALREADY_INVITED'
+  | 'HAS_PENDING_REQUEST'
+  | 'NOT_FOUND';
+
+interface InvitationResult {
+  username: string;
+  status: InvitationResultStatus;
+}
 
 interface InviteMemberModalProps {
   groupId: string;
   onSuccess: () => void;
+  excludedIds?: string[];
 }
 
-export function InviteMemberModal({ groupId, onSuccess }: InviteMemberModalProps) {
+export function InviteMemberModal({ groupId, onSuccess, excludedIds }: InviteMemberModalProps) {
   const { t } = useTranslation('groups');
   const [open, setOpen] = useState(false);
-  const [username, setUsername] = useState('');
+  const [inputValue, setInputValue] = useState('');
+  const [selectedUsers, setSelectedUsers] = useState<UserSearchResult[]>([]);
   const [isSending, setIsSending] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [selectionError, setSelectionError] = useState<string | null>(null);
+  const [results, setResults] = useState<InvitationResult[] | null>(null);
+
+  function handleOpenChange(next: boolean) {
+    setOpen(next);
+    if (!next) {
+      setInputValue('');
+      setSelectedUsers([]);
+      setError(null);
+      setSelectionError(null);
+      setResults(null);
+    }
+  }
+
+  function addUser(user: UserSearchResult) {
+    if (excludedIds?.includes(user.id)) {
+      setSelectionError(t('members.invite.alreadyExcluded'));
+      return;
+    }
+    setSelectionError(null);
+    setSelectedUsers((prev) => (prev.some((u) => u.id === user.id) ? prev : [...prev, user]));
+  }
+
+  function removeUser(id: string) {
+    setSelectedUsers((prev) => prev.filter((u) => u.id !== id));
+  }
 
   const handleSubmit = async (e: React.SubmitEvent) => {
     e.preventDefault();
-    if (!username.trim()) return;
+    if (selectedUsers.length === 0) return;
 
     setIsSending(true);
     setError(null);
 
     try {
-      await apiClient.post(`/v1/groups/${groupId}/invitations`, {
-        targetUsername: username.trim(),
-      });
-      setOpen(false);
-      setUsername('');
-      onSuccess();
+      const res = await apiClient.post<{ results: InvitationResult[] }>(
+        `/v1/groups/${groupId}/invitations`,
+        { usernames: selectedUsers.map((u) => u.username) },
+      );
+      setResults(res.data.results);
     } catch {
       setError(t('members.invite.error'));
     } finally {
@@ -47,8 +88,14 @@ export function InviteMemberModal({ groupId, onSuccess }: InviteMemberModalProps
     }
   };
 
+  function handleDone() {
+    const anyInvited = results?.some((r) => r.status === 'INVITED') ?? false;
+    handleOpenChange(false);
+    if (anyInvited) onSuccess();
+  }
+
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogTrigger
         render={
           <Button variant="outline" size="sm">
@@ -62,32 +109,72 @@ export function InviteMemberModal({ groupId, onSuccess }: InviteMemberModalProps
         <DialogTitle>{t('members.invite.title')}</DialogTitle>
         <DialogDescription className="sr-only">{t('members.invite.title')}</DialogDescription>
 
-        <form onSubmit={handleSubmit} className="mt-4 space-y-4">
-          <input
-            type="text"
-            value={username}
-            onChange={(e) => setUsername(e.target.value)}
-            placeholder={t('members.invite.usernamePlaceholder')}
-            className="w-full rounded-lg border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
-            autoComplete="off"
-            spellCheck={false}
-          />
-
-          {error && <p className="text-sm text-destructive">{error}</p>}
-
-          <div className="flex justify-end gap-2">
-            <DialogClose
-              render={
-                <Button variant="outline" size="sm" type="button">
-                  {t('members.invite.cancel', { ns: 'groups' })}
-                </Button>
-              }
-            />
-            <Button size="sm" type="submit" disabled={isSending || !username.trim()}>
-              {isSending ? t('members.invite.sending') : t('members.invite.submit')}
-            </Button>
+        {results ? (
+          <div className="mt-4 space-y-4">
+            <p className="text-sm font-medium">{t('members.invite.results.title')}</p>
+            <ul className="space-y-2">
+              {results.map((r) => (
+                <li key={r.username} className="flex items-center justify-between text-sm">
+                  <span className="font-medium">@{r.username}</span>
+                  <span className="text-muted-foreground">
+                    {t(`members.invite.result.${r.status}`)}
+                  </span>
+                </li>
+              ))}
+            </ul>
+            <div className="flex justify-end">
+              <Button size="sm" type="button" onClick={handleDone}>
+                {t('members.invite.done')}
+              </Button>
+            </div>
           </div>
-        </form>
+        ) : (
+          <form onSubmit={handleSubmit} className="mt-4 space-y-4">
+            {selectedUsers.length > 0 && (
+              <div className="flex flex-wrap gap-2">
+                {selectedUsers.map((u) => (
+                  <span
+                    key={u.id}
+                    className="flex items-center gap-1 rounded-full bg-muted px-3 py-1 text-sm"
+                  >
+                    @{u.username}
+                    <button
+                      type="button"
+                      onClick={() => removeUser(u.id)}
+                      className="ml-1 rounded-full hover:text-destructive"
+                      aria-label={t('members.invite.removeUser', { username: u.username })}
+                    >
+                      ×
+                    </button>
+                  </span>
+                ))}
+              </div>
+            )}
+
+            <UserAutocomplete
+              value={inputValue}
+              onChange={setInputValue}
+              onSelect={addUser}
+              placeholder={t('members.invite.usernamePlaceholder')}
+            />
+
+            {selectionError && <p className="text-sm text-destructive">{selectionError}</p>}
+            {error && <p className="text-sm text-destructive">{error}</p>}
+
+            <div className="flex justify-end gap-2">
+              <DialogClose
+                render={
+                  <Button variant="outline" size="sm" type="button">
+                    {t('members.invite.cancel', { ns: 'groups' })}
+                  </Button>
+                }
+              />
+              <Button size="sm" type="submit" disabled={isSending || selectedUsers.length === 0}>
+                {isSending ? t('members.invite.sending') : t('members.invite.submit')}
+              </Button>
+            </div>
+          </form>
+        )}
       </DialogPopup>
     </Dialog>
   );

--- a/apps/web/src/components/groups/members/MemberList.tsx
+++ b/apps/web/src/components/groups/members/MemberList.tsx
@@ -11,6 +11,7 @@ interface MemberListProps {
   members: GroupMember[];
   currentUserRole: GroupRole | null;
   onInviteSuccess: () => void;
+  excludedIds?: string[];
 }
 
 const ADMIN_ROLES: GroupRole[] = [GroupRole.OWNER, GroupRole.ADMIN];
@@ -20,6 +21,7 @@ export function MemberList({
   members,
   currentUserRole,
   onInviteSuccess,
+  excludedIds,
 }: MemberListProps) {
   const { t } = useTranslation('groups');
   const isAdmin = currentUserRole !== null && ADMIN_ROLES.includes(currentUserRole);
@@ -30,7 +32,13 @@ export function MemberList({
         <p className="text-sm font-semibold">
           {t('members.title')} ({members.length})
         </p>
-        {isAdmin && <InviteMemberModal groupId={groupId} onSuccess={onInviteSuccess} />}
+        {isAdmin && (
+          <InviteMemberModal
+            groupId={groupId}
+            onSuccess={onInviteSuccess}
+            excludedIds={excludedIds}
+          />
+        )}
       </div>
 
       {members.length === 0 ? (

--- a/apps/web/src/components/ui/user-autocomplete.test.tsx
+++ b/apps/web/src/components/ui/user-autocomplete.test.tsx
@@ -1,0 +1,138 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+vi.mock('@base-ui/react/avatar', () => ({
+  Avatar: {
+    Root: ({ children, ...props }: React.ComponentProps<'div'>) => <div {...props}>{children}</div>,
+    Image: ({ src, alt }: React.ComponentProps<'img'>) => <img src={src} alt={alt} />,
+    Fallback: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+  },
+}));
+
+const mocks = vi.hoisted(() => ({
+  mockUseUserSearch: vi.fn(),
+}));
+
+vi.mock('@/hooks/useUserSearch', () => ({
+  useUserSearch: mocks.mockUseUserSearch,
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+import { UserAutocomplete } from './user-autocomplete';
+import type { UserSearchResult } from '@/types/user';
+
+const mockUser: UserSearchResult = {
+  id: 'user-1',
+  username: 'janedoe',
+  displayName: 'Jane Doe',
+  avatar: null,
+};
+
+function setup(value = '', onSelect = vi.fn(), onChange = vi.fn()) {
+  const user = userEvent.setup();
+  render(
+    <UserAutocomplete
+      value={value}
+      onChange={onChange}
+      onSelect={onSelect}
+      placeholder="Search"
+      data-testid="user-autocomplete"
+    />,
+  );
+  return { user, onSelect, onChange };
+}
+
+beforeEach(() => {
+  mocks.mockUseUserSearch.mockReturnValue({ results: [], isLoading: false });
+});
+
+describe('UserAutocomplete', () => {
+  it('renders the input', () => {
+    setup();
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
+  });
+
+  it('does not show dropdown when value is empty', () => {
+    setup('');
+    expect(screen.queryByRole('list')).not.toBeInTheDocument();
+  });
+
+  it('shows spinner when loading', async () => {
+    mocks.mockUseUserSearch.mockReturnValue({ results: [], isLoading: true });
+    const { user } = setup('ja');
+    await user.click(screen.getByRole('textbox'));
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
+  });
+
+  it('shows empty state when no results and query is valid', async () => {
+    mocks.mockUseUserSearch.mockReturnValue({ results: [], isLoading: false });
+    const { user } = setup('zzz');
+    await user.click(screen.getByRole('textbox'));
+
+    await waitFor(() => {
+      expect(screen.getByText('members.invite.noResults')).toBeInTheDocument();
+    });
+  });
+
+  it('renders result items in dropdown', async () => {
+    mocks.mockUseUserSearch.mockReturnValue({ results: [mockUser], isLoading: false });
+    const { user } = setup('jane');
+    await user.click(screen.getByRole('textbox'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Jane Doe')).toBeInTheDocument();
+      expect(screen.getByText('@janedoe')).toBeInTheDocument();
+    });
+  });
+
+  it('calls onSelect and onChange when item is clicked', async () => {
+    mocks.mockUseUserSearch.mockReturnValue({ results: [mockUser], isLoading: false });
+    const onSelect = vi.fn();
+    const onChange = vi.fn();
+    const { user } = setup('jane', onSelect, onChange);
+    await user.click(screen.getByRole('textbox'));
+
+    await waitFor(() => screen.getByText('Jane Doe'));
+    await user.click(screen.getByText('Jane Doe'));
+
+    expect(onSelect).toHaveBeenCalledWith(mockUser);
+    expect(onChange).toHaveBeenCalledWith('');
+  });
+
+  it('closes dropdown on Escape key', async () => {
+    mocks.mockUseUserSearch.mockReturnValue({ results: [mockUser], isLoading: false });
+    const { user } = setup('jane');
+    const input = screen.getByRole('textbox');
+    await user.click(input);
+
+    await waitFor(() => screen.getByText('Jane Doe'));
+    await user.keyboard('{Escape}');
+
+    expect(screen.queryByText('Jane Doe')).not.toBeInTheDocument();
+  });
+
+  it('selects item with keyboard Enter after ArrowDown', async () => {
+    mocks.mockUseUserSearch.mockReturnValue({ results: [mockUser], isLoading: false });
+    const onSelect = vi.fn();
+    const onChange = vi.fn();
+    const { user } = setup('jane', onSelect, onChange);
+    const input = screen.getByRole('textbox');
+    await user.click(input);
+
+    await waitFor(() => screen.getByText('Jane Doe'));
+    await user.keyboard('{ArrowDown}{Enter}');
+
+    expect(onSelect).toHaveBeenCalledWith(mockUser);
+  });
+
+  it('does not show dropdown when query is just @', async () => {
+    mocks.mockUseUserSearch.mockReturnValue({ results: [], isLoading: false });
+    const { user } = setup('@');
+    await user.click(screen.getByRole('textbox'));
+    expect(screen.queryByText('members.invite.noResults')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/ui/user-autocomplete.tsx
+++ b/apps/web/src/components/ui/user-autocomplete.tsx
@@ -35,7 +35,7 @@ function UserAutocomplete({
   const { results, isLoading } = useUserSearch(value);
 
   const showDropdown =
-    open && value.length >= 1 && (isLoading || results.length > 0 || (!isLoading && value !== '@'));
+    open && value.length >= 1 && (isLoading || results.length > 0 || value !== '@');
   const showEmpty =
     open && value.length >= 1 && value !== '@' && !isLoading && results.length === 0;
 
@@ -87,7 +87,7 @@ function UserAutocomplete({
         className={cn(className)}
       />
 
-      {(showDropdown || showEmpty) && (
+      {showDropdown && (
         <div className="absolute top-full z-50 mt-1 w-full rounded-md border bg-popover text-popover-foreground shadow-md">
           {isLoading ? (
             <div className="flex items-center justify-center p-3">

--- a/apps/web/src/components/ui/user-autocomplete.tsx
+++ b/apps/web/src/components/ui/user-autocomplete.tsx
@@ -1,0 +1,137 @@
+'use client';
+
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { cn } from '@/lib/utils';
+import { Avatar } from '@/components/ui/avatar';
+import { Input } from '@/components/ui/input';
+import { Spinner } from '@/components/ui/spinner';
+import { useUserSearch } from '@/hooks/useUserSearch';
+import type { UserSearchResult } from '@/types/user';
+
+interface UserAutocompleteProps {
+  value: string;
+  onChange: (val: string) => void;
+  onSelect: (user: UserSearchResult) => void;
+  placeholder?: string;
+  className?: string;
+  'aria-invalid'?: boolean;
+  'data-testid'?: string;
+}
+
+function UserAutocomplete({
+  value,
+  onChange,
+  onSelect,
+  placeholder,
+  className,
+  'aria-invalid': ariaInvalid,
+  'data-testid': testId,
+}: UserAutocompleteProps) {
+  const { t } = useTranslation('groups');
+  const [open, setOpen] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(-1);
+  const { results, isLoading } = useUserSearch(value);
+
+  const showDropdown =
+    open && value.length >= 1 && (isLoading || results.length > 0 || (!isLoading && value !== '@'));
+  const showEmpty =
+    open && value.length >= 1 && value !== '@' && !isLoading && results.length === 0;
+
+  function handleSelect(user: UserSearchResult) {
+    onChange('');
+    onSelect(user);
+    setOpen(false);
+    setActiveIndex(-1);
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (!open) return;
+
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setActiveIndex((i) => Math.min(i + 1, results.length - 1));
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setActiveIndex((i) => Math.max(i - 1, 0));
+    } else if (e.key === 'Enter' && activeIndex >= 0 && results[activeIndex]) {
+      e.preventDefault();
+      handleSelect(results[activeIndex]);
+    } else if (e.key === 'Escape') {
+      setOpen(false);
+      setActiveIndex(-1);
+    }
+  }
+
+  return (
+    <div className="relative">
+      <Input
+        type="text"
+        value={value}
+        onChange={(e) => {
+          onChange(e.target.value);
+          setActiveIndex(-1);
+          setOpen(e.target.value.length >= 1);
+        }}
+        onFocus={() => {
+          if (value.length >= 1) setOpen(true);
+        }}
+        onBlur={() => setTimeout(() => setOpen(false), 150)}
+        onKeyDown={handleKeyDown}
+        placeholder={placeholder}
+        aria-invalid={ariaInvalid}
+        data-testid={testId}
+        autoComplete="off"
+        spellCheck={false}
+        className={cn(className)}
+      />
+
+      {(showDropdown || showEmpty) && (
+        <div className="absolute top-full z-50 mt-1 w-full rounded-md border bg-popover text-popover-foreground shadow-md">
+          {isLoading ? (
+            <div className="flex items-center justify-center p-3">
+              <Spinner size="sm" />
+            </div>
+          ) : showEmpty ? (
+            <p className="px-3 py-2 text-sm text-muted-foreground">
+              {t('members.invite.noResults')}
+            </p>
+          ) : (
+            <ul className="max-h-60 overflow-auto py-1">
+              {results.map((user, index) => (
+                <li key={user.id}>
+                  <button
+                    type="button"
+                    data-active={index === activeIndex}
+                    className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm hover:bg-muted data-[active=true]:bg-muted"
+                    onMouseDown={(e) => {
+                      e.preventDefault();
+                      handleSelect(user);
+                    }}
+                  >
+                    <Avatar
+                      src={user.avatar?.url}
+                      alt=""
+                      fallback={user.displayName.charAt(0).toUpperCase()}
+                      size="sm"
+                    />
+                    <span className="flex min-w-0 flex-col">
+                      <span className="truncate font-medium">{user.displayName}</span>
+                      <span className="truncate text-xs text-muted-foreground">
+                        @{user.username}
+                      </span>
+                    </span>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export { UserAutocomplete };
+export type { UserAutocompleteProps };

--- a/apps/web/src/hooks/useUserSearch.test.ts
+++ b/apps/web/src/hooks/useUserSearch.test.ts
@@ -1,0 +1,136 @@
+import { act, renderHook } from '@testing-library/react';
+import axios, { type AxiosRequestConfig } from 'axios';
+import { useUserSearch } from './useUserSearch';
+
+vi.mock('@/services/api-client', () => ({
+  apiClient: { get: vi.fn() },
+}));
+
+import { apiClient } from '@/services/api-client';
+const mockGet = vi.mocked(apiClient.get);
+
+const mockResults = [{ id: 'user-1', username: 'janedoe', displayName: 'Jane Doe', avatar: null }];
+
+function apiResponse(data = mockResults) {
+  return Promise.resolve({ data: { data, total: data.length } });
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  mockGet.mockReset();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('useUserSearch', () => {
+  it('returns empty results when query is empty', () => {
+    const { result } = renderHook(() => useUserSearch(''));
+    expect(result.current.results).toEqual([]);
+    expect(result.current.isLoading).toBe(false);
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  it('returns empty results when query is only whitespace', () => {
+    const { result } = renderHook(() => useUserSearch('   '));
+    expect(result.current.results).toEqual([]);
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  it('returns empty results when query is just @', () => {
+    const { result } = renderHook(() => useUserSearch('@'));
+    expect(result.current.results).toEqual([]);
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  it('fires request after 300ms debounce and returns results', async () => {
+    mockGet.mockReturnValue(apiResponse());
+
+    const { result } = renderHook(() => useUserSearch('jane'));
+
+    expect(mockGet).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(300);
+    });
+
+    expect(mockGet).toHaveBeenCalledWith(
+      '/v1/users/search',
+      expect.objectContaining({ params: expect.objectContaining({ q: 'jane' }) }),
+    );
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.results).toEqual(mockResults);
+  });
+
+  it('does not fire request within the debounce window', async () => {
+    mockGet.mockReturnValue(apiResponse());
+
+    const { rerender } = renderHook(({ q }) => useUserSearch(q), {
+      initialProps: { q: 'ja' },
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(200);
+    });
+    rerender({ q: 'jan' });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(200);
+    });
+    expect(mockGet).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(100);
+    });
+    expect(mockGet).toHaveBeenCalledTimes(1);
+  });
+
+  it('aborts in-flight request when query changes', async () => {
+    let aborted = false;
+    mockGet.mockImplementation((_url: string, config: AxiosRequestConfig | undefined) => {
+      (config?.signal as AbortSignal | undefined)?.addEventListener('abort', () => {
+        aborted = true;
+      });
+      return new Promise(() => {});
+    });
+
+    const { rerender } = renderHook(({ q }) => useUserSearch(q), {
+      initialProps: { q: 'ja' },
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(300);
+    });
+    expect(mockGet).toHaveBeenCalledTimes(1);
+
+    rerender({ q: 'jan' });
+    expect(aborted).toBe(true);
+  });
+
+  it('returns empty results on network error', async () => {
+    mockGet.mockRejectedValue(new Error('network error'));
+
+    const { result } = renderHook(() => useUserSearch('jane'));
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(300);
+    });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.results).toEqual([]);
+  });
+
+  it('does not update results when request is cancelled', async () => {
+    mockGet.mockRejectedValue(new axios.CanceledError());
+
+    const { result } = renderHook(() => useUserSearch('jane'));
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(300);
+    });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.results).toEqual([]);
+  });
+});

--- a/apps/web/src/hooks/useUserSearch.ts
+++ b/apps/web/src/hooks/useUserSearch.ts
@@ -1,0 +1,45 @@
+import axios from 'axios';
+import { useEffect, useState } from 'react';
+
+import { apiClient } from '@/services/api-client';
+import type { UserSearchResponse, UserSearchResult } from '@/types/user';
+
+export function useUserSearch(query: string, limit = 10) {
+  const [results, setResults] = useState<UserSearchResult[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    const controller = new AbortController();
+
+    if (!query.trim() || query === '@') {
+      setResults([]);
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      setIsLoading(true);
+
+      apiClient
+        .get<UserSearchResponse>('/v1/users/search', {
+          params: { q: query, limit },
+          signal: controller.signal,
+        })
+        .then((res) => {
+          setResults(res.data.data);
+        })
+        .catch((err: unknown) => {
+          if (!axios.isCancel(err)) {
+            setResults([]);
+          }
+        })
+        .finally(() => setIsLoading(false));
+    }, 300);
+
+    return () => {
+      clearTimeout(timer);
+      controller.abort();
+    };
+  }, [query, limit]);
+
+  return { results, isLoading };
+}

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -244,6 +244,7 @@
         "noResults": "No users found",
         "removeUser": "Remove {{username}}",
         "alreadyExcluded": "This user is already a member or has a pending invitation",
+        "maxUsers": "You can invite up to 20 users at once",
         "done": "Done",
         "results": {
           "title": "Invitation results"

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -235,12 +235,26 @@
       "invite": {
         "button": "Invite member",
         "title": "Invite a member",
-        "usernamePlaceholder": "e.g. john_doe",
+        "usernamePlaceholder": "Search by name or @username",
         "submit": "Send invitation",
         "sending": "Sending...",
         "cancel": "Cancel",
         "success": "Invitation sent",
-        "error": "Failed to send invitation"
+        "error": "Failed to send invitation",
+        "noResults": "No users found",
+        "removeUser": "Remove {{username}}",
+        "alreadyExcluded": "This user is already a member or has a pending invitation",
+        "done": "Done",
+        "results": {
+          "title": "Invitation results"
+        },
+        "result": {
+          "INVITED": "Invited successfully",
+          "ALREADY_MEMBER": "Already a member",
+          "ALREADY_INVITED": "Already invited",
+          "HAS_PENDING_REQUEST": "Has a pending join request",
+          "NOT_FOUND": "User not found"
+        }
       },
       "joinRequest": {
         "button": "Request to join",

--- a/apps/web/src/locales/es.json
+++ b/apps/web/src/locales/es.json
@@ -235,12 +235,26 @@
       "invite": {
         "button": "Invitar miembro",
         "title": "Invitar un miembro",
-        "usernamePlaceholder": "p.ej. juan_doe",
+        "usernamePlaceholder": "Busca por nombre o @usuario",
         "submit": "Enviar invitación",
         "sending": "Enviando...",
         "cancel": "Cancelar",
         "success": "Invitación enviada",
-        "error": "Error al enviar la invitación"
+        "error": "Error al enviar la invitación",
+        "noResults": "No se encontraron usuarios",
+        "removeUser": "Eliminar {{username}}",
+        "alreadyExcluded": "Este usuario ya es miembro o tiene una invitación pendiente",
+        "done": "Listo",
+        "results": {
+          "title": "Resultados de invitación"
+        },
+        "result": {
+          "INVITED": "Invitado exitosamente",
+          "ALREADY_MEMBER": "Ya es miembro",
+          "ALREADY_INVITED": "Ya tiene invitación pendiente",
+          "HAS_PENDING_REQUEST": "Tiene una solicitud de unión pendiente",
+          "NOT_FOUND": "Usuario no encontrado"
+        }
       },
       "joinRequest": {
         "button": "Solicitar unirse",

--- a/apps/web/src/locales/es.json
+++ b/apps/web/src/locales/es.json
@@ -244,6 +244,7 @@
         "noResults": "No se encontraron usuarios",
         "removeUser": "Eliminar {{username}}",
         "alreadyExcluded": "Este usuario ya es miembro o tiene una invitación pendiente",
+        "maxUsers": "Puedes invitar hasta 20 usuarios a la vez",
         "done": "Listo",
         "results": {
           "title": "Resultados de invitación"

--- a/apps/web/src/types/user.ts
+++ b/apps/web/src/types/user.ts
@@ -1,0 +1,13 @@
+import type { ResolvedAsset } from '@chamuco/shared-types';
+
+export interface UserSearchResult {
+  id: string;
+  username: string;
+  displayName: string;
+  avatar: ResolvedAsset | null;
+}
+
+export interface UserSearchResponse {
+  data: UserSearchResult[];
+  total: number;
+}


### PR DESCRIPTION
## Summary

Issue #282 asked for a reusable user autocomplete component wired into the group member invitation form. While implementing it, a second design problem surfaced: the existing single-user invitation endpoint (204 No Content) couldn't support multi-user flows gracefully. This PR delivers both together: a fully generic `UserAutocomplete` component and a redesigned invite modal that lets admins select multiple members at once and see per-user results inline.

The `groupId` exclusion parameter was intentionally removed from `GET /v1/users/search` — filtering results based on group membership is a group concern, not a user-search concern. Exclusion is now handled client-side via the `excludedIds` prop, which the members page derives from its already-loaded members and pending invitees.

## Changes

**Backend — user search**
- `GET /v1/users/search`: new endpoint with debounced username/display-name search, avatar resolution, and OpenAPI docs
- Removed `groupId` query param — endpoint no longer performs group-member exclusion
- New `SearchUsersQueryDto` and `UserSearchResultDto`

**Backend — bulk invitations**
- `POST /v1/groups/:id/invitations`: changed from single-user (204) to bulk (200 + per-user results)
- New `usernames: string[]` DTO (1–20 per request) replacing `targetUsername`
- New `BulkInvitationResponseDto` with statuses: `INVITED | ALREADY_MEMBER | ALREADY_INVITED | HAS_PENDING_REQUEST | NOT_FOUND`
- Admin check done once upfront; per-user conflicts return a status instead of throwing

**Frontend — autocomplete**
- New reusable `UserAutocomplete` component: debounced search (300ms), avatar + name + @username dropdown, keyboard navigation (↑↓ Enter Esc), loading and empty states
- New `useUserSearch` hook with request cancellation on debounce
- Shared `UserSearchResult` type in `src/types/user.ts`

**Frontend — invite modal**
- Full rework of `InviteMemberModal`: chip-based multi-select, bulk POST, inline per-user results view
- Selecting a user already in `excludedIds` shows an inline error instead of hiding them from results
- `Done` button calls `onSuccess()` only if at least one user was `INVITED`
- Members page derives `excludedIds` from active members + pending invitees and passes it down

**Frontend — reload bug fix**
- Fixed race condition where pending invitations disappeared on page refresh: `loadData` was firing before `useUser()` finished loading `appUser`, causing the admin check to fail

## Breaking Changes

- `POST /v1/groups/:id/invitations`: request body changed from `{ targetUsername: string }` to `{ usernames: string[] }`. Response changed from 204 to 200 with `{ results: InvitationResultDto[] }`.
- `GET /v1/users/search`: `groupId` query param removed.

## Testing

- Backend: `sendInvitations` covered for all 5 per-user statuses + multi-user call + ForbiddenException + REJECTED re-invite
- Frontend: `UserAutocomplete` tested for render, select (input clears), keyboard nav, loading/empty states; `InviteMemberModal` tested for chip add/remove, POST payload, results view, Done behavior (with/without INVITED), `alreadyExcluded` error path

Closes #282