### PR TITLE
feat(notifications): implement FCM push channel strategy

### DIFF
--- a/apps/api/src/modules/auth/firebase-admin.service.ts
+++ b/apps/api/src/modules/auth/firebase-admin.service.ts
@@ -28,4 +28,8 @@ export class FirebaseAdminService implements OnModuleInit {
   auth(): admin.auth.Auth {
     return admin.auth();
   }
+
+  messaging(): admin.messaging.Messaging {
+    return admin.messaging();
+  }
 }

--- a/apps/api/src/modules/notifications/channel-strategies/channel-strategies.spec.ts
+++ b/apps/api/src/modules/notifications/channel-strategies/channel-strategies.spec.ts
@@ -1,26 +1,197 @@
+import { DeliveryStatus, NotificationType } from '@chamuco/shared-types';
+import type { DrizzleClient } from '@/database/drizzle.provider';
+import type { FirebaseAdminService } from '@/modules/auth/firebase-admin.service';
 import { PushChannelStrategy } from './push-channel.strategy';
 import { EmailChannelStrategy } from './email-channel.strategy';
 import { SmsChannelStrategy } from './sms-channel.strategy';
 import type { NotificationRow } from './notification-channel.strategy';
-import { NotificationType } from '@chamuco/shared-types';
 
 const FAKE_NOTIFICATION: NotificationRow = {
   id: 'notif-1',
   userId: 'user-1',
   type: NotificationType.PASSPORT_EXPIRING_SOON,
-  title: 'Test',
+  title: 'Test title',
   body: 'Test body',
   data: {},
   readAt: null,
   createdAt: new Date(),
 };
 
+type SendResponse = { success: boolean; error?: { code: string; message?: string } };
+
+function makeBatchResponse(responses: SendResponse[]) {
+  return {
+    successCount: responses.filter((r) => r.success).length,
+    failureCount: responses.filter((r) => !r.success).length,
+    responses,
+  };
+}
+
+function makeContext(tokens: string[], sendEachForMulticast: jest.Mock) {
+  const updateSetWhere = jest.fn().mockResolvedValue(undefined);
+  const updateSet = jest.fn().mockReturnValue({ where: updateSetWhere });
+  const deleteWhere = jest.fn().mockResolvedValue(undefined);
+
+  const db = {
+    select: jest.fn().mockReturnValue({
+      from: jest.fn().mockReturnValue({
+        where: jest.fn().mockResolvedValue(tokens.map((token) => ({ token }))),
+      }),
+    }),
+    delete: jest.fn().mockReturnValue({ where: deleteWhere }),
+    update: jest.fn().mockReturnValue({ set: updateSet }),
+  };
+
+  const firebaseAdmin = {
+    messaging: jest.fn().mockReturnValue({ sendEachForMulticast }),
+  };
+
+  const strategy = new PushChannelStrategy(
+    db as unknown as DrizzleClient,
+    firebaseAdmin as unknown as FirebaseAdminService,
+  );
+
+  const getSetArgs = () =>
+    updateSet.mock.calls[0]?.[0] as
+      | { status: DeliveryStatus; sentAt: Date | null; error: string | null }
+      | undefined;
+
+  return { strategy, db, updateSet, deleteWhere, getSetArgs };
+}
+
+// ─── PushChannelStrategy ─────────────────────────────────────────────────────
+
 describe('PushChannelStrategy', () => {
-  it('send() resolves without throwing', async () => {
-    const strategy = new PushChannelStrategy();
-    await expect(strategy.send(FAKE_NOTIFICATION, {})).resolves.toBeUndefined();
+  describe('no tokens for user', () => {
+    it('marks delivery FAILED(no_fcm_tokens) and skips FCM call', async () => {
+      const sendEachForMulticast = jest.fn();
+      const { strategy, db, getSetArgs } = makeContext([], sendEachForMulticast);
+
+      await strategy.send(FAKE_NOTIFICATION, {});
+
+      expect(sendEachForMulticast).not.toHaveBeenCalled();
+      expect(db.delete).not.toHaveBeenCalled();
+      expect(getSetArgs()?.status).toBe(DeliveryStatus.FAILED);
+      expect(getSetArgs()?.error).toBe('no_fcm_tokens');
+      expect(getSetArgs()?.sentAt).toBeNull();
+    });
+  });
+
+  describe('all tokens succeed', () => {
+    it('calls FCM with correct args and marks delivery SENT', async () => {
+      const sendEachForMulticast = jest
+        .fn()
+        .mockResolvedValue(makeBatchResponse([{ success: true }, { success: true }]));
+      const { strategy, db, getSetArgs } = makeContext(['tok-a', 'tok-b'], sendEachForMulticast);
+
+      await strategy.send(FAKE_NOTIFICATION, { key: 'val' });
+
+      expect(sendEachForMulticast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tokens: ['tok-a', 'tok-b'],
+          notification: { title: FAKE_NOTIFICATION.title, body: FAKE_NOTIFICATION.body },
+          data: { key: 'val' },
+        }),
+      );
+      expect(db.delete).not.toHaveBeenCalled();
+      expect(getSetArgs()?.status).toBe(DeliveryStatus.SENT);
+      expect(getSetArgs()?.sentAt).toBeInstanceOf(Date);
+      expect(getSetArgs()?.error).toBeNull();
+    });
+  });
+
+  describe('mixed: one stale token, one success', () => {
+    it('deletes stale token and marks delivery SENT', async () => {
+      const sendEachForMulticast = jest
+        .fn()
+        .mockResolvedValue(
+          makeBatchResponse([
+            { success: true },
+            { success: false, error: { code: 'messaging/registration-token-not-registered' } },
+          ]),
+        );
+      const { strategy, db, getSetArgs } = makeContext(
+        ['tok-ok', 'tok-stale'],
+        sendEachForMulticast,
+      );
+
+      await strategy.send(FAKE_NOTIFICATION, {});
+
+      expect(db.delete).toHaveBeenCalled();
+      expect(getSetArgs()?.status).toBe(DeliveryStatus.SENT);
+      expect(getSetArgs()?.sentAt).toBeInstanceOf(Date);
+    });
+  });
+
+  describe('all tokens stale', () => {
+    it('deletes all tokens and marks delivery FAILED(no_fcm_tokens)', async () => {
+      const sendEachForMulticast = jest.fn().mockResolvedValue(
+        makeBatchResponse([
+          { success: false, error: { code: 'messaging/registration-token-not-registered' } },
+          { success: false, error: { code: 'messaging/registration-token-not-registered' } },
+        ]),
+      );
+      const { strategy, db, getSetArgs } = makeContext(['s1', 's2'], sendEachForMulticast);
+
+      await strategy.send(FAKE_NOTIFICATION, {});
+
+      expect(db.delete).toHaveBeenCalled();
+      expect(getSetArgs()?.status).toBe(DeliveryStatus.FAILED);
+      expect(getSetArgs()?.error).toBe('no_fcm_tokens');
+    });
+  });
+
+  describe('non-stale FCM error', () => {
+    it('does NOT delete token and marks delivery FAILED with error message', async () => {
+      const sendEachForMulticast = jest.fn().mockResolvedValue(
+        makeBatchResponse([
+          {
+            success: false,
+            error: { code: 'messaging/invalid-argument', message: 'Bad token format' },
+          },
+        ]),
+      );
+      const { strategy, db, getSetArgs } = makeContext(['tok-bad'], sendEachForMulticast);
+
+      await strategy.send(FAKE_NOTIFICATION, {});
+
+      expect(db.delete).not.toHaveBeenCalled();
+      expect(getSetArgs()?.status).toBe(DeliveryStatus.FAILED);
+      expect(getSetArgs()?.error).toBe('Bad token format');
+    });
+  });
+
+  describe('sendEachForMulticast throws', () => {
+    it('marks delivery FAILED with thrown error message', async () => {
+      const sendEachForMulticast = jest.fn().mockRejectedValue(new Error('Network timeout'));
+      const { strategy, getSetArgs } = makeContext(['tok-x'], sendEachForMulticast);
+
+      await strategy.send(FAKE_NOTIFICATION, {});
+
+      expect(getSetArgs()?.status).toBe(DeliveryStatus.FAILED);
+      expect(getSetArgs()?.error).toBe('Network timeout');
+    });
+  });
+
+  describe('payload coercion', () => {
+    it('converts non-string values to JSON strings', async () => {
+      const sendEachForMulticast = jest
+        .fn()
+        .mockResolvedValue(makeBatchResponse([{ success: true }]));
+      const { strategy } = makeContext(['tok-a'], sendEachForMulticast);
+
+      await strategy.send(FAKE_NOTIFICATION, { count: 3, flag: true, nested: { x: 1 } });
+
+      expect(sendEachForMulticast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: { count: '3', flag: 'true', nested: '{"x":1}' },
+        }),
+      );
+    });
   });
 });
+
+// ─── Stub strategy smoke tests ───────────────────────────────────────────────
 
 describe('EmailChannelStrategy', () => {
   it('send() resolves without throwing', async () => {

--- a/apps/api/src/modules/notifications/channel-strategies/channel-strategies.spec.ts
+++ b/apps/api/src/modules/notifications/channel-strategies/channel-strategies.spec.ts
@@ -56,7 +56,7 @@ function makeContext(tokens: string[], sendEachForMulticast: jest.Mock) {
       | { status: DeliveryStatus; sentAt: Date | null; error: string | null }
       | undefined;
 
-  return { strategy, db, updateSet, deleteWhere, getSetArgs };
+  return { strategy, db, updateSet, updateSetWhere, deleteWhere, getSetArgs };
 }
 
 // ─── PushChannelStrategy ─────────────────────────────────────────────────────
@@ -82,7 +82,10 @@ describe('PushChannelStrategy', () => {
       const sendEachForMulticast = jest
         .fn()
         .mockResolvedValue(makeBatchResponse([{ success: true }, { success: true }]));
-      const { strategy, db, getSetArgs } = makeContext(['tok-a', 'tok-b'], sendEachForMulticast);
+      const { strategy, db, updateSetWhere, getSetArgs } = makeContext(
+        ['tok-a', 'tok-b'],
+        sendEachForMulticast,
+      );
 
       await strategy.send(FAKE_NOTIFICATION, { key: 'val' });
 
@@ -97,6 +100,8 @@ describe('PushChannelStrategy', () => {
       expect(getSetArgs()?.status).toBe(DeliveryStatus.SENT);
       expect(getSetArgs()?.sentAt).toBeInstanceOf(Date);
       expect(getSetArgs()?.error).toBeNull();
+      // WHERE clause must be applied — guards against updateDelivery updating wrong rows
+      expect(updateSetWhere).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -170,6 +175,20 @@ describe('PushChannelStrategy', () => {
 
       expect(getSetArgs()?.status).toBe(DeliveryStatus.FAILED);
       expect(getSetArgs()?.error).toBe('Network timeout');
+    });
+  });
+
+  describe('FCM returns failure with no error object', () => {
+    it('marks delivery FAILED with unknown_fcm_error', async () => {
+      const sendEachForMulticast = jest
+        .fn()
+        .mockResolvedValue(makeBatchResponse([{ success: false }]));
+      const { strategy, getSetArgs } = makeContext(['tok-x'], sendEachForMulticast);
+
+      await strategy.send(FAKE_NOTIFICATION, {});
+
+      expect(getSetArgs()?.status).toBe(DeliveryStatus.FAILED);
+      expect(getSetArgs()?.error).toBe('unknown_fcm_error');
     });
   });
 

--- a/apps/api/src/modules/notifications/channel-strategies/push-channel.strategy.ts
+++ b/apps/api/src/modules/notifications/channel-strategies/push-channel.strategy.ts
@@ -1,8 +1,111 @@
-import { Injectable } from '@nestjs/common';
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { and, eq, inArray } from 'drizzle-orm';
+import { DeliveryStatus, NotificationChannel } from '@chamuco/shared-types';
+import { DRIZZLE_CLIENT, DrizzleClient } from '@/database/drizzle.provider';
+import { FirebaseAdminService } from '@/modules/auth/firebase-admin.service';
+import { notificationDeliveries } from '@/modules/notifications/schema/notification-deliveries.schema';
+import { userFcmTokens } from '@/modules/notifications/schema/user-fcm-tokens.schema';
 import type { NotificationChannelStrategy, NotificationRow } from './notification-channel.strategy';
+
+const STALE_TOKEN_ERROR = 'messaging/registration-token-not-registered';
 
 @Injectable()
 export class PushChannelStrategy implements NotificationChannelStrategy {
-  // TODO(Epic #8): implement FCM push via FirebaseAdminService.messaging()
-  async send(_notification: NotificationRow, _payload: Record<string, unknown>): Promise<void> {}
+  private readonly logger = new Logger(PushChannelStrategy.name);
+
+  constructor(
+    @Inject(DRIZZLE_CLIENT) private readonly db: DrizzleClient,
+    private readonly firebaseAdmin: FirebaseAdminService,
+  ) {}
+
+  async send(notification: NotificationRow, payload: Record<string, unknown>): Promise<void> {
+    const tokenRows = await this.db
+      .select({ token: userFcmTokens.token })
+      .from(userFcmTokens)
+      .where(eq(userFcmTokens.userId, notification.userId));
+
+    if (tokenRows.length === 0) {
+      await this.updateDelivery(notification.id, DeliveryStatus.FAILED, null, 'no_fcm_tokens');
+      return;
+    }
+
+    const tokens = tokenRows.map((r) => r.token);
+    const data = this.coercePayload(payload);
+
+    let batchResponse;
+    try {
+      batchResponse = await this.firebaseAdmin.messaging().sendEachForMulticast({
+        tokens,
+        notification: { title: notification.title, body: notification.body },
+        data,
+      });
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.logger.error(`FCM multicast failed for notification ${notification.id}`, err);
+      await this.updateDelivery(notification.id, DeliveryStatus.FAILED, null, message);
+      return;
+    }
+
+    const staleTokens: string[] = [];
+    let firstNonStaleError: string | null = null;
+
+    batchResponse.responses.forEach((response, index) => {
+      if (!response.success && response.error) {
+        if (response.error.code === STALE_TOKEN_ERROR) {
+          staleTokens.push(tokens[index]!);
+        } else if (firstNonStaleError === null) {
+          firstNonStaleError = response.error.message ?? response.error.code;
+        }
+      }
+    });
+
+    if (staleTokens.length > 0) {
+      await this.db
+        .delete(userFcmTokens)
+        .where(
+          and(
+            eq(userFcmTokens.userId, notification.userId),
+            inArray(userFcmTokens.token, staleTokens),
+          ),
+        );
+      this.logger.log(
+        `Removed ${staleTokens.length} stale FCM token(s) for user ${notification.userId}`,
+      );
+    }
+
+    const activeSent = batchResponse.successCount;
+    const hasNonStaleFailure = firstNonStaleError !== null;
+
+    if (activeSent === 0 && staleTokens.length === tokens.length) {
+      // All tokens were stale — nothing delivered
+      await this.updateDelivery(notification.id, DeliveryStatus.FAILED, null, 'no_fcm_tokens');
+    } else if (hasNonStaleFailure) {
+      await this.updateDelivery(notification.id, DeliveryStatus.FAILED, null, firstNonStaleError!);
+    } else {
+      await this.updateDelivery(notification.id, DeliveryStatus.SENT, new Date(), null);
+    }
+  }
+
+  private async updateDelivery(
+    notificationId: string,
+    status: DeliveryStatus,
+    sentAt: Date | null,
+    error: string | null,
+  ): Promise<void> {
+    await this.db
+      .update(notificationDeliveries)
+      .set({ status, sentAt, error, updatedAt: new Date() })
+      .where(
+        and(
+          eq(notificationDeliveries.notificationId, notificationId),
+          eq(notificationDeliveries.channel, NotificationChannel.PUSH),
+        ),
+      );
+  }
+
+  private coercePayload(payload: Record<string, unknown>): Record<string, string> {
+    return Object.fromEntries(
+      Object.entries(payload).map(([k, v]) => [k, typeof v === 'string' ? v : JSON.stringify(v)]),
+    );
+  }
 }

--- a/apps/api/src/modules/notifications/channel-strategies/push-channel.strategy.ts
+++ b/apps/api/src/modules/notifications/channel-strategies/push-channel.strategy.ts
@@ -1,4 +1,5 @@
 import { Inject, Injectable, Logger } from '@nestjs/common';
+import type * as admin from 'firebase-admin';
 import { and, eq, inArray } from 'drizzle-orm';
 import { DeliveryStatus, NotificationChannel } from '@chamuco/shared-types';
 import { DRIZZLE_CLIENT, DrizzleClient } from '@/database/drizzle.provider';
@@ -32,7 +33,7 @@ export class PushChannelStrategy implements NotificationChannelStrategy {
     const tokens = tokenRows.map((r) => r.token);
     const data = this.coercePayload(payload);
 
-    let batchResponse;
+    let batchResponse: admin.messaging.BatchResponse;
     try {
       batchResponse = await this.firebaseAdmin.messaging().sendEachForMulticast({
         tokens,
@@ -81,8 +82,10 @@ export class PushChannelStrategy implements NotificationChannelStrategy {
       await this.updateDelivery(notification.id, DeliveryStatus.FAILED, null, 'no_fcm_tokens');
     } else if (hasNonStaleFailure) {
       await this.updateDelivery(notification.id, DeliveryStatus.FAILED, null, firstNonStaleError!);
-    } else {
+    } else if (activeSent > 0) {
       await this.updateDelivery(notification.id, DeliveryStatus.SENT, new Date(), null);
+    } else {
+      await this.updateDelivery(notification.id, DeliveryStatus.FAILED, null, 'unknown_fcm_error');
     }
   }
 

--- a/apps/api/src/modules/notifications/notifications.service.ts
+++ b/apps/api/src/modules/notifications/notifications.service.ts
@@ -193,9 +193,6 @@ export class NotificationsService {
 
     await this.db.insert(notificationDeliveries).values(deliveryRows);
 
-    // TODO(Epic #8): update delivery status to SENT or FAILED based on strategy outcome.
-    // Currently rows stay PENDING indefinitely — add retry/status-update logic when
-    // real channel strategies are implemented.
     await Promise.allSettled(
       inserted.flatMap((n) =>
         channels.map((channel) =>


### PR DESCRIPTION
## Summary

Implements the `PushChannelStrategy` to complete the FCM push dispatch path (Epic #8). Previously, `dispatchChannels()` inserted `PENDING` delivery rows but never resolved them — all push sends were no-ops. This PR wires the real Firebase multicast call and closes the feedback loop by updating each delivery row to `SENT` or `FAILED`.

## Changes

**`FirebaseAdminService`** — exposes `messaging(): admin.messaging.Messaging`, parallel to the existing `auth()` method, so channel strategies can access FCM without reimporting the `firebase-admin` package directly.

**`PushChannelStrategy`** — full implementation replacing the stub:
- Fetches all `user_fcm_tokens` rows for the notification's user
- Calls `sendEachForMulticast()` with title, body, and coerced data payload (`Record<string, string>` — non-string values are `JSON.stringify`-ed)
- Inspects per-token `SendResponse[]`: tokens returning `messaging/registration-token-not-registered` are bulk-deleted from `user_fcm_tokens` immediately
- Updates the `notification_deliveries` row to `SENT` (with `sentAt`) or `FAILED` (with `error`) based on the multicast outcome
- Status logic: all-stale → `FAILED(no_fcm_tokens)`, non-stale error on any token → `FAILED(<message>)`, at least one delivered → `SENT`

**Tests** — replaces the stub smoke test with 7 focused cases: no tokens, all succeed, mixed stale/success, all stale, non-stale error, FCM throws, and payload coercion. All mocks are local to each test via a `makeContext` factory.

## Testing

- `pnpm --filter api exec jest channel-strategies` — 12 tests pass
- `pnpm --filter api test:cov` — 982 tests pass, coverage ≥ 90%
- `pnpm --filter api lint:check && pnpm --filter api typecheck` — clean

## Notes

`NotificationsModule` required no changes — `FirebaseAdminService` is already globally available via `@Global() AuthModule`.

The `notifications.service.ts` TODO comment about "rows stay PENDING indefinitely" is resolved: the strategy now owns its delivery row update after each send attempt.

Closes #305