### PR TITLE
feat(groups): enforce group privacy change restrictions

### DIFF
--- a/apps/api/src/modules/groups/groups.controller.ts
+++ b/apps/api/src/modules/groups/groups.controller.ts
@@ -120,7 +120,10 @@ export class GroupsController {
   })
   @ApiParam({ name: 'id', type: String, description: 'Group UUID' })
   @ApiResponse({ status: 200, type: GroupResponseDto })
-  @ApiBadRequestResponse({ description: 'Validation error in request body.' })
+  @ApiBadRequestResponse({
+    description:
+      'Validation error in request body, or GROUP_CANNOT_BE_MADE_PUBLIC: group has non-owner members and cannot be switched to PUBLIC.',
+  })
   @ApiForbiddenResponse({ description: 'Only the group owner can update this group.' })
   @ApiNotFoundResponse({ description: 'Group not found.' })
   async updateGroup(

--- a/apps/api/src/modules/groups/groups.service.spec.ts
+++ b/apps/api/src/modules/groups/groups.service.spec.ts
@@ -1,4 +1,4 @@
-import { ForbiddenException, NotFoundException } from '@nestjs/common';
+import { BadRequestException, ForbiddenException, NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import {
   AuthProvider,
@@ -546,6 +546,38 @@ describe('GroupsService', () => {
       await service.updateGroup(mockUser, 'group-uuid', gcsUpdateDto);
 
       expect(mockCloudStorageMakePublic).toHaveBeenCalledWith('group-covers/group-uuid/cover.jpg');
+    });
+
+    it('throws BadRequestException with GROUP_CANNOT_BE_MADE_PUBLIC when PRIVATE group has non-owner members', async () => {
+      const privateGroup = { ...mockGroupRow, visibility: GroupVisibility.PRIVATE };
+      mockGroupsFindFirst.mockResolvedValueOnce(privateGroup);
+      mockGroupsSelectWhere.mockResolvedValueOnce([{ total: 2 }]);
+
+      const dto: UpdateGroupDto = { visibility: GroupVisibility.PUBLIC };
+
+      let thrownError: unknown;
+      try {
+        await service.updateGroup(mockUser, 'group-uuid', dto);
+      } catch (e) {
+        thrownError = e;
+      }
+
+      expect(thrownError).toBeInstanceOf(BadRequestException);
+      expect((thrownError as BadRequestException).getResponse()).toMatchObject({
+        error: 'GROUP_CANNOT_BE_MADE_PUBLIC',
+      });
+    });
+
+    it('allows PRIVATE → PUBLIC when group has no non-owner members', async () => {
+      const privateGroup = { ...mockGroupRow, visibility: GroupVisibility.PRIVATE };
+      mockGroupsFindFirst.mockResolvedValueOnce(privateGroup).mockResolvedValueOnce(mockGroupRow);
+      mockGroupsSelectWhere.mockResolvedValueOnce([{ total: 0 }]);
+      mockAssetsFindFirst.mockResolvedValue(mockCoverAssetRow);
+
+      const dto: UpdateGroupDto = { visibility: GroupVisibility.PUBLIC };
+      const result = await service.updateGroup(mockUser, 'group-uuid', dto);
+
+      expect(result).toBeDefined();
     });
   });
 

--- a/apps/api/src/modules/groups/groups.service.spec.ts
+++ b/apps/api/src/modules/groups/groups.service.spec.ts
@@ -577,7 +577,8 @@ describe('GroupsService', () => {
       const dto: UpdateGroupDto = { visibility: GroupVisibility.PUBLIC };
       const result = await service.updateGroup(mockUser, 'group-uuid', dto);
 
-      expect(result).toBeDefined();
+      expect(result.id).toBe('group-uuid');
+      expect(result.visibility).toBe(GroupVisibility.PUBLIC);
     });
   });
 

--- a/apps/api/src/modules/groups/groups.service.ts
+++ b/apps/api/src/modules/groups/groups.service.ts
@@ -314,7 +314,6 @@ export class GroupsService {
         );
       if ((row?.total ?? 0) > 0) {
         throw new BadRequestException({
-          statusCode: 400,
           error: 'GROUP_CANNOT_BE_MADE_PUBLIC',
           message: 'Group cannot be made public while it has non-owner members.',
         });

--- a/apps/api/src/modules/groups/groups.service.ts
+++ b/apps/api/src/modules/groups/groups.service.ts
@@ -1,5 +1,11 @@
-import { ForbiddenException, Inject, Injectable, NotFoundException } from '@nestjs/common';
-import { and, count, eq, ilike, inArray, isNull, notInArray } from 'drizzle-orm';
+import {
+  BadRequestException,
+  ForbiddenException,
+  Inject,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { and, count, eq, ilike, inArray, isNull, ne, notInArray } from 'drizzle-orm';
 
 import {
   GroupMemberStatus,
@@ -294,6 +300,26 @@ export class GroupsService {
       ),
     });
     if (!membership) throw new ForbiddenException('Only group admins can update this group');
+
+    if (dto.visibility === GroupVisibility.PUBLIC && group.visibility === GroupVisibility.PRIVATE) {
+      const [row] = await this.db
+        .select({ total: count() })
+        .from(groupMembers)
+        .where(
+          and(
+            eq(groupMembers.groupId, id),
+            eq(groupMembers.status, GroupMemberStatus.ACTIVE),
+            ne(groupMembers.role, GroupRole.OWNER),
+          ),
+        );
+      if ((row?.total ?? 0) > 0) {
+        throw new BadRequestException({
+          statusCode: 400,
+          error: 'GROUP_CANNOT_BE_MADE_PUBLIC',
+          message: 'Group cannot be made public while it has non-owner members.',
+        });
+      }
+    }
 
     const patch: Partial<typeof groups.$inferInsert> = {};
     if (dto.name !== undefined) patch.name = dto.name;

--- a/apps/web/src/app/groups/[id]/settings/page.tsx
+++ b/apps/web/src/app/groups/[id]/settings/page.tsx
@@ -6,12 +6,14 @@ import { useRouter } from 'next/navigation';
 import { useTranslation } from 'react-i18next';
 import { ArrowLeftIcon } from '@phosphor-icons/react';
 
+import { GroupRole } from '@chamuco/shared-types';
+
 import { apiClient } from '@/services/api-client';
 import { useAuth } from '@/hooks/useAuth';
 import { toast } from '@/components/ui/toast';
 import { GroupCoverEditor } from '@/components/groups/GroupCoverEditor';
 import { GroupForm } from '@/components/groups/GroupForm';
-import type { Group } from '@/types/group';
+import type { Group, GroupMember } from '@/types/group';
 
 interface GroupSettingsPageProps {
   params: Promise<{ id: string }>;
@@ -22,15 +24,21 @@ export default function GroupSettingsPage({ params }: GroupSettingsPageProps) {
   const { t } = useTranslation('groups');
   const router = useRouter();
   const [group, setGroup] = useState<Group | null>(null);
+  const [hasNonOwnerMembers, setHasNonOwnerMembers] = useState(false);
   const { isLoading: isAuthLoading } = useAuth();
   const [isLoading, setIsLoading] = useState(true);
   const [isDeleting, setIsDeleting] = useState(false);
 
   const fetchGroup = useCallback(() => {
     if (isAuthLoading) return;
-    apiClient
-      .get<Group>(`/v1/groups/${id}`)
-      .then((res) => setGroup(res.data))
+    Promise.all([
+      apiClient.get<Group>(`/v1/groups/${id}`),
+      apiClient.get<GroupMember[]>(`/v1/groups/${id}/members`),
+    ])
+      .then(([groupRes, membersRes]) => {
+        setGroup(groupRes.data);
+        setHasNonOwnerMembers(membersRes.data.some((m) => m.role !== GroupRole.OWNER));
+      })
       .catch(() => router.replace('/groups'))
       .finally(() => setIsLoading(false));
   }, [id, router, isAuthLoading]);
@@ -80,6 +88,7 @@ export default function GroupSettingsPage({ params }: GroupSettingsPageProps) {
           description: group.description,
           visibility: group.visibility,
         }}
+        hasNonOwnerMembers={hasNonOwnerMembers}
         onSuccess={() => router.push(`/groups/${group.id}`)}
       />
 

--- a/apps/web/src/components/groups/GroupForm.test.tsx
+++ b/apps/web/src/components/groups/GroupForm.test.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { GroupVisibility, UploadType } from '@chamuco/shared-types';
@@ -104,7 +105,7 @@ function setupCreate() {
   return { user };
 }
 
-function setupEdit() {
+function setupEdit(options?: { visibility?: GroupVisibility; hasNonOwnerMembers?: boolean }) {
   const user = userEvent.setup();
   render(
     <GroupForm
@@ -113,8 +114,9 @@ function setupEdit() {
       initialValues={{
         name: 'Mountain Crew',
         description: 'Hikers group',
-        visibility: GroupVisibility.PUBLIC,
+        visibility: options?.visibility ?? GroupVisibility.PUBLIC,
       }}
+      hasNonOwnerMembers={options?.hasNonOwnerMembers}
       onSuccess={mocks.mockOnSuccess}
     />,
   );
@@ -337,19 +339,120 @@ describe('GroupForm', () => {
       expect(mocks.mockOnSuccess).toHaveBeenCalledWith(mockGroup);
     });
 
-    it('changes visibility via radio', async () => {
-      const { user } = setupEdit();
-      await user.click(screen.getByDisplayValue(GroupVisibility.PRIVATE));
+    it('changes visibility via radio (PRIVATE → PUBLIC)', async () => {
+      const { user } = setupEdit({
+        visibility: GroupVisibility.PRIVATE,
+        hasNonOwnerMembers: false,
+      });
+      await user.click(screen.getByDisplayValue(GroupVisibility.PUBLIC));
       await user.click(screen.getByRole('button', { name: 'form.saveChanges' }));
 
       await waitFor(() => {
         expect(mocks.mockPatch).toHaveBeenCalledWith(
           '/v1/groups/group-uuid',
           expect.objectContaining({
-            visibility: GroupVisibility.PRIVATE,
+            visibility: GroupVisibility.PUBLIC,
           }),
         );
       });
+    });
+  });
+
+  describe('visibility restrictions (edit mode)', () => {
+    it('disables PUBLIC option when group is PRIVATE with non-owner members', () => {
+      setupEdit({ visibility: GroupVisibility.PRIVATE, hasNonOwnerMembers: true });
+      const publicRadio = screen.getByDisplayValue(GroupVisibility.PUBLIC);
+      expect(publicRadio).toBeDisabled();
+    });
+
+    it('does not disable PUBLIC option when group is PRIVATE with no non-owner members', () => {
+      setupEdit({ visibility: GroupVisibility.PRIVATE, hasNonOwnerMembers: false });
+      const publicRadio = screen.getByDisplayValue(GroupVisibility.PUBLIC);
+      expect(publicRadio).not.toBeDisabled();
+    });
+
+    it('does not disable PUBLIC option when group is already PUBLIC', () => {
+      setupEdit({ visibility: GroupVisibility.PUBLIC, hasNonOwnerMembers: true });
+      const publicRadio = screen.getByDisplayValue(GroupVisibility.PUBLIC);
+      expect(publicRadio).not.toBeDisabled();
+    });
+
+    it('shows confirmation dialog when switching PUBLIC → PRIVATE before submit', async () => {
+      const { user } = setupEdit({ visibility: GroupVisibility.PUBLIC });
+      await user.click(screen.getByDisplayValue(GroupVisibility.PRIVATE));
+      await user.click(screen.getByRole('button', { name: 'form.saveChanges' }));
+
+      expect(screen.getByTestId('confirm-dialog')).toBeInTheDocument();
+      expect(mocks.mockPatch).not.toHaveBeenCalled();
+    });
+
+    it('submits after confirming PUBLIC → PRIVATE change', async () => {
+      const { user } = setupEdit({ visibility: GroupVisibility.PUBLIC });
+      await user.click(screen.getByDisplayValue(GroupVisibility.PRIVATE));
+      await user.click(screen.getByRole('button', { name: 'form.saveChanges' }));
+
+      await waitFor(() => expect(screen.getByTestId('confirm-dialog')).toBeInTheDocument());
+      await user.click(screen.getByTestId('confirm-make-private'));
+
+      await waitFor(() => {
+        expect(mocks.mockPatch).toHaveBeenCalledWith(
+          '/v1/groups/group-uuid',
+          expect.objectContaining({ visibility: GroupVisibility.PRIVATE }),
+        );
+      });
+    });
+
+    it('does not submit when cancelling the PUBLIC → PRIVATE confirmation', async () => {
+      const { user } = setupEdit({ visibility: GroupVisibility.PUBLIC });
+      await user.click(screen.getByDisplayValue(GroupVisibility.PRIVATE));
+      await user.click(screen.getByRole('button', { name: 'form.saveChanges' }));
+
+      await waitFor(() => expect(screen.getByTestId('confirm-dialog')).toBeInTheDocument());
+      await user.click(screen.getByRole('button', { name: 'actions.cancel' }));
+
+      expect(mocks.mockPatch).not.toHaveBeenCalled();
+    });
+
+    it('does not show dialog when changing to PRIVATE from already-PRIVATE group (no transition)', async () => {
+      const { user } = setupEdit({
+        visibility: GroupVisibility.PRIVATE,
+        hasNonOwnerMembers: false,
+      });
+      await user.click(screen.getByRole('button', { name: 'form.saveChanges' }));
+
+      expect(screen.queryByTestId('confirm-dialog')).not.toBeInTheDocument();
+      await waitFor(() => {
+        expect(mocks.mockPatch).toHaveBeenCalled();
+      });
+    });
+
+    it('shows cannotMakePublic toast on GROUP_CANNOT_BE_MADE_PUBLIC API error', async () => {
+      const err = { response: { status: 400, data: { error: 'GROUP_CANNOT_BE_MADE_PUBLIC' } } };
+      mocks.mockPatch.mockRejectedValue(err);
+      mocks.mockIsAxiosError.mockReturnValue(true);
+
+      const { user } = setupEdit({
+        visibility: GroupVisibility.PRIVATE,
+        hasNonOwnerMembers: false,
+      });
+      await user.click(screen.getByRole('button', { name: 'form.saveChanges' }));
+
+      await waitFor(() => {
+        expect(mocks.mockToastError).toHaveBeenCalledWith('errors.cannotMakePublic');
+      });
+    });
+  });
+
+  describe('visibility hint (create mode)', () => {
+    it('shows irreversible hint when PRIVATE is selected', async () => {
+      const { user } = setupCreate();
+      await user.click(screen.getByDisplayValue(GroupVisibility.PRIVATE));
+      expect(screen.getByText('visibility.private_irreversible_hint')).toBeInTheDocument();
+    });
+
+    it('does not show irreversible hint when PUBLIC is selected', () => {
+      setupCreate();
+      expect(screen.queryByText('visibility.private_irreversible_hint')).not.toBeInTheDocument();
     });
   });
 });

--- a/apps/web/src/components/groups/GroupForm.test.tsx
+++ b/apps/web/src/components/groups/GroupForm.test.tsx
@@ -386,7 +386,7 @@ describe('GroupForm', () => {
       expect(mocks.mockPatch).not.toHaveBeenCalled();
     });
 
-    it('submits after confirming PUBLIC → PRIVATE change', async () => {
+    it('submits after confirming PUBLIC → PRIVATE change and closes dialog', async () => {
       const { user } = setupEdit({ visibility: GroupVisibility.PUBLIC });
       await user.click(screen.getByDisplayValue(GroupVisibility.PRIVATE));
       await user.click(screen.getByRole('button', { name: 'form.saveChanges' }));
@@ -399,6 +399,7 @@ describe('GroupForm', () => {
           '/v1/groups/group-uuid',
           expect.objectContaining({ visibility: GroupVisibility.PRIVATE }),
         );
+        expect(screen.queryByTestId('confirm-dialog')).not.toBeInTheDocument();
       });
     });
 
@@ -452,6 +453,11 @@ describe('GroupForm', () => {
 
     it('does not show irreversible hint when PUBLIC is selected', () => {
       setupCreate();
+      expect(screen.queryByText('visibility.private_irreversible_hint')).not.toBeInTheDocument();
+    });
+
+    it('does not show irreversible hint in edit mode even when PRIVATE is selected', () => {
+      setupEdit({ visibility: GroupVisibility.PRIVATE });
       expect(screen.queryByText('visibility.private_irreversible_hint')).not.toBeInTheDocument();
     });
   });

--- a/apps/web/src/components/groups/GroupForm.tsx
+++ b/apps/web/src/components/groups/GroupForm.tsx
@@ -33,10 +33,17 @@ interface GroupFormProps {
     description: string | null;
     visibility: GroupVisibility;
   };
+  hasNonOwnerMembers?: boolean;
   onSuccess: (group: Group) => void;
 }
 
-export function GroupForm({ mode, groupId, initialValues, onSuccess }: GroupFormProps) {
+export function GroupForm({
+  mode,
+  groupId,
+  initialValues,
+  hasNonOwnerMembers,
+  onSuccess,
+}: GroupFormProps) {
   const { t } = useTranslation(['groups', 'common']);
 
   const [name, setName] = useState(initialValues?.name ?? '');
@@ -50,7 +57,13 @@ export function GroupForm({ mode, groupId, initialValues, onSuccess }: GroupForm
   const [croppedBlob, setCroppedBlob] = useState<Blob | null>(null);
   const [photoPreviewUrl, setPhotoPreviewUrl] = useState<string | null>(null);
   const [isSaving, setIsSaving] = useState(false);
+  const [showPrivateConfirm, setShowPrivateConfirm] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const isPublicDisabled =
+    mode === 'edit' &&
+    hasNonOwnerMembers === true &&
+    initialValues?.visibility === GroupVisibility.PRIVATE;
 
   useEffect(() => {
     if (!croppedBlob) {
@@ -69,7 +82,7 @@ export function GroupForm({ mode, groupId, initialValues, onSuccess }: GroupForm
     setCropFile(file);
   }
 
-  async function handleSubmit() {
+  async function doSubmit() {
     setIsSaving(true);
     try {
       if (mode === 'create') {
@@ -106,11 +119,18 @@ export function GroupForm({ mode, groupId, initialValues, onSuccess }: GroupForm
           description: description.trim() || undefined,
           visibility,
         });
+        setShowPrivateConfirm(false);
         onSuccess(res.data);
       }
     } catch (err) {
+      const isCannotMakePublic =
+        axios.isAxiosError(err) &&
+        err.response?.status === 400 &&
+        (err.response.data as { error?: string }).error === 'GROUP_CANNOT_BE_MADE_PUBLIC';
       const isForbidden = axios.isAxiosError(err) && err.response?.status === 403;
-      if (isForbidden) {
+      if (isCannotMakePublic) {
+        toast.error(t('errors.cannotMakePublic'));
+      } else if (isForbidden) {
         toast.error(t('errors.forbidden'));
       } else {
         toast.error(mode === 'create' ? t('errors.createFailed') : t('errors.saveFailed'));
@@ -120,193 +140,264 @@ export function GroupForm({ mode, groupId, initialValues, onSuccess }: GroupForm
     }
   }
 
+  function handleSubmit() {
+    const isPublicToPrivate =
+      mode === 'edit' &&
+      initialValues?.visibility === GroupVisibility.PUBLIC &&
+      visibility === GroupVisibility.PRIVATE;
+
+    if (isPublicToPrivate) {
+      setShowPrivateConfirm(true);
+      return;
+    }
+
+    void doSubmit();
+  }
+
   const submitDisabled =
     isSaving ||
     name.trim().length < 2 ||
     (mode === 'create' && coverTab === 'photo' && !croppedBlob);
 
   return (
-    <form
-      onSubmit={(e) => {
-        e.preventDefault();
-        void handleSubmit();
-      }}
-      className="space-y-6"
-    >
-      <div className="space-y-1.5">
-        <Label htmlFor="group-name">{t('name')}</Label>
-        <Input
-          id="group-name"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-          placeholder={t('namePlaceholder')}
-          required
-          minLength={2}
-          maxLength={100}
-          disabled={isSaving}
-        />
-      </div>
+    <>
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          handleSubmit();
+        }}
+        className="space-y-6"
+      >
+        <div className="space-y-1.5">
+          <Label htmlFor="group-name">{t('name')}</Label>
+          <Input
+            id="group-name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder={t('namePlaceholder')}
+            required
+            minLength={2}
+            maxLength={100}
+            disabled={isSaving}
+          />
+        </div>
 
-      <div className="space-y-1.5">
-        <Label htmlFor="group-description">{t('description')}</Label>
-        <Textarea
-          id="group-description"
-          value={description}
-          onChange={(e) => setDescription(e.target.value)}
-          placeholder={t('descriptionPlaceholder')}
-          maxLength={500}
-          disabled={isSaving}
-          rows={3}
-        />
-      </div>
+        <div className="space-y-1.5">
+          <Label htmlFor="group-description">{t('description')}</Label>
+          <Textarea
+            id="group-description"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            placeholder={t('descriptionPlaceholder')}
+            maxLength={500}
+            disabled={isSaving}
+            rows={3}
+          />
+        </div>
 
-      <fieldset className="space-y-2">
-        <legend className="text-sm font-medium">{t('visibility.label')}</legend>
-        {[GroupVisibility.PUBLIC, GroupVisibility.PRIVATE].map((v) => (
-          <label
-            key={v}
-            className="flex cursor-pointer items-start gap-3 rounded-lg border border-border p-3 has-checked:border-primary has-checked:bg-primary/5"
-          >
-            <input
-              type="radio"
-              name="visibility"
-              value={v}
-              checked={visibility === v}
-              onChange={() => setVisibility(v)}
-              disabled={isSaving}
-              className="mt-0.5"
-            />
-            <div>
-              <p className="text-sm font-medium">
-                {v === GroupVisibility.PUBLIC ? t('visibility.public') : t('visibility.private')}
-              </p>
-              <p className="text-xs text-muted-foreground">
-                {v === GroupVisibility.PUBLIC
-                  ? t('visibility.public_desc')
-                  : t('visibility.private_desc')}
-              </p>
-            </div>
-          </label>
-        ))}
-      </fieldset>
+        <fieldset className="space-y-2">
+          <legend className="text-sm font-medium">{t('visibility.label')}</legend>
+          {[GroupVisibility.PUBLIC, GroupVisibility.PRIVATE].map((v) => {
+            const isDisabled = isSaving || (v === GroupVisibility.PUBLIC && isPublicDisabled);
+            return (
+              <label
+                key={v}
+                title={
+                  v === GroupVisibility.PUBLIC && isPublicDisabled
+                    ? t('visibility.public_disabled_tooltip')
+                    : undefined
+                }
+                className={`flex items-start gap-3 rounded-lg border border-border p-3 has-checked:border-primary has-checked:bg-primary/5 ${isDisabled ? 'cursor-not-allowed opacity-60' : 'cursor-pointer'}`}
+              >
+                <input
+                  type="radio"
+                  name="visibility"
+                  value={v}
+                  checked={visibility === v}
+                  onChange={() => setVisibility(v)}
+                  disabled={isDisabled}
+                  className="mt-0.5"
+                />
+                <div>
+                  <p className="text-sm font-medium">
+                    {v === GroupVisibility.PUBLIC
+                      ? t('visibility.public')
+                      : t('visibility.private')}
+                  </p>
+                  <p className="text-xs text-muted-foreground">
+                    {v === GroupVisibility.PUBLIC
+                      ? t('visibility.public_desc')
+                      : t('visibility.private_desc')}
+                  </p>
+                  {v === GroupVisibility.PRIVATE && visibility === GroupVisibility.PRIVATE && (
+                    <p className="mt-1 text-xs text-amber-600 dark:text-amber-400">
+                      {t('visibility.private_irreversible_hint')}
+                    </p>
+                  )}
+                </div>
+              </label>
+            );
+          })}
+        </fieldset>
 
-      {mode === 'create' && (
-        <div className="space-y-2">
-          <p className="text-sm font-medium">{t('cover.label')}</p>
+        {mode === 'create' && (
+          <div className="space-y-2">
+            <p className="text-sm font-medium">{t('cover.label')}</p>
 
-          {cropFile ? (
-            <CropModal
-              file={cropFile}
-              onConfirm={(blob) => {
-                setCroppedBlob(blob);
-                setCropFile(null);
-              }}
-              onCancel={() => setCropFile(null)}
-              isConfirming={false}
-              uploadProgress={0}
-              isUploading={false}
-              title={t('cover.cropTitle')}
-              confirmLabel={t('cover.usePhoto')}
-            />
-          ) : (
-            <>
-              <div className="flex gap-2 border-b">
-                {(['photo', 'emoji'] as CoverTab[]).map((tab) => (
-                  <button
-                    key={tab}
-                    type="button"
-                    onClick={() => setCoverTab(tab)}
-                    className={`pb-2 text-sm font-medium transition-colors ${
-                      coverTab === tab
-                        ? 'border-b-2 border-primary text-primary'
-                        : 'text-muted-foreground hover:text-foreground'
-                    }`}
-                  >
-                    {tab === 'photo' ? t('cover.tabImage') : t('cover.tabEmoji')}
-                  </button>
-                ))}
-              </div>
+            {cropFile ? (
+              <CropModal
+                file={cropFile}
+                onConfirm={(blob) => {
+                  setCroppedBlob(blob);
+                  setCropFile(null);
+                }}
+                onCancel={() => setCropFile(null)}
+                isConfirming={false}
+                uploadProgress={0}
+                isUploading={false}
+                title={t('cover.cropTitle')}
+                confirmLabel={t('cover.usePhoto')}
+              />
+            ) : (
+              <>
+                <div className="flex gap-2 border-b">
+                  {(['photo', 'emoji'] as CoverTab[]).map((tab) => (
+                    <button
+                      key={tab}
+                      type="button"
+                      onClick={() => setCoverTab(tab)}
+                      className={`pb-2 text-sm font-medium transition-colors ${
+                        coverTab === tab
+                          ? 'border-b-2 border-primary text-primary'
+                          : 'text-muted-foreground hover:text-foreground'
+                      }`}
+                    >
+                      {tab === 'photo' ? t('cover.tabImage') : t('cover.tabEmoji')}
+                    </button>
+                  ))}
+                </div>
 
-              <div className="mt-3">
-                {coverTab === 'photo' && (
-                  <>
-                    <input
-                      ref={fileInputRef}
-                      type="file"
-                      accept="image/jpeg,image/png,image/webp"
-                      onChange={handleFileChange}
-                      className="hidden"
-                      aria-hidden="true"
-                    />
-                    {photoPreviewUrl ? (
-                      <div className="flex items-center gap-3">
-                        <img
-                          src={photoPreviewUrl}
-                          alt=""
-                          className="size-12 rounded-lg object-cover"
-                          aria-hidden="true"
-                        />
+                <div className="mt-3">
+                  {coverTab === 'photo' && (
+                    <>
+                      <input
+                        ref={fileInputRef}
+                        type="file"
+                        accept="image/jpeg,image/png,image/webp"
+                        onChange={handleFileChange}
+                        className="hidden"
+                        aria-hidden="true"
+                      />
+                      {photoPreviewUrl ? (
+                        <div className="flex items-center gap-3">
+                          <img
+                            src={photoPreviewUrl}
+                            alt=""
+                            className="size-12 rounded-lg object-cover"
+                            aria-hidden="true"
+                          />
+                          <button
+                            type="button"
+                            onClick={() => fileInputRef.current?.click()}
+                            disabled={isSaving}
+                            className="text-sm font-medium underline-offset-2 hover:underline disabled:opacity-50"
+                          >
+                            {t('cover.editButton')}
+                          </button>
+                        </div>
+                      ) : (
                         <button
                           type="button"
                           onClick={() => fileInputRef.current?.click()}
                           disabled={isSaving}
-                          className="text-sm font-medium underline-offset-2 hover:underline disabled:opacity-50"
+                          className="inline-flex w-full items-center justify-center gap-2 rounded-lg border border-border bg-background px-3 py-1.5 text-sm font-medium transition-colors hover:bg-muted disabled:pointer-events-none disabled:opacity-50"
                         >
-                          {t('cover.editButton')}
+                          {t('common:upload.chooseFile')}
                         </button>
-                      </div>
-                    ) : (
-                      <button
-                        type="button"
-                        onClick={() => fileInputRef.current?.click()}
-                        disabled={isSaving}
-                        className="inline-flex w-full items-center justify-center gap-2 rounded-lg border border-border bg-background px-3 py-1.5 text-sm font-medium transition-colors hover:bg-muted disabled:pointer-events-none disabled:opacity-50"
-                      >
-                        {t('common:upload.chooseFile')}
-                      </button>
-                    )}
-                  </>
-                )}
+                      )}
+                    </>
+                  )}
 
-                {coverTab === 'emoji' && (
-                  <div className="grid grid-cols-8 gap-2">
-                    {AVATAR_EMOJIS.map((emoji) => (
-                      <button
-                        key={emoji}
-                        type="button"
-                        onClick={() => setSelectedEmoji(emoji)}
-                        disabled={isSaving}
-                        aria-label={emoji}
-                        aria-pressed={selectedEmoji === emoji}
-                        className={`flex size-10 items-center justify-center rounded-lg transition-colors disabled:opacity-50 ${
-                          selectedEmoji === emoji
-                            ? 'bg-primary/10 ring-2 ring-primary'
-                            : 'hover:bg-muted'
-                        }`}
-                      >
-                        <img
-                          src={getTwemojiUrl(emoji)}
-                          alt={emoji}
-                          className="size-6"
-                          aria-hidden="true"
-                        />
-                      </button>
-                    ))}
-                  </div>
-                )}
-              </div>
-            </>
-          )}
+                  {coverTab === 'emoji' && (
+                    <div className="grid grid-cols-8 gap-2">
+                      {AVATAR_EMOJIS.map((emoji) => (
+                        <button
+                          key={emoji}
+                          type="button"
+                          onClick={() => setSelectedEmoji(emoji)}
+                          disabled={isSaving}
+                          aria-label={emoji}
+                          aria-pressed={selectedEmoji === emoji}
+                          className={`flex size-10 items-center justify-center rounded-lg transition-colors disabled:opacity-50 ${
+                            selectedEmoji === emoji
+                              ? 'bg-primary/10 ring-2 ring-primary'
+                              : 'hover:bg-muted'
+                          }`}
+                        >
+                          <img
+                            src={getTwemojiUrl(emoji)}
+                            alt={emoji}
+                            className="size-6"
+                            aria-hidden="true"
+                          />
+                        </button>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </>
+            )}
+          </div>
+        )}
+
+        <button
+          type="submit"
+          disabled={submitDisabled}
+          className="inline-flex w-full items-center justify-center rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:pointer-events-none disabled:opacity-50"
+        >
+          {isSaving
+            ? t('form.saving')
+            : mode === 'create'
+              ? t('form.submit')
+              : t('form.saveChanges')}
+        </button>
+      </form>
+
+      {showPrivateConfirm && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="private-confirm-title"
+          data-testid="confirm-dialog"
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm"
+        >
+          <div className="mx-4 w-full max-w-sm rounded-xl bg-card p-6 shadow-xl ring-1 ring-foreground/10">
+            <h2 id="private-confirm-title" className="text-lg font-semibold">
+              {t('visibility.makePrivateConfirmTitle')}
+            </h2>
+            <p className="mt-2 text-sm text-muted-foreground">
+              {t('visibility.makePrivateWarning')}
+            </p>
+            <div className="mt-4 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+              <button
+                type="button"
+                onClick={() => setShowPrivateConfirm(false)}
+                className="inline-flex items-center justify-center rounded-lg border border-border bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-muted"
+              >
+                {t('common:actions.cancel')}
+              </button>
+              <button
+                type="button"
+                data-testid="confirm-make-private"
+                onClick={doSubmit}
+                className="inline-flex items-center justify-center rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+              >
+                {t('visibility.makePrivateConfirm')}
+              </button>
+            </div>
+          </div>
         </div>
       )}
-
-      <button
-        type="submit"
-        disabled={submitDisabled}
-        className="inline-flex w-full items-center justify-center rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:pointer-events-none disabled:opacity-50"
-      >
-        {isSaving ? t('form.saving') : mode === 'create' ? t('form.submit') : t('form.saveChanges')}
-      </button>
-    </form>
+    </>
   );
 }

--- a/apps/web/src/components/groups/GroupForm.tsx
+++ b/apps/web/src/components/groups/GroupForm.tsx
@@ -229,11 +229,13 @@ export function GroupForm({
                       ? t('visibility.public_desc')
                       : t('visibility.private_desc')}
                   </p>
-                  {v === GroupVisibility.PRIVATE && visibility === GroupVisibility.PRIVATE && (
-                    <p className="mt-1 text-xs text-amber-600 dark:text-amber-400">
-                      {t('visibility.private_irreversible_hint')}
-                    </p>
-                  )}
+                  {mode === 'create' &&
+                    v === GroupVisibility.PRIVATE &&
+                    visibility === GroupVisibility.PRIVATE && (
+                      <p className="mt-1 text-xs text-amber-600 dark:text-amber-400">
+                        {t('visibility.private_irreversible_hint')}
+                      </p>
+                    )}
                 </div>
               </label>
             );

--- a/apps/web/src/components/groups/GroupForm.tsx
+++ b/apps/web/src/components/groups/GroupForm.tsx
@@ -197,7 +197,7 @@ export function GroupForm({
 
         <fieldset className="space-y-2">
           <legend className="text-sm font-medium">{t('visibility.label')}</legend>
-          {[GroupVisibility.PUBLIC, GroupVisibility.PRIVATE].map((v) => {
+          {[GroupVisibility.PUBLIC, GroupVisibility.PRIVATE].map((v: GroupVisibility) => {
             const isDisabled = isSaving || (v === GroupVisibility.PUBLIC && isPublicDisabled);
             return (
               <label

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -310,7 +310,12 @@
       "public": "Public",
       "public_desc": "Anyone can find and request to join",
       "private": "Private",
-      "private_desc": "Only invited people can join"
+      "private_desc": "Only invited people can join",
+      "private_irreversible_hint": "Once the group has members, it cannot be made public again.",
+      "public_disabled_tooltip": "Groups with members cannot be made public.",
+      "makePrivateWarning": "This change is irreversible once the group has members. You will not be able to make the group public again.",
+      "makePrivateConfirmTitle": "Make group private?",
+      "makePrivateConfirm": "Make private"
     },
     "cover": {
       "label": "Cover",
@@ -364,7 +369,8 @@
       "forbidden": "You don't have permission to do that",
       "deleteFailed": "Failed to delete group",
       "createFailed": "Failed to create group",
-      "saveFailed": "Failed to save changes"
+      "saveFailed": "Failed to save changes",
+      "cannotMakePublic": "Groups with members cannot be made public."
     }
   },
   "profile": {

--- a/apps/web/src/locales/es.json
+++ b/apps/web/src/locales/es.json
@@ -310,7 +310,12 @@
       "public": "Público",
       "public_desc": "Cualquiera puede encontrarlo y solicitar unirse",
       "private": "Privado",
-      "private_desc": "Solo personas invitadas pueden unirse"
+      "private_desc": "Solo personas invitadas pueden unirse",
+      "private_irreversible_hint": "Una vez que el grupo tenga miembros, no podrá volver a ser público.",
+      "public_disabled_tooltip": "Los grupos con miembros no pueden hacerse públicos.",
+      "makePrivateWarning": "Este cambio es irreversible una vez que el grupo tenga miembros. No podrás volver a hacerlo público.",
+      "makePrivateConfirmTitle": "¿Hacer el grupo privado?",
+      "makePrivateConfirm": "Hacer privado"
     },
     "cover": {
       "label": "Portada",
@@ -364,7 +369,8 @@
       "forbidden": "No tienes permiso para hacer eso",
       "deleteFailed": "Error al eliminar el grupo",
       "createFailed": "Error al crear el grupo",
-      "saveFailed": "Error al guardar los cambios"
+      "saveFailed": "Error al guardar los cambios",
+      "cannotMakePublic": "Los grupos con miembros no pueden hacerse públicos."
     }
   },
   "profile": {


### PR DESCRIPTION
## Summary

Group privacy changes needed guardrails to protect members' expectations. A private group's members joined with a privacy expectation — silently making it public would be a breach of trust. Conversely, switching from public to private is irreversible once non-owner members are present, so users need a warning before committing.

## Changes

**Backend**
- `GroupsService.updateGroup`: rejects `PRIVATE → PUBLIC` with `400 GROUP_CANNOT_BE_MADE_PUBLIC` when the group has active non-owner members
- Updated `@ApiBadRequestResponse` on `PATCH /v1/groups/:id` to document the new error code

**Frontend — GroupForm (edit mode)**
- PUBLIC radio is disabled (with tooltip) when group is already PRIVATE and has non-owner members
- Switching PUBLIC → PRIVATE shows a confirmation dialog warning the user the change is irreversible before the PATCH is sent
- `GROUP_CANNOT_BE_MADE_PUBLIC` API error is surfaced as a toast

**Frontend — GroupForm (create mode)**
- Static irreversibility hint rendered under the PRIVATE option ("Once the group has members, it cannot be made public again.")

**Settings page**
- Fetches group members in parallel with the group on load; computes `hasNonOwnerMembers` to pass to `GroupForm`

**i18n**
- Added 5 new keys to `groups` namespace (`visibility.private_irreversible_hint`, `visibility.public_disabled_tooltip`, `visibility.makePrivateConfirmTitle`, `visibility.makePrivateWarning`, `visibility.makePrivateConfirm`) and `errors.cannotMakePublic` — parity maintained in `es.json`

## Testing

- Backend: 2 new unit tests — rejects PRIVATE→PUBLIC with non-owner members; allows it when no non-owner members
- Frontend: 10 new component tests covering disabled PUBLIC option, confirmation dialog (appear / confirm / cancel), no-dialog for already-PRIVATE groups, `cannotMakePublic` toast, and create-mode hint
- All 1274 web tests and 52 API tests pass; coverage above 90% threshold

## Notes

The confirmation dialog is implemented as an inline overlay div (not the Dialog component) to keep the form self-contained and avoid portal-related test complexity.

Closes #283