### PR TITLE
refactor(web): named React imports + PWA install mobile-only

### DIFF
--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -228,6 +228,29 @@ import { FileUploadButton, UploadType } from '@/components/ui/file-upload-button
 - `upload.errorDefault` — user-facing error message
 - `upload.progressLabel` — ARIA label for the progress bar (`Upload progress: {{progress}}%`)
 
+### 5. React imports — always use named imports
+
+Next.js uses the automatic JSX transform. **Never use `import React from 'react'` or `import * as React from 'react'`** — neither is needed for JSX and both pull in the entire module as a namespace.
+
+**Rules:**
+
+- Import only the specific APIs you need: `useState`, `useRef`, `type ComponentProps`, etc.
+- Use `import type` (or the `type` modifier per-import) for type-only imports.
+- Never reference `React.X` — always destructure the name you need.
+
+```tsx
+// ✅ Correct
+import { useState, type ComponentProps, type ReactNode } from 'react';
+import { type ComponentPropsWithoutRef } from 'react';
+
+// ❌ Wrong — never use these patterns
+import React from 'react';
+import * as React from 'react';
+// and never use React.useState, React.ComponentProps, React.ReactNode, etc.
+```
+
+**Exception:** `React.createElement` must be replaced with the named `createElement` import.
+
 ### 4. React event types — use the React 19 replacements, not FormEvent
 
 `FormEvent` and `FormEventHandler` are **deprecated** in React 19 (`@deprecated FormEvent doesn't actually exist`). Use the specific React event types instead.

--- a/apps/web/src/components/IosPwaPrompt.test.tsx
+++ b/apps/web/src/components/IosPwaPrompt.test.tsx
@@ -115,6 +115,27 @@ describe('IosPwaPrompt', () => {
     });
   });
 
+  describe('desktop suppression', () => {
+    it('does not show on desktop even when beforeinstallprompt fires', () => {
+      setUserAgent(
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+      );
+      render(<IosPwaPrompt />);
+      const calls = (window.addEventListener as ReturnType<typeof vi.fn>).mock.calls;
+      const hasListener = calls.some((args: unknown[]) => args[0] === 'beforeinstallprompt');
+      expect(hasListener).toBe(false);
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+
+    it('does not show on desktop Safari', () => {
+      setUserAgent(
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 14_0) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15',
+      );
+      render(<IosPwaPrompt />);
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+  });
+
   describe('Android / beforeinstallprompt', () => {
     it('does not show before beforeinstallprompt fires', () => {
       render(<IosPwaPrompt />);

--- a/apps/web/src/components/IosPwaPrompt.tsx
+++ b/apps/web/src/components/IosPwaPrompt.tsx
@@ -21,6 +21,14 @@ function isIosSafari(): boolean {
   return isIos && isSafari;
 }
 
+function isMobileDevice(): boolean {
+  if (typeof navigator === 'undefined') return false;
+  if ('userAgentData' in navigator) {
+    return (navigator as { userAgentData?: { mobile: boolean } }).userAgentData?.mobile ?? false;
+  }
+  return /android|iphone|ipad|ipod/i.test(navigator.userAgent);
+}
+
 function isInStandaloneMode(): boolean {
   if (typeof window === 'undefined') return false;
   return (
@@ -43,6 +51,7 @@ export function IosPwaPrompt() {
 
   useEffect(() => {
     if (isInStandaloneMode()) return;
+    if (!isMobileDevice()) return;
     if (!shouldShow()) return;
 
     if (isIosSafari()) {

--- a/apps/web/src/components/groups/GroupForm.test.tsx
+++ b/apps/web/src/components/groups/GroupForm.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { GroupVisibility, UploadType } from '@chamuco/shared-types';

--- a/apps/web/src/components/groups/members/InviteMemberModal.test.tsx
+++ b/apps/web/src/components/groups/members/InviteMemberModal.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { type ComponentProps, type ReactNode } from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -22,9 +22,9 @@ vi.mock('@/hooks/useUserSearch', () => ({
 
 vi.mock('@base-ui/react/avatar', () => ({
   Avatar: {
-    Root: ({ children, ...props }: React.ComponentProps<'div'>) => <div {...props}>{children}</div>,
-    Image: ({ src, alt }: React.ComponentProps<'img'>) => <img src={src} alt={alt} />,
-    Fallback: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+    Root: ({ children, ...props }: ComponentProps<'div'>) => <div {...props}>{children}</div>,
+    Image: ({ src, alt }: ComponentProps<'img'>) => <img src={src} alt={alt} />,
+    Fallback: ({ children }: { children: ReactNode }) => <span>{children}</span>,
   },
 }));
 

--- a/apps/web/src/components/groups/members/InviteMemberModal.tsx
+++ b/apps/web/src/components/groups/members/InviteMemberModal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState } from 'react';
+import { useState, type SubmitEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 import { UserPlusIcon } from '@phosphor-icons/react';
 import { apiClient } from '@/services/api-client';
@@ -73,7 +73,7 @@ export function InviteMemberModal({ groupId, onSuccess, excludedIds }: InviteMem
     setSelectionError(null);
   }
 
-  const handleSubmit = async (e: React.SubmitEvent) => {
+  const handleSubmit = async (e: SubmitEvent) => {
     e.preventDefault();
     if (selectedUsers.length === 0) return;
 

--- a/apps/web/src/components/header/UserAvatar.test.tsx
+++ b/apps/web/src/components/header/UserAvatar.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { type ComponentProps, type ReactNode } from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type { User } from 'firebase/auth';
@@ -41,24 +41,24 @@ vi.mock('react-i18next', () => ({
 
 // Menu primitives use portals — stub them so assertions work in jsdom
 vi.mock('@/components/ui/menu', () => ({
-  MenuRoot: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  MenuTrigger: ({ children, ...props }: React.ComponentProps<'button'>) => (
+  MenuRoot: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  MenuTrigger: ({ children, ...props }: ComponentProps<'button'>) => (
     <button {...props}>{children}</button>
   ),
-  MenuPopup: ({ children }: { children: React.ReactNode }) => (
+  MenuPopup: ({ children }: { children: ReactNode }) => (
     <div data-testid="menu-popup">{children}</div>
   ),
   MenuItem: ({
     children,
     onClick,
     className,
-  }: React.ComponentProps<'div'> & { onClick?: () => void }) => (
+  }: ComponentProps<'div'> & { onClick?: () => void }) => (
     <div role="menuitem" onClick={onClick} className={className}>
       {children}
     </div>
   ),
   MenuSeparator: () => <hr />,
-  MenuLabel: ({ children }: { children: React.ReactNode }) => (
+  MenuLabel: ({ children }: { children: ReactNode }) => (
     <div data-testid="menu-label">{children}</div>
   ),
 }));

--- a/apps/web/src/components/layout/AppShell.test.tsx
+++ b/apps/web/src/components/layout/AppShell.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { type ReactNode } from 'react';
 import { render, screen } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import { AppShell } from './AppShell';
@@ -24,7 +24,7 @@ vi.mock('@/components/navigation', () => ({
 }));
 
 vi.mock('@/store/group-invitations', () => ({
-  GroupInvitationsProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  GroupInvitationsProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
   useGroupInvitations: vi.fn(() => ({
     invitations: [],
     count: 0,

--- a/apps/web/src/components/profile/HealthSection.test.tsx
+++ b/apps/web/src/components/profile/HealthSection.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { type ComponentProps } from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -24,11 +24,11 @@ vi.mock('react-i18next', () => ({
 }));
 
 vi.mock('@/components/ui/input', () => ({
-  Input: (props: React.ComponentProps<'input'>) => <input {...props} />,
+  Input: (props: ComponentProps<'input'>) => <input {...props} />,
 }));
 
 vi.mock('@/components/ui/textarea', () => ({
-  Textarea: (props: React.ComponentProps<'textarea'>) => <textarea {...props} />,
+  Textarea: (props: ComponentProps<'textarea'>) => <textarea {...props} />,
 }));
 
 vi.mock('@/components/ui/spinner', () => ({
@@ -36,13 +36,11 @@ vi.mock('@/components/ui/spinner', () => ({
 }));
 
 vi.mock('@/components/ui/button', () => ({
-  Button: (props: React.ComponentProps<'button'>) => <button {...props} />,
+  Button: (props: ComponentProps<'button'>) => <button {...props} />,
 }));
 
 vi.mock('@/components/ui/label', () => ({
-  Label: ({ children, ...props }: React.ComponentProps<'label'>) => (
-    <label {...props}>{children}</label>
-  ),
+  Label: ({ children, ...props }: ComponentProps<'label'>) => <label {...props}>{children}</label>,
 }));
 
 import { HealthSection } from './HealthSection';

--- a/apps/web/src/components/profile/PersonalDetailsSection.test.tsx
+++ b/apps/web/src/components/profile/PersonalDetailsSection.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { type ComponentProps } from 'react';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -37,7 +37,7 @@ vi.mock('countries-list', () => ({
 }));
 
 vi.mock('@/components/ui/input', () => ({
-  Input: (props: React.ComponentProps<'input'>) => <input {...props} />,
+  Input: (props: ComponentProps<'input'>) => <input {...props} />,
 }));
 
 vi.mock('@/components/ui/country-combobox', () => ({

--- a/apps/web/src/components/ui/avatar.test.tsx
+++ b/apps/web/src/components/ui/avatar.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { type ComponentProps, type ReactNode } from 'react';
 import { render, screen } from '@testing-library/react';
 import { describe, it, expect } from 'vitest';
 
@@ -6,11 +6,11 @@ import { describe, it, expect } from 'vitest';
 // Stub the primitives so the <img> is always rendered for prop assertions.
 vi.mock('@base-ui/react/avatar', () => ({
   Avatar: {
-    Root: ({ children, ...props }: React.ComponentProps<'div'>) => <div {...props}>{children}</div>,
-    Image: ({ src, alt, className, referrerPolicy }: React.ComponentProps<'img'>) => (
+    Root: ({ children, ...props }: ComponentProps<'div'>) => <div {...props}>{children}</div>,
+    Image: ({ src, alt, className, referrerPolicy }: ComponentProps<'img'>) => (
       <img src={src} alt={alt} className={className} referrerPolicy={referrerPolicy} />
     ),
-    Fallback: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+    Fallback: ({ children }: { children: ReactNode }) => <span>{children}</span>,
   },
 }));
 

--- a/apps/web/src/components/ui/avatar.tsx
+++ b/apps/web/src/components/ui/avatar.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { type ComponentPropsWithoutRef, type ReactNode } from 'react';
 import { Avatar as AvatarPrimitive } from '@base-ui/react/avatar';
 import { cva, type VariantProps } from 'class-variance-authority';
 
@@ -22,7 +22,7 @@ const avatarVariants = cva(
 
 export interface AvatarProps
   extends
-    React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Root>,
+    ComponentPropsWithoutRef<typeof AvatarPrimitive.Root>,
     VariantProps<typeof avatarVariants> {
   src?: string;
   /**
@@ -31,7 +31,7 @@ export interface AvatarProps
    * For standalone avatars (e.g. in a list), pass the user's full name.
    */
   alt?: string;
-  fallback?: React.ReactNode;
+  fallback?: ReactNode;
 }
 
 function Avatar({ className, size, src, alt, fallback, ...props }: AvatarProps) {

--- a/apps/web/src/components/ui/badge.tsx
+++ b/apps/web/src/components/ui/badge.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { type ComponentProps } from 'react';
 import { cva, type VariantProps } from 'class-variance-authority';
 
 import { cn } from '@/lib/utils';
@@ -20,8 +20,7 @@ const badgeVariants = cva(
   },
 );
 
-export interface BadgeProps
-  extends React.ComponentProps<'span'>, VariantProps<typeof badgeVariants> {}
+export interface BadgeProps extends ComponentProps<'span'>, VariantProps<typeof badgeVariants> {}
 
 function Badge({ className, variant, ...props }: BadgeProps) {
   return (

--- a/apps/web/src/components/ui/card.tsx
+++ b/apps/web/src/components/ui/card.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { type ComponentProps } from 'react';
 
 import { cn } from '@/lib/utils';
 
@@ -6,7 +6,7 @@ function Card({
   className,
   size = 'default',
   ...props
-}: React.ComponentProps<'div'> & { size?: 'default' | 'sm' }) {
+}: ComponentProps<'div'> & { size?: 'default' | 'sm' }) {
   return (
     <div
       data-slot="card"
@@ -20,7 +20,7 @@ function Card({
   );
 }
 
-function CardHeader({ className, ...props }: React.ComponentProps<'div'>) {
+function CardHeader({ className, ...props }: ComponentProps<'div'>) {
   return (
     <div
       data-slot="card-header"
@@ -33,7 +33,7 @@ function CardHeader({ className, ...props }: React.ComponentProps<'div'>) {
   );
 }
 
-function CardTitle({ className, ...props }: React.ComponentProps<'div'>) {
+function CardTitle({ className, ...props }: ComponentProps<'div'>) {
   return (
     <div
       data-slot="card-title"
@@ -46,7 +46,7 @@ function CardTitle({ className, ...props }: React.ComponentProps<'div'>) {
   );
 }
 
-function CardDescription({ className, ...props }: React.ComponentProps<'div'>) {
+function CardDescription({ className, ...props }: ComponentProps<'div'>) {
   return (
     <div
       data-slot="card-description"
@@ -56,7 +56,7 @@ function CardDescription({ className, ...props }: React.ComponentProps<'div'>) {
   );
 }
 
-function CardAction({ className, ...props }: React.ComponentProps<'div'>) {
+function CardAction({ className, ...props }: ComponentProps<'div'>) {
   return (
     <div
       data-slot="card-action"
@@ -66,7 +66,7 @@ function CardAction({ className, ...props }: React.ComponentProps<'div'>) {
   );
 }
 
-function CardContent({ className, ...props }: React.ComponentProps<'div'>) {
+function CardContent({ className, ...props }: ComponentProps<'div'>) {
   return (
     <div
       data-slot="card-content"
@@ -76,7 +76,7 @@ function CardContent({ className, ...props }: React.ComponentProps<'div'>) {
   );
 }
 
-function CardFooter({ className, ...props }: React.ComponentProps<'div'>) {
+function CardFooter({ className, ...props }: ComponentProps<'div'>) {
   return (
     <div
       data-slot="card-footer"

--- a/apps/web/src/components/ui/city-combobox.tsx
+++ b/apps/web/src/components/ui/city-combobox.tsx
@@ -28,13 +28,15 @@ function CityCombobox({
 }: CityComboboxProps) {
   const [query, setQuery] = useState(value);
   const [open, setOpen] = useState(false);
-  const { results, isLoading } = useCitySearch(country, query);
+  const [userHasTyped, setUserHasTyped] = useState(false);
+  const { results, isLoading } = useCitySearch(country, userHasTyped ? query : '');
 
   useEffect(() => {
     setQuery(value);
   }, [value]);
 
   function handleChange(raw: string) {
+    setUserHasTyped(true);
     const upper = raw.toUpperCase();
     setQuery(upper);
     if (upper === '') onChange('');

--- a/apps/web/src/components/ui/command.tsx
+++ b/apps/web/src/components/ui/command.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import * as React from 'react';
+import { type ComponentPropsWithoutRef } from 'react';
 import {
   Command as CommandPrimitive,
   CommandEmpty,
@@ -14,7 +14,7 @@ import { MagnifyingGlassIcon } from '@phosphor-icons/react';
 
 import { cn } from '@/lib/utils';
 
-function Command({ className, ...props }: React.ComponentPropsWithoutRef<typeof CommandPrimitive>) {
+function Command({ className, ...props }: ComponentPropsWithoutRef<typeof CommandPrimitive>) {
   return (
     <CommandPrimitive
       className={cn(
@@ -26,10 +26,7 @@ function Command({ className, ...props }: React.ComponentPropsWithoutRef<typeof 
   );
 }
 
-function CommandSearch({
-  className,
-  ...props
-}: React.ComponentPropsWithoutRef<typeof CommandInput>) {
+function CommandSearch({ className, ...props }: ComponentPropsWithoutRef<typeof CommandInput>) {
   return (
     <div className="flex items-center border-b border-border px-3" cmdk-input-wrapper="">
       <MagnifyingGlassIcon className="mr-2 size-4 shrink-0 text-muted-foreground" />
@@ -44,7 +41,7 @@ function CommandSearch({
   );
 }
 
-function CommandItems({ className, ...props }: React.ComponentPropsWithoutRef<typeof CommandList>) {
+function CommandItems({ className, ...props }: ComponentPropsWithoutRef<typeof CommandList>) {
   return (
     <CommandList
       className={cn('max-h-64 overflow-y-auto overflow-x-hidden', className)}
@@ -53,10 +50,7 @@ function CommandItems({ className, ...props }: React.ComponentPropsWithoutRef<ty
   );
 }
 
-function CommandNoResults({
-  className,
-  ...props
-}: React.ComponentPropsWithoutRef<typeof CommandEmpty>) {
+function CommandNoResults({ className, ...props }: ComponentPropsWithoutRef<typeof CommandEmpty>) {
   return (
     <CommandEmpty
       className={cn('py-6 text-center text-sm text-muted-foreground', className)}
@@ -68,7 +62,7 @@ function CommandNoResults({
 function CommandGroupSection({
   className,
   ...props
-}: React.ComponentPropsWithoutRef<typeof CommandGroup>) {
+}: ComponentPropsWithoutRef<typeof CommandGroup>) {
   return (
     <CommandGroup
       className={cn(
@@ -80,10 +74,7 @@ function CommandGroupSection({
   );
 }
 
-function CommandOption({
-  className,
-  ...props
-}: React.ComponentPropsWithoutRef<typeof CommandItem>) {
+function CommandOption({ className, ...props }: ComponentPropsWithoutRef<typeof CommandItem>) {
   return (
     <CommandItem
       className={cn(

--- a/apps/web/src/components/ui/country-combobox.tsx
+++ b/apps/web/src/components/ui/country-combobox.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import * as React from 'react';
+import { useState } from 'react';
 import { getCountryDataList, getEmojiFlag, type ICountryData } from 'countries-list';
 import { CaretUpDownIcon, CheckIcon } from '@phosphor-icons/react';
 
@@ -58,7 +58,7 @@ function CountryCombobox({
   'aria-labelledby': ariaLabelledBy,
   'data-testid': testId,
 }: CountryComboboxProps) {
-  const [open, setOpen] = React.useState(false);
+  const [open, setOpen] = useState(false);
   const selected = value ? ALL_COUNTRIES.find((c) => c.iso2 === value) : undefined;
 
   const triggerLabel = selected

--- a/apps/web/src/components/ui/date-of-birth-field.test.tsx
+++ b/apps/web/src/components/ui/date-of-birth-field.test.tsx
@@ -1,17 +1,17 @@
-import React from 'react';
+import { type ComponentProps } from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 vi.mock('@/components/ui/button', () => ({
-  Button: (props: React.ComponentProps<'button'>) => <button {...props} />,
+  Button: (props: ComponentProps<'button'>) => <button {...props} />,
 }));
 
 vi.mock('@/components/ui/input', () => ({
-  Input: (props: React.ComponentProps<'input'>) => <input {...props} />,
+  Input: (props: ComponentProps<'input'>) => <input {...props} />,
 }));
 
 vi.mock('@/components/ui/label', () => ({
-  Label: (props: React.ComponentProps<'label'>) => <label {...props} />,
+  Label: (props: ComponentProps<'label'>) => <label {...props} />,
 }));
 
 vi.mock('@/components/ui/field-message', () => ({

--- a/apps/web/src/components/ui/dialog.tsx
+++ b/apps/web/src/components/ui/dialog.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import * as React from 'react';
+import { type ComponentProps, type ComponentPropsWithoutRef } from 'react';
 import { Dialog as DialogPrimitive } from '@base-ui/react/dialog';
 import { XIcon } from '@phosphor-icons/react';
 
@@ -14,7 +14,7 @@ const DialogTrigger = DialogPrimitive.Trigger;
 function DialogBackdrop({
   className,
   ...props
-}: React.ComponentPropsWithoutRef<typeof DialogPrimitive.Backdrop>) {
+}: ComponentPropsWithoutRef<typeof DialogPrimitive.Backdrop>) {
   return (
     <DialogPrimitive.Backdrop
       className={cn(
@@ -31,7 +31,7 @@ function DialogPopup({
   className,
   children,
   ...props
-}: React.ComponentPropsWithoutRef<typeof DialogPrimitive.Popup>) {
+}: ComponentPropsWithoutRef<typeof DialogPrimitive.Popup>) {
   return (
     <DialogPrimitive.Portal>
       <DialogBackdrop />
@@ -53,13 +53,13 @@ function DialogPopup({
   );
 }
 
-function DialogHeader({ className, ...props }: React.ComponentProps<'div'>) {
+function DialogHeader({ className, ...props }: ComponentProps<'div'>) {
   return (
     <div data-slot="dialog-header" className={cn('flex flex-col gap-1.5', className)} {...props} />
   );
 }
 
-function DialogFooter({ className, ...props }: React.ComponentProps<'div'>) {
+function DialogFooter({ className, ...props }: ComponentProps<'div'>) {
   return (
     <div
       data-slot="dialog-footer"
@@ -72,7 +72,7 @@ function DialogFooter({ className, ...props }: React.ComponentProps<'div'>) {
 function DialogTitle({
   className,
   ...props
-}: React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>) {
+}: ComponentPropsWithoutRef<typeof DialogPrimitive.Title>) {
   return (
     <DialogPrimitive.Title
       className={cn('text-lg font-semibold leading-none tracking-tight', className)}
@@ -84,7 +84,7 @@ function DialogTitle({
 function DialogDescription({
   className,
   ...props
-}: React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>) {
+}: ComponentPropsWithoutRef<typeof DialogPrimitive.Description>) {
   return (
     <DialogPrimitive.Description
       className={cn('text-sm text-muted-foreground', className)}
@@ -97,7 +97,7 @@ function DialogClose({
   className,
   children,
   ...props
-}: React.ComponentPropsWithoutRef<typeof DialogPrimitive.Close>) {
+}: ComponentPropsWithoutRef<typeof DialogPrimitive.Close>) {
   return (
     <DialogPrimitive.Close
       className={cn(

--- a/apps/web/src/components/ui/empty-state.tsx
+++ b/apps/web/src/components/ui/empty-state.tsx
@@ -1,12 +1,12 @@
-import * as React from 'react';
+import { type ComponentProps, type ReactNode } from 'react';
 
 import { cn } from '@/lib/utils';
 
-export interface EmptyStateProps extends Omit<React.ComponentProps<'div'>, 'title'> {
-  icon?: React.ReactNode;
-  title: React.ReactNode;
-  description?: React.ReactNode;
-  action?: React.ReactNode;
+export interface EmptyStateProps extends Omit<ComponentProps<'div'>, 'title'> {
+  icon?: ReactNode;
+  title: ReactNode;
+  description?: ReactNode;
+  action?: ReactNode;
 }
 
 function EmptyState({ className, icon, title, description, action, ...props }: EmptyStateProps) {

--- a/apps/web/src/components/ui/input.tsx
+++ b/apps/web/src/components/ui/input.tsx
@@ -1,9 +1,9 @@
-import * as React from 'react';
+import { type ComponentProps } from 'react';
 import { Input as InputPrimitive } from '@base-ui/react/input';
 
 import { cn } from '@/lib/utils';
 
-function Input({ className, type, ...props }: React.ComponentProps<'input'>) {
+function Input({ className, type, ...props }: ComponentProps<'input'>) {
   return (
     <InputPrimitive
       type={type}

--- a/apps/web/src/components/ui/label.tsx
+++ b/apps/web/src/components/ui/label.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import * as React from 'react';
+import { type ComponentProps } from 'react';
 
 import { cn } from '@/lib/utils';
 
-function Label({ className, ...props }: React.ComponentProps<'label'>) {
+function Label({ className, ...props }: ComponentProps<'label'>) {
   return (
     <label
       data-slot="label"

--- a/apps/web/src/components/ui/loyalty-program-combobox.test.tsx
+++ b/apps/web/src/components/ui/loyalty-program-combobox.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { type ComponentProps } from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -7,7 +7,7 @@ vi.mock('react-i18next', () => ({
 }));
 
 vi.mock('@/components/ui/input', () => ({
-  Input: (props: React.ComponentProps<'input'>) => <input {...props} />,
+  Input: (props: ComponentProps<'input'>) => <input {...props} />,
 }));
 
 import { LoyaltyProgramCombobox } from './loyalty-program-combobox';

--- a/apps/web/src/components/ui/menu.tsx
+++ b/apps/web/src/components/ui/menu.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import * as React from 'react';
+import { type ComponentProps, type ComponentPropsWithoutRef } from 'react';
 import { Menu as MenuPrimitive } from '@base-ui/react/menu';
 
 import { cn } from '@/lib/utils';
@@ -8,10 +8,7 @@ import { cn } from '@/lib/utils';
 const MenuRoot = MenuPrimitive.Root;
 const MenuTrigger = MenuPrimitive.Trigger;
 
-function MenuPopup({
-  className,
-  ...props
-}: React.ComponentPropsWithoutRef<typeof MenuPrimitive.Popup>) {
+function MenuPopup({ className, ...props }: ComponentPropsWithoutRef<typeof MenuPrimitive.Popup>) {
   return (
     <MenuPrimitive.Portal>
       <MenuPrimitive.Positioner align="end" sideOffset={8}>
@@ -30,10 +27,7 @@ function MenuPopup({
   );
 }
 
-function MenuItem({
-  className,
-  ...props
-}: React.ComponentPropsWithoutRef<typeof MenuPrimitive.Item>) {
+function MenuItem({ className, ...props }: ComponentPropsWithoutRef<typeof MenuPrimitive.Item>) {
   return (
     <MenuPrimitive.Item
       className={cn(
@@ -47,11 +41,11 @@ function MenuItem({
   );
 }
 
-function MenuSeparator({ className, ...props }: React.ComponentProps<'hr'>) {
+function MenuSeparator({ className, ...props }: ComponentProps<'hr'>) {
   return <hr role="separator" className={cn('my-1 h-px bg-border', className)} {...props} />;
 }
 
-function MenuLabel({ className, ...props }: React.ComponentProps<'div'>) {
+function MenuLabel({ className, ...props }: ComponentProps<'div'>) {
   return <div className={cn('px-3 py-2 text-xs text-muted-foreground', className)} {...props} />;
 }
 

--- a/apps/web/src/components/ui/popover.tsx
+++ b/apps/web/src/components/ui/popover.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import * as React from 'react';
+import { type ComponentProps } from 'react';
 import { Popover as PopoverPrimitive } from '@base-ui/react/popover';
 
 import { cn } from '@/lib/utils';
@@ -44,7 +44,7 @@ function PopoverContent({
   );
 }
 
-function PopoverHeader({ className, ...props }: React.ComponentProps<'div'>) {
+function PopoverHeader({ className, ...props }: ComponentProps<'div'>) {
   return (
     <div
       data-slot="popover-header"

--- a/apps/web/src/components/ui/save-button.test.tsx
+++ b/apps/web/src/components/ui/save-button.test.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
+import { type ComponentProps } from 'react';
 import { render, screen } from '@testing-library/react';
 
 vi.mock('@/components/ui/button', () => ({
-  Button: (props: React.ComponentProps<'button'>) => <button {...props} />,
+  Button: (props: ComponentProps<'button'>) => <button {...props} />,
 }));
 
 vi.mock('@/components/ui/spinner', () => ({

--- a/apps/web/src/components/ui/select.tsx
+++ b/apps/web/src/components/ui/select.tsx
@@ -1,8 +1,8 @@
-import * as React from 'react';
+import { type ComponentProps } from 'react';
 
 import { cn } from '@/lib/utils';
 
-function Select({ className, ...props }: React.ComponentProps<'select'>) {
+function Select({ className, ...props }: ComponentProps<'select'>) {
   return (
     <select
       data-slot="select"

--- a/apps/web/src/components/ui/spinner.tsx
+++ b/apps/web/src/components/ui/spinner.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { type ComponentPropsWithoutRef } from 'react';
 import { cva, type VariantProps } from 'class-variance-authority';
 
 import { cn } from '@/lib/utils';
@@ -17,7 +17,7 @@ const spinnerVariants = cva('animate-spin text-muted-foreground', {
 });
 
 export interface SpinnerProps
-  extends React.ComponentPropsWithoutRef<'svg'>, VariantProps<typeof spinnerVariants> {
+  extends ComponentPropsWithoutRef<'svg'>, VariantProps<typeof spinnerVariants> {
   label?: string;
 }
 

--- a/apps/web/src/components/ui/textarea.tsx
+++ b/apps/web/src/components/ui/textarea.tsx
@@ -1,8 +1,8 @@
-import * as React from 'react';
+import { type ComponentProps } from 'react';
 
 import { cn } from '@/lib/utils';
 
-function Textarea({ className, ...props }: React.ComponentProps<'textarea'>) {
+function Textarea({ className, ...props }: ComponentProps<'textarea'>) {
   return (
     <textarea
       data-slot="textarea"

--- a/apps/web/src/components/ui/timezone-combobox.tsx
+++ b/apps/web/src/components/ui/timezone-combobox.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import * as React from 'react';
+import { useState } from 'react';
 import { CaretUpDownIcon, CheckIcon } from '@phosphor-icons/react';
 
 import { cn } from '@/lib/utils';
@@ -39,7 +39,7 @@ export function TimezoneCombobox({
   'aria-invalid': ariaInvalid,
   'aria-labelledby': ariaLabelledBy,
 }: TimezoneComboboxProps) {
-  const [open, setOpen] = React.useState(false);
+  const [open, setOpen] = useState(false);
 
   const triggerLabel = value ? formatTimezoneLabel(value) : placeholder;
 

--- a/apps/web/src/components/ui/toast.test.tsx
+++ b/apps/web/src/components/ui/toast.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { type ReactNode } from 'react';
 import { render, screen, act, cleanup } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect, afterEach, vi } from 'vitest';
@@ -8,7 +8,7 @@ vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key }),
 }));
 
-function renderWithProvider(ui: React.ReactNode) {
+function renderWithProvider(ui: ReactNode) {
   return render(<ToastProvider>{ui}</ToastProvider>);
 }
 

--- a/apps/web/src/components/ui/toast.tsx
+++ b/apps/web/src/components/ui/toast.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import * as React from 'react';
+import { type ComponentPropsWithoutRef } from 'react';
 import { Toast as ToastPrimitive } from '@base-ui/react/toast';
 import { cva } from 'class-variance-authority';
 import { CheckCircleIcon, InfoIcon, WarningIcon, XCircleIcon, XIcon } from '@phosphor-icons/react';
@@ -15,7 +15,7 @@ export const toastManager = ToastPrimitive.createToastManager();
 function ToastProvider({
   children,
   ...props
-}: React.ComponentPropsWithoutRef<typeof ToastPrimitive.Provider>) {
+}: ComponentPropsWithoutRef<typeof ToastPrimitive.Provider>) {
   return (
     <ToastPrimitive.Provider toastManager={toastManager} {...props}>
       {children}

--- a/apps/web/src/components/ui/user-autocomplete.test.tsx
+++ b/apps/web/src/components/ui/user-autocomplete.test.tsx
@@ -1,12 +1,12 @@
-import React from 'react';
+import { type ComponentProps, type ReactNode } from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 vi.mock('@base-ui/react/avatar', () => ({
   Avatar: {
-    Root: ({ children, ...props }: React.ComponentProps<'div'>) => <div {...props}>{children}</div>,
-    Image: ({ src, alt }: React.ComponentProps<'img'>) => <img src={src} alt={alt} />,
-    Fallback: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+    Root: ({ children, ...props }: ComponentProps<'div'>) => <div {...props}>{children}</div>,
+    Image: ({ src, alt }: ComponentProps<'img'>) => <img src={src} alt={alt} />,
+    Fallback: ({ children }: { children: ReactNode }) => <span>{children}</span>,
   },
 }));
 

--- a/apps/web/src/components/ui/user-autocomplete.tsx
+++ b/apps/web/src/components/ui/user-autocomplete.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState } from 'react';
+import { useState, type KeyboardEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { cn } from '@/lib/utils';
@@ -46,7 +46,7 @@ function UserAutocomplete({
     setActiveIndex(-1);
   }
 
-  function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+  function handleKeyDown(e: KeyboardEvent<HTMLInputElement>) {
     if (!open) return;
 
     if (e.key === 'ArrowDown') {

--- a/apps/web/src/hooks/useUser.test.ts
+++ b/apps/web/src/hooks/useUser.test.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import { createElement } from 'react';
 import { renderHook } from '@testing-library/react';
 
 // Break the firebase import chain triggered by @/store/user → @/hooks/useAuth → @/store/auth → @/lib/firebase
@@ -26,7 +26,7 @@ describe('useUser', () => {
   it('returns context value when inside UserProvider', () => {
     const { result } = renderHook(() => useUser(), {
       wrapper: ({ children }) =>
-        React.createElement(UserContext.Provider, { value: mockContextValue }, children),
+        createElement(UserContext.Provider, { value: mockContextValue }, children),
     });
 
     expect(result.current).toBe(mockContextValue);

--- a/apps/web/src/store/group-invitations.test.tsx
+++ b/apps/web/src/store/group-invitations.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { type ReactNode } from 'react';
 import { renderHook, waitFor, act } from '@testing-library/react';
 import type { User } from 'firebase/auth';
 import type { AuthContextValue } from '@/store/auth';
@@ -36,7 +36,7 @@ function makeFirebaseUser(overrides: Partial<User> = {}): User {
   return { uid: 'uid-123', displayName: 'Test', email: 'test@example.com', ...overrides } as User;
 }
 
-function wrapper({ children }: { children: React.ReactNode }) {
+function wrapper({ children }: { children: ReactNode }) {
   return <GroupInvitationsProvider>{children}</GroupInvitationsProvider>;
 }
 

--- a/apps/web/src/store/user.test.tsx
+++ b/apps/web/src/store/user.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { renderHook, waitFor } from '@testing-library/react';
 import type { User } from 'firebase/auth';
 import { ProfileVisibility } from '@chamuco/shared-types';
@@ -18,7 +17,7 @@ vi.mock('@/services/api-client', () => ({
   apiClient: { get: mocks.mockApiGet },
 }));
 
-import { useContext } from 'react';
+import { useContext, type ReactNode } from 'react';
 import { useAuth } from '@/hooks/useAuth';
 import { UserContext, UserProvider } from './user';
 
@@ -47,7 +46,7 @@ function makeFirebaseUser(overrides: Partial<User> = {}): User {
   } as User;
 }
 
-function wrapper({ children }: { children: React.ReactNode }) {
+function wrapper({ children }: { children: ReactNode }) {
   return <UserProvider>{children}</UserProvider>;
 }
 


### PR DESCRIPTION
## Summary

- **Named React imports**: replace all `import React from 'react'` and `import * as React from 'react'` with specific named imports across 34 files. The automatic JSX transform makes namespace imports unnecessary; named imports are explicit and tree-shakeable. Adds a standing rule in `apps/web/CLAUDE.md` to enforce this going forward.
- **PWA install banner mobile-only**: `IosPwaPrompt` now exits early on desktop via a new `isMobileDevice()` guard (`userAgentData.mobile` with UA regex fallback). The `beforeinstallprompt` event fires on desktop Chrome too, but the custom banner should only appear on mobile.
- **CityCombobox deferred search**: `useCitySearch` is now called with an empty query until the user actually types, avoiding an unnecessary API call on initial render.

## Test plan

- [ ] All 1275 existing web tests pass (`pnpm --filter web test`)
- [ ] 2 new desktop suppression tests added to `IosPwaPrompt.test.tsx` (17 tests total)
- [ ] No `React.` namespace references remain in `apps/web/src`
- [ ] Typecheck passes (`pnpm --filter web typecheck`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)