### PR TITLE
feat(notifications): add user_fcm_tokens schema and FCM token registration endpoints

### DIFF
--- a/apps/api/src/database/migrations/0021_tranquil_lester.sql
+++ b/apps/api/src/database/migrations/0021_tranquil_lester.sql
@@ -1,0 +1,11 @@
+CREATE TABLE "user_fcm_tokens" (
+	"user_id" uuid NOT NULL,
+	"token" text NOT NULL,
+	"device_hint" varchar(100),
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"last_used_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "user_fcm_tokens_user_id_token_pk" PRIMARY KEY("user_id","token")
+);
+--> statement-breakpoint
+ALTER TABLE "user_fcm_tokens" ADD CONSTRAINT "user_fcm_tokens_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "idx_user_fcm_tokens_user_id" ON "user_fcm_tokens" USING btree ("user_id");

--- a/apps/api/src/database/migrations/meta/0021_snapshot.json
+++ b/apps/api/src/database/migrations/meta/0021_snapshot.json
@@ -1,0 +1,1787 @@
+{
+  "id": "6c9ba22a-f282-471f-972b-1286d731cb6f",
+  "prevId": "05b08286-aed8-4204-81da-6648e507349f",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.assets": {
+      "name": "assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "asset_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "asset_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target": {
+          "name": "target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_member_stats": {
+      "name": "group_member_stats",
+      "schema": "",
+      "columns": {
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tier": {
+          "name": "tier",
+          "type": "group_member_tier",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'NEWCOMER'"
+        },
+        "group_trips_completed": {
+          "name": "group_trips_completed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_streak": {
+          "name": "active_streak",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "group_member_stats_group_id_groups_id_fk": {
+          "name": "group_member_stats_group_id_groups_id_fk",
+          "tableFrom": "group_member_stats",
+          "tableTo": "groups",
+          "columnsFrom": ["group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_member_stats_user_id_users_id_fk": {
+          "name": "group_member_stats_user_id_users_id_fk",
+          "tableFrom": "group_member_stats",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "group_member_stats_group_id_user_id_pk": {
+          "name": "group_member_stats_group_id_user_id_pk",
+          "columns": ["group_id", "user_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_members": {
+      "name": "group_members",
+      "schema": "",
+      "columns": {
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "group_member_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "group_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'MEMBER'"
+        },
+        "initiated_at": {
+          "name": "initiated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "responded_at": {
+          "name": "responded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "initiated_by": {
+          "name": "initiated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decided_by": {
+          "name": "decided_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_group_members_user_id_status": {
+          "name": "idx_group_members_user_id_status",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_members_group_id_status": {
+          "name": "idx_group_members_group_id_status",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "group_members_group_id_groups_id_fk": {
+          "name": "group_members_group_id_groups_id_fk",
+          "tableFrom": "group_members",
+          "tableTo": "groups",
+          "columnsFrom": ["group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "group_members_user_id_users_id_fk": {
+          "name": "group_members_user_id_users_id_fk",
+          "tableFrom": "group_members",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "group_members_initiated_by_users_id_fk": {
+          "name": "group_members_initiated_by_users_id_fk",
+          "tableFrom": "group_members",
+          "tableTo": "users",
+          "columnsFrom": ["initiated_by"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "group_members_decided_by_users_id_fk": {
+          "name": "group_members_decided_by_users_id_fk",
+          "tableFrom": "group_members",
+          "tableTo": "users",
+          "columnsFrom": ["decided_by"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "group_members_group_id_user_id_pk": {
+          "name": "group_members_group_id_user_id_pk",
+          "columns": ["group_id", "user_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.groups": {
+      "name": "groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover": {
+          "name": "cover",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "group_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "groups_cover_assets_id_fk": {
+          "name": "groups_cover_assets_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "assets",
+          "columnsFrom": ["cover"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "groups_created_by_users_id_fk": {
+          "name": "groups_created_by_users_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_deliveries": {
+      "name": "notification_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "notification_id": {
+          "name": "notification_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "notification_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "delivery_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_notification_deliveries_status": {
+          "name": "idx_notification_deliveries_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_deliveries_notification_id_notifications_id_fk": {
+          "name": "notification_deliveries_notification_id_notifications_id_fk",
+          "tableFrom": "notification_deliveries",
+          "tableTo": "notifications",
+          "columnsFrom": ["notification_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "notification_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_notifications_user_id_created_at": {
+          "name": "idx_notifications_user_id_created_at",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_users_id_fk": {
+          "name": "notifications_user_id_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_fcm_tokens": {
+      "name": "user_fcm_tokens",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_hint": {
+          "name": "device_hint",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_user_fcm_tokens_user_id": {
+          "name": "idx_user_fcm_tokens_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_fcm_tokens_user_id_users_id_fk": {
+          "name": "user_fcm_tokens_user_id_users_id_fk",
+          "tableFrom": "user_fcm_tokens",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_fcm_tokens_user_id_token_pk": {
+          "name": "user_fcm_tokens_user_id_token_pk",
+          "columns": ["user_id", "token"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.support_admin_audit_log": {
+      "name": "support_admin_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "admin_user_id": {
+          "name": "admin_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_table": {
+          "name": "target_table",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "before_state": {
+          "name": "before_state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "after_state": {
+          "name": "after_state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "performed_at": {
+          "name": "performed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "support_admin_audit_log_admin_user_id_idx": {
+          "name": "support_admin_audit_log_admin_user_id_idx",
+          "columns": [
+            {
+              "expression": "admin_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "support_admin_audit_log_performed_at_idx": {
+          "name": "support_admin_audit_log_performed_at_idx",
+          "columns": [
+            {
+              "expression": "performed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "support_admin_audit_log_admin_user_id_users_id_fk": {
+          "name": "support_admin_audit_log_admin_user_id_users_id_fk",
+          "tableFrom": "support_admin_audit_log",
+          "tableTo": "users",
+          "columnsFrom": ["admin_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_etas": {
+      "name": "user_etas",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_nationality_id": {
+          "name": "user_nationality_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "passport_number": {
+          "name": "passport_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination_country": {
+          "name": "destination_country",
+          "type": "char(2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authorization_number": {
+          "name": "authorization_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "eta_type": {
+          "name": "eta_type",
+          "type": "eta_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entries": {
+          "name": "entries",
+          "type": "visa_entries",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiry_date": {
+          "name": "expiry_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "eta_status": {
+          "name": "eta_status",
+          "type": "eta_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_etas_user_nationality_id_idx": {
+          "name": "user_etas_user_nationality_id_idx",
+          "columns": [
+            {
+              "expression": "user_nationality_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_etas_eta_status_idx": {
+          "name": "user_etas_eta_status_idx",
+          "columns": [
+            {
+              "expression": "eta_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_etas_passport_number_idx": {
+          "name": "user_etas_passport_number_idx",
+          "columns": [
+            {
+              "expression": "passport_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_etas_user_nationality_id_user_nationalities_id_fk": {
+          "name": "user_etas_user_nationality_id_user_nationalities_id_fk",
+          "tableFrom": "user_etas",
+          "tableTo": "user_nationalities",
+          "columnsFrom": ["user_nationality_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_nationalities": {
+      "name": "user_nationalities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country_code": {
+          "name": "country_code",
+          "type": "char(2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "national_id_number": {
+          "name": "national_id_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "passport_number": {
+          "name": "passport_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "passport_issue_date": {
+          "name": "passport_issue_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "passport_expiry_date": {
+          "name": "passport_expiry_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "passport_status": {
+          "name": "passport_status",
+          "type": "passport_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_nationalities_user_id_idx": {
+          "name": "user_nationalities_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_nationalities_one_primary_per_user": {
+          "name": "user_nationalities_one_primary_per_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"user_nationalities\".\"is_primary\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_nationalities_user_id_users_id_fk": {
+          "name": "user_nationalities_user_id_users_id_fk",
+          "tableFrom": "user_nationalities",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_nationalities_user_id_country_code_unique": {
+          "name": "user_nationalities_user_id_country_code_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id", "country_code"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "passport_data_consistency": {
+          "name": "passport_data_consistency",
+          "value": "(\"user_nationalities\".\"passport_status\" = 'OMITTED'\n        AND \"user_nationalities\".\"passport_number\" IS NULL\n        AND \"user_nationalities\".\"passport_issue_date\" IS NULL\n        AND \"user_nationalities\".\"passport_expiry_date\" IS NULL)\n      OR\n      (\"user_nationalities\".\"passport_status\" <> 'OMITTED'\n        AND \"user_nationalities\".\"passport_number\" IS NOT NULL\n        AND \"user_nationalities\".\"passport_issue_date\" IS NOT NULL\n        AND \"user_nationalities\".\"passport_expiry_date\" IS NOT NULL)"
+        },
+        "national_id_number_format": {
+          "name": "national_id_number_format",
+          "value": "\"user_nationalities\".\"national_id_number\" IS NULL OR \"user_nationalities\".\"national_id_number\" ~ '^[A-Z0-9]([A-Z0-9-]*[A-Z0-9])?$'"
+        },
+        "passport_number_format": {
+          "name": "passport_number_format",
+          "value": "\"user_nationalities\".\"passport_number\" IS NULL OR \"user_nationalities\".\"passport_number\" ~ '^[A-Z0-9]([A-Z0-9-]*[A-Z0-9])?$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_preferences": {
+      "name": "user_preferences",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "app_language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ES'"
+        },
+        "currency": {
+          "name": "currency",
+          "type": "app_currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'COP'"
+        },
+        "theme": {
+          "name": "theme",
+          "type": "app_theme",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'SYSTEM'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_preferences_user_id_users_id_fk": {
+          "name": "user_preferences_user_id_users_id_fk",
+          "tableFrom": "user_preferences",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_profiles": {
+      "name": "user_profiles",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_of_birth": {
+          "name": "date_of_birth",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "birth_country": {
+          "name": "birth_country",
+          "type": "char(2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "birth_city": {
+          "name": "birth_city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "home_country": {
+          "name": "home_country",
+          "type": "char(2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "home_city": {
+          "name": "home_city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "phone_country_code": {
+          "name": "phone_country_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone_local_number": {
+          "name": "phone_local_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone_verified": {
+          "name": "phone_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blood_type": {
+          "name": "blood_type",
+          "type": "blood_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dietary_preference": {
+          "name": "dietary_preference",
+          "type": "dietary_preference",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'OMNIVORE'"
+        },
+        "dietary_notes": {
+          "name": "dietary_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "general_medical_notes": {
+          "name": "general_medical_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "food_allergies": {
+          "name": "food_allergies",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "phobias": {
+          "name": "phobias",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "physical_limitations": {
+          "name": "physical_limitations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "medical_conditions": {
+          "name": "medical_conditions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "emergency_contacts": {
+          "name": "emergency_contacts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "loyalty_programs": {
+          "name": "loyalty_programs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_profiles_user_id_users_id_fk": {
+          "name": "user_profiles_user_id_users_id_fk",
+          "tableFrom": "user_profiles",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_visas": {
+      "name": "user_visas",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "nationality_id": {
+          "name": "nationality_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "coverage_type": {
+          "name": "coverage_type",
+          "type": "visa_coverage_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country_code": {
+          "name": "country_code",
+          "type": "char(2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visa_zone": {
+          "name": "visa_zone",
+          "type": "visa_zone",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visa_type": {
+          "name": "visa_type",
+          "type": "visa_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entries": {
+          "name": "entries",
+          "type": "visa_entries",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiry_date": {
+          "name": "expiry_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visa_status": {
+          "name": "visa_status",
+          "type": "visa_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_visas_nationality_id_idx": {
+          "name": "user_visas_nationality_id_idx",
+          "columns": [
+            {
+              "expression": "nationality_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_visas_visa_status_idx": {
+          "name": "user_visas_visa_status_idx",
+          "columns": [
+            {
+              "expression": "visa_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_visas_nationality_id_user_nationalities_id_fk": {
+          "name": "user_visas_nationality_id_user_nationalities_id_fk",
+          "tableFrom": "user_visas",
+          "tableTo": "user_nationalities",
+          "columnsFrom": ["nationality_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "visa_coverage_consistency": {
+          "name": "visa_coverage_consistency",
+          "value": "(\"user_visas\".\"coverage_type\" = 'COUNTRY' AND \"user_visas\".\"country_code\" IS NOT NULL AND \"user_visas\".\"visa_zone\" IS NULL)\n      OR\n      (\"user_visas\".\"coverage_type\" = 'ZONE' AND \"user_visas\".\"visa_zone\" IS NOT NULL AND \"user_visas\".\"country_code\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_provider": {
+          "name": "auth_provider",
+          "type": "auth_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "firebase_uid": {
+          "name": "firebase_uid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "platform_role": {
+          "name": "platform_role",
+          "type": "platform_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'USER'"
+        },
+        "profile_visibility": {
+          "name": "profile_visibility",
+          "type": "profile_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PRIVATE'"
+        },
+        "agency_id": {
+          "name": "agency_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_avatar_assets_id_fk": {
+          "name": "users_avatar_assets_id_fk",
+          "tableFrom": "users",
+          "tableTo": "assets",
+          "columnsFrom": ["avatar"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": ["username"]
+        },
+        "users_firebase_uid_unique": {
+          "name": "users_firebase_uid_unique",
+          "nullsNotDistinct": false,
+          "columns": ["firebase_uid"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "users_username_format": {
+          "name": "users_username_format",
+          "value": "\"users\".\"username\" ~ '^[a-z0-9_-]{3,30}$'"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.asset_source": {
+      "name": "asset_source",
+      "schema": "public",
+      "values": ["gcs", "url", "emoji", "text"]
+    },
+    "public.asset_type": {
+      "name": "asset_type",
+      "schema": "public",
+      "values": ["image", "video", "file", "link", "text"]
+    },
+    "public.group_member_tier": {
+      "name": "group_member_tier",
+      "schema": "public",
+      "values": ["NEWCOMER", "NOVICE", "EXPLORER", "VETERAN"]
+    },
+    "public.group_member_status": {
+      "name": "group_member_status",
+      "schema": "public",
+      "values": ["REQUEST", "INVITED", "ACTIVE", "REJECTED", "REMOVED", "LEFT"]
+    },
+    "public.group_role": {
+      "name": "group_role",
+      "schema": "public",
+      "values": ["OWNER", "ADMIN", "MEMBER"]
+    },
+    "public.group_visibility": {
+      "name": "group_visibility",
+      "schema": "public",
+      "values": ["PUBLIC", "PRIVATE"]
+    },
+    "public.delivery_status": {
+      "name": "delivery_status",
+      "schema": "public",
+      "values": ["PENDING", "SENT", "FAILED"]
+    },
+    "public.notification_channel": {
+      "name": "notification_channel",
+      "schema": "public",
+      "values": ["PUSH", "EMAIL", "SMS"]
+    },
+    "public.notification_type": {
+      "name": "notification_type",
+      "schema": "public",
+      "values": [
+        "GROUP_INVITATION",
+        "GROUP_JOIN_ACCEPTED",
+        "GROUP_ANNOUNCEMENT",
+        "TRIP_INVITATION",
+        "TRIP_ANNOUNCEMENT",
+        "TRIP_KEY_DATE_REMINDER",
+        "TRIP_COMPLETED",
+        "PASSPORT_EXPIRING_SOON",
+        "PASSPORT_EXPIRED",
+        "ACHIEVEMENT_UNLOCKED"
+      ]
+    },
+    "public.eta_status": {
+      "name": "eta_status",
+      "schema": "public",
+      "values": ["ACTIVE", "EXPIRING_SOON", "EXPIRED"]
+    },
+    "public.eta_type": {
+      "name": "eta_type",
+      "schema": "public",
+      "values": ["TOURIST", "TRANSIT"]
+    },
+    "public.passport_status": {
+      "name": "passport_status",
+      "schema": "public",
+      "values": ["OMITTED", "ACTIVE", "EXPIRING_SOON", "EXPIRED"]
+    },
+    "public.app_currency": {
+      "name": "app_currency",
+      "schema": "public",
+      "values": ["COP", "USD"]
+    },
+    "public.app_language": {
+      "name": "app_language",
+      "schema": "public",
+      "values": ["ES", "EN"]
+    },
+    "public.app_theme": {
+      "name": "app_theme",
+      "schema": "public",
+      "values": ["LIGHT", "DARK", "SYSTEM"]
+    },
+    "public.blood_type": {
+      "name": "blood_type",
+      "schema": "public",
+      "values": [
+        "A_POSITIVE",
+        "A_NEGATIVE",
+        "B_POSITIVE",
+        "B_NEGATIVE",
+        "AB_POSITIVE",
+        "AB_NEGATIVE",
+        "O_POSITIVE",
+        "O_NEGATIVE"
+      ]
+    },
+    "public.dietary_preference": {
+      "name": "dietary_preference",
+      "schema": "public",
+      "values": ["OMNIVORE", "VEGETARIAN", "VEGAN", "PESCATARIAN", "GLUTEN_FREE", "OTHER"]
+    },
+    "public.food_allergen": {
+      "name": "food_allergen",
+      "schema": "public",
+      "values": [
+        "GLUTEN",
+        "CRUSTACEANS",
+        "EGGS",
+        "FISH",
+        "PEANUTS",
+        "SOYBEANS",
+        "MILK",
+        "TREE_NUTS",
+        "CELERY",
+        "MUSTARD",
+        "SESAME",
+        "SULPHITES",
+        "LUPIN",
+        "MOLLUSCS",
+        "OTHER"
+      ]
+    },
+    "public.medical_condition_type": {
+      "name": "medical_condition_type",
+      "schema": "public",
+      "values": [
+        "DIABETES",
+        "EPILEPSY",
+        "SEVERE_ALLERGY_EPIPEN",
+        "ASTHMA",
+        "HEART_CONDITION",
+        "HYPERTENSION",
+        "BLOOD_CLOTTING_DISORDER",
+        "MENTAL_HEALTH_CONDITION",
+        "OTHER"
+      ]
+    },
+    "public.phobia_type": {
+      "name": "phobia_type",
+      "schema": "public",
+      "values": [
+        "HEIGHTS",
+        "ENCLOSED_SPACES",
+        "FLYING",
+        "DEEP_WATER",
+        "OPEN_WATER",
+        "ANIMALS",
+        "INSECTS",
+        "SNAKES",
+        "SPIDERS",
+        "DARKNESS",
+        "CROWDS",
+        "MOTION_SICKNESS",
+        "OTHER"
+      ]
+    },
+    "public.physical_limitation_type": {
+      "name": "physical_limitation_type",
+      "schema": "public",
+      "values": [
+        "WHEELCHAIR_USER",
+        "REDUCED_MOBILITY",
+        "CANNOT_USE_STAIRS",
+        "HEARING_IMPAIRMENT",
+        "VISUAL_IMPAIRMENT",
+        "REQUIRES_OXYGEN",
+        "REQUIRES_CPAP",
+        "CHRONIC_PAIN",
+        "JOINT_CONDITION",
+        "CARDIAC_CONDITION",
+        "RESPIRATORY_CONDITION",
+        "PREGNANCY",
+        "OTHER"
+      ]
+    },
+    "public.visa_coverage_type": {
+      "name": "visa_coverage_type",
+      "schema": "public",
+      "values": ["COUNTRY", "ZONE"]
+    },
+    "public.visa_entries": {
+      "name": "visa_entries",
+      "schema": "public",
+      "values": ["SINGLE", "DOUBLE", "MULTIPLE"]
+    },
+    "public.visa_status": {
+      "name": "visa_status",
+      "schema": "public",
+      "values": ["ACTIVE", "EXPIRING_SOON", "EXPIRED"]
+    },
+    "public.visa_type": {
+      "name": "visa_type",
+      "schema": "public",
+      "values": ["TOURIST", "BUSINESS", "TRANSIT", "WORK", "STUDENT", "DIGITAL_NOMAD", "OTHER"]
+    },
+    "public.visa_zone": {
+      "name": "visa_zone",
+      "schema": "public",
+      "values": ["SCHENGEN", "GCC", "CARICOM", "EAC", "CAN", "MERCOSUR", "ECOWAS"]
+    },
+    "public.auth_provider": {
+      "name": "auth_provider",
+      "schema": "public",
+      "values": ["GOOGLE", "FACEBOOK"]
+    },
+    "public.platform_role": {
+      "name": "platform_role",
+      "schema": "public",
+      "values": ["USER", "SUPPORT_ADMIN"]
+    },
+    "public.profile_visibility": {
+      "name": "profile_visibility",
+      "schema": "public",
+      "values": ["PRIVATE", "CONNECTIONS_ONLY", "MEMBERS_ONLY", "PUBLIC"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/src/database/migrations/meta/_journal.json
+++ b/apps/api/src/database/migrations/meta/_journal.json
@@ -148,6 +148,13 @@
       "when": 1779306770195,
       "tag": "0020_normal_fat_cobra",
       "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "7",
+      "when": 1779675327093,
+      "tag": "0021_tranquil_lester",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/database/schema/index.ts
+++ b/apps/api/src/database/schema/index.ts
@@ -15,6 +15,7 @@ export * from '@/modules/groups/schema/group-members.schema';
 export * from '@/modules/groups/schema/groups.schema';
 export * from '@/modules/notifications/schema/notification-deliveries.schema';
 export * from '@/modules/notifications/schema/notifications.schema';
+export * from '@/modules/notifications/schema/user-fcm-tokens.schema';
 export * from '@/modules/users/schema/support-admin-audit-log.schema';
 export * from '@/modules/users/schema/user-etas.schema';
 export * from '@/modules/users/schema/user-nationalities.schema';

--- a/apps/api/src/modules/notifications/dto/delete-fcm-token.dto.ts
+++ b/apps/api/src/modules/notifications/dto/delete-fcm-token.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class DeleteFcmTokenDto {
+  @ApiProperty({
+    description: 'FCM registration token to remove.',
+    example: 'fGXk3m2...',
+  })
+  @IsString()
+  @IsNotEmpty()
+  token!: string;
+}

--- a/apps/api/src/modules/notifications/dto/delete-fcm-token.dto.ts
+++ b/apps/api/src/modules/notifications/dto/delete-fcm-token.dto.ts
@@ -1,12 +1,14 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsNotEmpty, IsString } from 'class-validator';
+import { IsNotEmpty, IsString, MaxLength } from 'class-validator';
 
 export class DeleteFcmTokenDto {
   @ApiProperty({
     description: 'FCM registration token to remove.',
     example: 'fGXk3m2...',
+    maxLength: 512,
   })
   @IsString()
   @IsNotEmpty()
+  @MaxLength(512)
   token!: string;
 }

--- a/apps/api/src/modules/notifications/dto/register-fcm-token.dto.ts
+++ b/apps/api/src/modules/notifications/dto/register-fcm-token.dto.ts
@@ -1,0 +1,24 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsNotEmpty, IsOptional, IsString, MaxLength } from 'class-validator';
+
+export class RegisterFcmTokenDto {
+  @ApiProperty({
+    description: 'FCM registration token for the device.',
+    example: 'fGXk3m2...',
+    maxLength: 512,
+  })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(512)
+  token!: string;
+
+  @ApiPropertyOptional({
+    description: 'Short device hint to help identify the token (e.g. browser UA snippet).',
+    example: 'Chrome 124 / macOS',
+    maxLength: 100,
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  deviceHint?: string;
+}

--- a/apps/api/src/modules/notifications/notifications.controller.spec.ts
+++ b/apps/api/src/modules/notifications/notifications.controller.spec.ts
@@ -53,6 +53,8 @@ let mockFindAll: jest.Mock;
 let mockCountUnread: jest.Mock;
 let mockMarkRead: jest.Mock;
 let mockMarkAllRead: jest.Mock;
+let mockRegisterToken: jest.Mock;
+let mockDeleteToken: jest.Mock;
 
 describe('NotificationsController', () => {
   let controller: NotificationsController;
@@ -62,6 +64,8 @@ describe('NotificationsController', () => {
     mockCountUnread = jest.fn().mockResolvedValue(1);
     mockMarkRead = jest.fn().mockResolvedValue(undefined);
     mockMarkAllRead = jest.fn().mockResolvedValue(undefined);
+    mockRegisterToken = jest.fn().mockResolvedValue(undefined);
+    mockDeleteToken = jest.fn().mockResolvedValue(undefined);
 
     const module: TestingModule = await Test.createTestingModule({
       controllers: [NotificationsController],
@@ -73,6 +77,8 @@ describe('NotificationsController', () => {
             countUnread: mockCountUnread,
             markRead: mockMarkRead,
             markAllRead: mockMarkAllRead,
+            registerToken: mockRegisterToken,
+            deleteToken: mockDeleteToken,
           },
         },
       ],
@@ -156,6 +162,43 @@ describe('NotificationsController', () => {
 
     it('returns undefined', async () => {
       const result = await controller.markRead(mockAuthUser, 'notif-uuid');
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('POST /v1/notifications/fcm-token', () => {
+    it('delegates to registerToken with user id and dto', async () => {
+      await controller.registerFcmToken(mockAuthUser, { token: 'tok-abc', deviceHint: 'Chrome' });
+
+      expect(mockRegisterToken).toHaveBeenCalledWith('user-uuid', {
+        token: 'tok-abc',
+        deviceHint: 'Chrome',
+      });
+    });
+
+    it('delegates to registerToken without deviceHint', async () => {
+      await controller.registerFcmToken(mockAuthUser, { token: 'tok-abc' });
+
+      expect(mockRegisterToken).toHaveBeenCalledWith('user-uuid', { token: 'tok-abc' });
+    });
+
+    it('returns undefined', async () => {
+      const result = await controller.registerFcmToken(mockAuthUser, { token: 'tok-abc' });
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('DELETE /v1/notifications/fcm-token', () => {
+    it('delegates to deleteToken with user id and dto', async () => {
+      await controller.deleteFcmToken(mockAuthUser, { token: 'tok-abc' });
+
+      expect(mockDeleteToken).toHaveBeenCalledWith('user-uuid', { token: 'tok-abc' });
+    });
+
+    it('returns undefined', async () => {
+      const result = await controller.deleteFcmToken(mockAuthUser, { token: 'tok-abc' });
 
       expect(result).toBeUndefined();
     });

--- a/apps/api/src/modules/notifications/notifications.controller.ts
+++ b/apps/api/src/modules/notifications/notifications.controller.ts
@@ -1,6 +1,18 @@
-import { Controller, Get, HttpCode, Param, ParseUUIDPipe, Patch, Query } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  Param,
+  ParseUUIDPipe,
+  Patch,
+  Post,
+  Query,
+} from '@nestjs/common';
 import {
   ApiBearerAuth,
+  ApiBody,
   ApiOperation,
   ApiParam,
   ApiQuery,
@@ -12,6 +24,8 @@ import type { AuthenticatedUser } from '@/types/express';
 import { NotificationsService } from './notifications.service';
 import { GetNotificationsQueryDto } from './dto/get-notifications-query.dto';
 import { NotificationsPageDto, toNotificationResponseDto } from './dto/notification-response.dto';
+import { RegisterFcmTokenDto } from './dto/register-fcm-token.dto';
+import { DeleteFcmTokenDto } from './dto/delete-fcm-token.dto';
 
 @ApiTags('notifications')
 @ApiBearerAuth()
@@ -87,5 +101,42 @@ export class NotificationsController {
     @Param('id', ParseUUIDPipe) id: string,
   ): Promise<void> {
     return this.notificationsService.markRead(user.id, id);
+  }
+
+  @Post('fcm-token')
+  @HttpCode(204)
+  @ApiOperation({
+    summary: 'Register FCM token',
+    description:
+      "Upserts an FCM registration token for the current user's device. " +
+      'Idempotent — registering the same token again updates last_used_at.',
+  })
+  @ApiBody({ type: RegisterFcmTokenDto })
+  @ApiResponse({ status: 204, description: 'Token registered' })
+  @ApiResponse({ status: 400, description: 'Validation error' })
+  @ApiResponse({ status: 401, description: 'Missing or invalid Firebase ID token' })
+  async registerFcmToken(
+    @CurrentUser() user: AuthenticatedUser,
+    @Body() dto: RegisterFcmTokenDto,
+  ): Promise<void> {
+    return this.notificationsService.registerToken(user.id, dto);
+  }
+
+  @Delete('fcm-token')
+  @HttpCode(204)
+  @ApiOperation({
+    summary: 'Remove FCM token',
+    description:
+      'Deletes the given FCM token on logout. ' + 'Returns 204 even if the token does not exist.',
+  })
+  @ApiBody({ type: DeleteFcmTokenDto })
+  @ApiResponse({ status: 204, description: 'Token removed (or was not present)' })
+  @ApiResponse({ status: 400, description: 'Validation error' })
+  @ApiResponse({ status: 401, description: 'Missing or invalid Firebase ID token' })
+  async deleteFcmToken(
+    @CurrentUser() user: AuthenticatedUser,
+    @Body() dto: DeleteFcmTokenDto,
+  ): Promise<void> {
+    return this.notificationsService.deleteToken(user.id, dto);
   }
 }

--- a/apps/api/src/modules/notifications/notifications.service.spec.ts
+++ b/apps/api/src/modules/notifications/notifications.service.spec.ts
@@ -64,6 +64,7 @@ describe('NotificationsService', () => {
     insert: jest.Mock;
     update: jest.Mock;
     select: jest.Mock;
+    delete: jest.Mock;
   };
 
   beforeEach(async () => {
@@ -78,6 +79,7 @@ describe('NotificationsService', () => {
       insert: jest.fn(),
       update: jest.fn(),
       select: jest.fn(),
+      delete: jest.fn(),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -295,6 +297,81 @@ describe('NotificationsService', () => {
       const result = await service.countUnread('user-1');
 
       expect(result).toBe(0);
+    });
+  });
+
+  describe('registerToken()', () => {
+    const makeInsertUpsert = () => ({
+      values: jest.fn().mockReturnValue({
+        onConflictDoUpdate: jest.fn().mockResolvedValue(undefined),
+      }),
+    });
+
+    it('inserts with the correct userId, token, and deviceHint', async () => {
+      db.insert.mockReturnValue(makeInsertUpsert());
+
+      await service.registerToken('user-1', { token: 'tok-abc', deviceHint: 'Chrome 124' });
+
+      expect(db.insert).toHaveBeenCalledTimes(1);
+      const valuesFn = db.insert.mock.results[0]!.value.values as jest.Mock;
+      const row = valuesFn.mock.calls[0]![0] as {
+        userId: string;
+        token: string;
+        deviceHint: string | null;
+      };
+      expect(row.userId).toBe('user-1');
+      expect(row.token).toBe('tok-abc');
+      expect(row.deviceHint).toBe('Chrome 124');
+    });
+
+    it('sets deviceHint to null when omitted', async () => {
+      db.insert.mockReturnValue(makeInsertUpsert());
+
+      await service.registerToken('user-1', { token: 'tok-abc' });
+
+      const valuesFn = db.insert.mock.results[0]!.value.values as jest.Mock;
+      const row = valuesFn.mock.calls[0]![0] as { deviceHint: string | null };
+      expect(row.deviceHint).toBeNull();
+    });
+
+    it('calls onConflictDoUpdate with userId + token as target', async () => {
+      db.insert.mockReturnValue(makeInsertUpsert());
+
+      await service.registerToken('user-1', { token: 'tok-abc' });
+
+      const valuesFn = db.insert.mock.results[0]!.value.values as jest.Mock;
+      const upsertFn = valuesFn.mock.results[0]!.value.onConflictDoUpdate as jest.Mock;
+      expect(upsertFn).toHaveBeenCalledTimes(1);
+      const upsertArg = upsertFn.mock.calls[0]![0] as { set: Record<string, unknown> };
+      expect(upsertArg.set).toHaveProperty('lastUsedAt');
+    });
+
+    it('resolves without throwing', async () => {
+      db.insert.mockReturnValue(makeInsertUpsert());
+
+      await expect(service.registerToken('user-1', { token: 'tok-abc' })).resolves.toBeUndefined();
+    });
+  });
+
+  describe('deleteToken()', () => {
+    const makeDelete = () => ({
+      where: jest.fn().mockResolvedValue(undefined),
+    });
+
+    it('calls delete with the correct userId and token', async () => {
+      db.delete.mockReturnValue(makeDelete());
+
+      await service.deleteToken('user-1', { token: 'tok-abc' });
+
+      expect(db.delete).toHaveBeenCalledTimes(1);
+    });
+
+    it('resolves without throwing when the token does not exist', async () => {
+      db.delete.mockReturnValue(makeDelete());
+
+      await expect(
+        service.deleteToken('user-1', { token: 'nonexistent' }),
+      ).resolves.toBeUndefined();
     });
   });
 

--- a/apps/api/src/modules/notifications/notifications.service.spec.ts
+++ b/apps/api/src/modules/notifications/notifications.service.spec.ts
@@ -358,12 +358,17 @@ describe('NotificationsService', () => {
       where: jest.fn().mockResolvedValue(undefined),
     });
 
-    it('calls delete with the correct userId and token', async () => {
+    it('calls delete with a scoped where clause', async () => {
       db.delete.mockReturnValue(makeDelete());
 
       await service.deleteToken('user-1', { token: 'tok-abc' });
 
       expect(db.delete).toHaveBeenCalledTimes(1);
+      const whereFn = db.delete.mock.results[0]!.value.where as jest.Mock;
+      expect(whereFn).toHaveBeenCalledTimes(1);
+      // Drizzle SQL expressions are opaque objects — verify a condition was applied
+      // (without .where(), the DELETE would affect all rows for all users)
+      expect(whereFn.mock.calls[0]![0]).toBeDefined();
     });
 
     it('resolves without throwing when the token does not exist', async () => {

--- a/apps/api/src/modules/notifications/notifications.service.ts
+++ b/apps/api/src/modules/notifications/notifications.service.ts
@@ -1,5 +1,5 @@
 import { BadRequestException, Inject, Injectable, Logger } from '@nestjs/common';
-import { and, count, desc, eq, isNull, lt } from 'drizzle-orm';
+import { and, count, desc, eq, isNull, lt, sql } from 'drizzle-orm';
 import {
   DeliveryStatus,
   NotificationChannel,
@@ -10,12 +10,15 @@ import { DRIZZLE_CLIENT, DrizzleClient } from '@/database/drizzle.provider';
 import { I18nService, SupportedLanguage } from '@/i18n/i18n.service';
 import { notifications } from '@/modules/notifications/schema/notifications.schema';
 import { notificationDeliveries } from '@/modules/notifications/schema/notification-deliveries.schema';
+import { userFcmTokens } from '@/modules/notifications/schema/user-fcm-tokens.schema';
 import { buildNotificationContent } from './notification-content.builder';
 import { EMAIL_STRATEGY, PUSH_STRATEGY, SMS_STRATEGY } from './notifications.constants';
 import type {
   NotificationChannelStrategy,
   NotificationRow,
 } from './channel-strategies/notification-channel.strategy';
+import type { RegisterFcmTokenDto } from './dto/register-fcm-token.dto';
+import type { DeleteFcmTokenDto } from './dto/delete-fcm-token.dto';
 
 @Injectable()
 export class NotificationsService {
@@ -128,6 +131,22 @@ export class NotificationsService {
       .from(notifications)
       .where(and(eq(notifications.userId, userId), isNull(notifications.readAt)));
     return result[0]?.count ?? 0;
+  }
+
+  async registerToken(userId: string, dto: RegisterFcmTokenDto): Promise<void> {
+    await this.db
+      .insert(userFcmTokens)
+      .values({ userId, token: dto.token, deviceHint: dto.deviceHint ?? null })
+      .onConflictDoUpdate({
+        target: [userFcmTokens.userId, userFcmTokens.token],
+        set: { lastUsedAt: sql`now()` },
+      });
+  }
+
+  async deleteToken(userId: string, dto: DeleteFcmTokenDto): Promise<void> {
+    await this.db
+      .delete(userFcmTokens)
+      .where(and(eq(userFcmTokens.userId, userId), eq(userFcmTokens.token, dto.token)));
   }
 
   async sendPassportStatusNotification(

--- a/apps/api/src/modules/notifications/notifications.service.ts
+++ b/apps/api/src/modules/notifications/notifications.service.ts
@@ -139,6 +139,8 @@ export class NotificationsService {
       .values({ userId, token: dto.token, deviceHint: dto.deviceHint ?? null })
       .onConflictDoUpdate({
         target: [userFcmTokens.userId, userFcmTokens.token],
+        // deviceHint is intentionally not refreshed on conflict — the token identity
+        // is stable, and a stale hint is harmless (used only for human-readable display).
         set: { lastUsedAt: sql`now()` },
       });
   }

--- a/apps/api/src/modules/notifications/schema/user-fcm-tokens.schema.ts
+++ b/apps/api/src/modules/notifications/schema/user-fcm-tokens.schema.ts
@@ -1,0 +1,25 @@
+import { relations } from 'drizzle-orm';
+import { index, pgTable, primaryKey, text, timestamp, uuid, varchar } from 'drizzle-orm/pg-core';
+
+import { users } from '@/modules/users/schema/users.schema';
+
+export const userFcmTokens = pgTable(
+  'user_fcm_tokens',
+  {
+    userId: uuid('user_id')
+      .references(() => users.id, { onDelete: 'cascade' })
+      .notNull(),
+    token: text('token').notNull(),
+    deviceHint: varchar('device_hint', { length: 100 }),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    lastUsedAt: timestamp('last_used_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [
+    primaryKey({ columns: [t.userId, t.token] }),
+    index('idx_user_fcm_tokens_user_id').on(t.userId),
+  ],
+);
+
+export const userFcmTokensRelations = relations(userFcmTokens, ({ one }) => ({
+  user: one(users, { fields: [userFcmTokens.userId], references: [users.id] }),
+}));


### PR DESCRIPTION
## Summary

Part of the Notifications epic (#8). Users can have multiple devices, each with its own FCM registration token. This PR adds the persistence layer and API endpoints to register a token on login and remove it on logout, enabling per-device push delivery when the `PushChannelStrategy` is implemented.

The token store was implemented as a dedicated table rather than a JSONB column on `users` because the composite PK `(user_id, token)` provides native upsert semantics (`ON CONFLICT DO UPDATE`), per-token `last_used_at` updates are trivial, and `ON DELETE CASCADE` auto-purges tokens when a user is deleted — none of which are ergonomic with a JSONB array.

## Changes

**Schema & migration**
- New `user_fcm_tokens` table with composite PK `(user_id, token)`, `ON DELETE CASCADE` FK to `users`, btree index on `user_id` for efficient per-user lookups, and a `last_used_at` timestamp refreshed on every upsert.
- Migration `0021_tranquil_lester.sql` generated and committed alongside the schema change.

**DTOs**
- `RegisterFcmTokenDto`: `token` (required, max 512 chars) + `deviceHint` (optional, max 100 chars).
- `DeleteFcmTokenDto`: `token` (required).

**Service**
- `registerToken(userId, dto)` — upserts via `INSERT … ON CONFLICT (user_id, token) DO UPDATE SET last_used_at = now()`. Idempotent by design.
- `deleteToken(userId, dto)` — deletes the row and resolves void regardless of whether the token existed.

**Controller**
- `POST /v1/notifications/fcm-token` — returns 204, fully annotated with `@ApiOperation`, `@ApiBody`, `@ApiResponse`.
- `DELETE /v1/notifications/fcm-token` — returns 204 even if the token was not present.

## Testing

- Service: 6 new unit tests covering upsert payload shape, `null` deviceHint, `onConflictDoUpdate` call, delete delegation, and idempotent delete on a non-existent token.
- Controller: 5 new unit tests verifying delegation to `registerToken` / `deleteToken` with and without `deviceHint`, and void return.
- All 976 API tests pass; `pnpm validate` exits 0.

## Notes

`DELETE` with a body is used (rather than a path param) because FCM tokens are long, non-URL-safe strings. This is valid HTTP and documented in the OpenAPI spec via `@ApiBody`.

Closes #304