### PR TITLE
feat(notifications): add notification bell and panel to app header

### DIFF
--- a/apps/web/src/components/header/Header.test.tsx
+++ b/apps/web/src/components/header/Header.test.tsx
@@ -12,6 +12,11 @@ vi.mock('./UserAvatar', () => ({
   UserAvatar: () => <button data-testid="user-avatar">User Avatar</button>,
 }));
 
+// Mock the NotificationBell component
+vi.mock('./NotificationBell', () => ({
+  NotificationBell: () => <button data-testid="notification-bell">Notification Bell</button>,
+}));
+
 // Mock the ThemeToggle component
 vi.mock('@/components/ThemeToggle', () => ({
   ThemeToggle: () => <button data-testid="theme-toggle">Theme Toggle</button>,
@@ -55,6 +60,11 @@ describe('Header', () => {
   it('renders UserAvatar component', () => {
     render(<Header />);
     expect(screen.getByTestId('user-avatar')).toBeInTheDocument();
+  });
+
+  it('renders NotificationBell component', () => {
+    render(<Header />);
+    expect(screen.getByTestId('notification-bell')).toBeInTheDocument();
   });
 
   it('renders LanguageToggle component', () => {

--- a/apps/web/src/components/header/Header.test.tsx
+++ b/apps/web/src/components/header/Header.test.tsx
@@ -1,5 +1,7 @@
 import { render, screen } from '@testing-library/react';
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { User } from 'firebase/auth';
+import type { AuthContextValue } from '@/store/auth';
 import { Header } from './Header';
 
 // Mock the Logo component
@@ -26,6 +28,33 @@ vi.mock('@/components/ThemeToggle', () => ({
 vi.mock('@/components/LanguageToggle', () => ({
   LanguageToggle: () => <button data-testid="language-toggle">Language Toggle</button>,
 }));
+
+vi.mock('@/hooks/useAuth', () => ({
+  useAuth: vi.fn(),
+}));
+
+import { useAuth } from '@/hooks/useAuth';
+
+function makeAuth(overrides: Partial<AuthContextValue> = {}): AuthContextValue {
+  return {
+    currentUser: null,
+    idToken: null,
+    isLoading: false,
+    getIdToken: vi.fn().mockResolvedValue(null),
+    signInWithGoogle: vi.fn(),
+    signInWithFacebook: vi.fn(),
+    signOut: vi.fn(),
+    ...overrides,
+  };
+}
+
+function makeFirebaseUser(): User {
+  return { uid: 'uid-1', displayName: 'Jane', email: 'jane@example.com' } as User;
+}
+
+beforeEach(() => {
+  vi.mocked(useAuth).mockReturnValue(makeAuth({ currentUser: makeFirebaseUser() }));
+});
 
 describe('Header', () => {
   it('renders as a header element', () => {
@@ -62,9 +91,15 @@ describe('Header', () => {
     expect(screen.getByTestId('user-avatar')).toBeInTheDocument();
   });
 
-  it('renders NotificationBell component', () => {
+  it('renders NotificationBell when user is authenticated', () => {
     render(<Header />);
     expect(screen.getByTestId('notification-bell')).toBeInTheDocument();
+  });
+
+  it('hides NotificationBell when user is not authenticated', () => {
+    vi.mocked(useAuth).mockReturnValue(makeAuth({ currentUser: null }));
+    render(<Header />);
+    expect(screen.queryByTestId('notification-bell')).not.toBeInTheDocument();
   });
 
   it('renders LanguageToggle component', () => {

--- a/apps/web/src/components/header/Header.tsx
+++ b/apps/web/src/components/header/Header.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useAuth } from '@/hooks/useAuth';
 import { Logo } from './Logo';
 import { UserAvatar } from './UserAvatar';
 import { NotificationBell } from './NotificationBell';
@@ -7,6 +8,8 @@ import { ThemeToggle } from '@/components/ThemeToggle';
 import { LanguageToggle } from '@/components/LanguageToggle';
 
 export function Header() {
+  const { currentUser } = useAuth();
+
   return (
     <header className="fixed top-0 left-0 right-0 z-50 h-header-safe pt-safe bg-background border-b border-border">
       <div className="flex items-center justify-between h-header px-4">
@@ -14,7 +17,7 @@ export function Header() {
 
         <div className="flex items-center gap-2">
           <UserAvatar />
-          <NotificationBell />
+          {currentUser && <NotificationBell />}
           <LanguageToggle />
           <ThemeToggle />
         </div>

--- a/apps/web/src/components/header/Header.tsx
+++ b/apps/web/src/components/header/Header.tsx
@@ -2,6 +2,7 @@
 
 import { Logo } from './Logo';
 import { UserAvatar } from './UserAvatar';
+import { NotificationBell } from './NotificationBell';
 import { ThemeToggle } from '@/components/ThemeToggle';
 import { LanguageToggle } from '@/components/LanguageToggle';
 
@@ -13,6 +14,7 @@ export function Header() {
 
         <div className="flex items-center gap-2">
           <UserAvatar />
+          <NotificationBell />
           <LanguageToggle />
           <ThemeToggle />
         </div>

--- a/apps/web/src/components/header/NotificationBell.test.tsx
+++ b/apps/web/src/components/header/NotificationBell.test.tsx
@@ -1,0 +1,92 @@
+import { type ReactNode } from 'react';
+import { render, screen } from '@testing-library/react';
+import type { NotificationItem } from '@/hooks/useNotifications';
+import { NotificationBell } from './NotificationBell';
+
+// --- hoisted mocks ---
+
+const mocks = vi.hoisted(() => ({
+  mockMarkRead: vi.fn(),
+  mockMarkAllRead: vi.fn(),
+  mockNotifications: [] as NotificationItem[],
+  mockUnreadCount: 0,
+  mockIsLoading: false,
+}));
+
+vi.mock('@/hooks/useNotifications', () => ({
+  useNotifications: () => ({
+    notifications: mocks.mockNotifications,
+    unreadCount: mocks.mockUnreadCount,
+    isLoading: mocks.mockIsLoading,
+    markRead: mocks.mockMarkRead,
+    markAllRead: mocks.mockMarkAllRead,
+  }),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, unknown>) =>
+      opts ? `${key}(${JSON.stringify(opts)})` : key,
+    i18n: { language: 'en' },
+  }),
+}));
+
+vi.mock('@/components/ui/popover', () => ({
+  Popover: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  PopoverTrigger: ({ children, ...props }: { children: ReactNode; [key: string]: unknown }) => (
+    <button {...props}>{children}</button>
+  ),
+  PopoverContent: ({ children }: { children: ReactNode }) => (
+    <div data-testid="popover-content">{children}</div>
+  ),
+}));
+
+vi.mock('./NotificationPanel', () => ({
+  NotificationPanel: () => <div data-testid="notification-panel">Panel</div>,
+}));
+
+// ---
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.mockNotifications = [];
+  mocks.mockUnreadCount = 0;
+  mocks.mockIsLoading = false;
+});
+
+describe('NotificationBell', () => {
+  it('renders a button with accessible label', () => {
+    render(<NotificationBell />);
+    expect(screen.getByRole('button', { name: 'notifications.openLabel' })).toBeInTheDocument();
+  });
+
+  it('does not show badge when unreadCount is 0', () => {
+    mocks.mockUnreadCount = 0;
+    render(<NotificationBell />);
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+    expect(screen.queryByText(/\d+/)).not.toBeInTheDocument();
+  });
+
+  it('shows badge with count when unreadCount > 0', () => {
+    mocks.mockUnreadCount = 5;
+    render(<NotificationBell />);
+    expect(screen.getByText('5')).toBeInTheDocument();
+  });
+
+  it('caps badge display at 99+ for counts > 99', () => {
+    mocks.mockUnreadCount = 150;
+    render(<NotificationBell />);
+    expect(screen.getByText('99+')).toBeInTheDocument();
+  });
+
+  it('shows exact count 99 without cap', () => {
+    mocks.mockUnreadCount = 99;
+    render(<NotificationBell />);
+    expect(screen.getByText('99')).toBeInTheDocument();
+  });
+
+  it('renders the notification panel inside the popover content', () => {
+    render(<NotificationBell />);
+    expect(screen.getByTestId('notification-panel')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/header/NotificationBell.tsx
+++ b/apps/web/src/components/header/NotificationBell.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { useTranslation } from 'react-i18next';
+import { BellIcon } from '@phosphor-icons/react';
+
+import { useNotifications } from '@/hooks/useNotifications';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { NotificationPanel } from './NotificationPanel';
+
+export function NotificationBell() {
+  const { t } = useTranslation();
+  const { notifications, unreadCount, isLoading, markRead, markAllRead } = useNotifications();
+
+  return (
+    <Popover>
+      <PopoverTrigger
+        className="relative rounded-lg p-2 hover:bg-muted transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        aria-label={t('notifications.openLabel')}
+      >
+        <BellIcon className="h-6 w-6" weight="regular" aria-hidden="true" />
+        {unreadCount > 0 && (
+          <span
+            className="absolute top-0.5 right-0.5 flex h-4 min-w-4 items-center justify-center rounded-full bg-destructive px-0.5 text-[10px] font-bold leading-none text-destructive-foreground"
+            aria-label={t('notifications.unreadBadge', { count: unreadCount })}
+          >
+            {unreadCount > 99 ? '99+' : unreadCount}
+          </span>
+        )}
+      </PopoverTrigger>
+
+      <PopoverContent align="end" sideOffset={8} className="w-80 p-0">
+        <NotificationPanel
+          notifications={notifications}
+          isLoading={isLoading}
+          onMarkRead={markRead}
+          onMarkAllRead={markAllRead}
+        />
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/apps/web/src/components/header/NotificationPanel.test.tsx
+++ b/apps/web/src/components/header/NotificationPanel.test.tsx
@@ -1,0 +1,248 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { NotificationType } from '@chamuco/shared-types';
+import type { NotificationItem } from '@/hooks/useNotifications';
+import { NotificationPanel } from './NotificationPanel';
+
+// --- hoisted mocks ---
+
+const mocks = vi.hoisted(() => ({
+  mockRouterPush: vi.fn(),
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mocks.mockRouterPush }),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: 'en' },
+  }),
+}));
+
+// --- helpers ---
+
+function makeNotification(overrides: Partial<NotificationItem> = {}): NotificationItem {
+  return {
+    id: 'notif-1',
+    type: NotificationType.TRIP_INVITATION,
+    title: 'New trip invitation',
+    body: 'You have been invited to join Summer Trip 2026.',
+    readAt: null,
+    data: { url: '/trips/trip-1' },
+    createdAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function renderPanel(
+  notifications: NotificationItem[] = [],
+  overrides: {
+    isLoading?: boolean;
+    onMarkRead?: (id: string) => void;
+    onMarkAllRead?: () => void;
+  } = {},
+) {
+  const onMarkRead = overrides.onMarkRead ?? vi.fn();
+  const onMarkAllRead = overrides.onMarkAllRead ?? vi.fn();
+  render(
+    <NotificationPanel
+      notifications={notifications}
+      isLoading={overrides.isLoading ?? false}
+      onMarkRead={onMarkRead}
+      onMarkAllRead={onMarkAllRead}
+    />,
+  );
+  return { onMarkRead, onMarkAllRead };
+}
+
+// ---
+
+describe('NotificationPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('empty state', () => {
+    it('shows empty state text when there are no notifications', () => {
+      renderPanel([]);
+      expect(screen.getByText('notifications.empty')).toBeInTheDocument();
+    });
+
+    it('does not render any notification rows when empty', () => {
+      renderPanel([]);
+      expect(screen.queryAllByRole('button', { name: /trip invitation/i })).toHaveLength(0);
+    });
+  });
+
+  describe('loading state', () => {
+    it('shows loading skeleton when isLoading and no notifications', () => {
+      renderPanel([], { isLoading: true });
+      expect(screen.getByLabelText('loading')).toBeInTheDocument();
+    });
+
+    it('shows notifications if present even when isLoading', () => {
+      const notif = makeNotification();
+      renderPanel([notif], { isLoading: true });
+      expect(screen.getByText(notif.title)).toBeInTheDocument();
+    });
+  });
+
+  describe('notification rows', () => {
+    it('renders title and body for each notification', () => {
+      const notif = makeNotification({ title: 'Trip invite', body: 'Join us!' });
+      renderPanel([notif]);
+      expect(screen.getByText('Trip invite')).toBeInTheDocument();
+      expect(screen.getByText('Join us!')).toBeInTheDocument();
+    });
+
+    it('renders unread indicator dot for unread notifications', () => {
+      const notif = makeNotification({ readAt: null });
+      renderPanel([notif]);
+      expect(screen.getByLabelText('unread')).toBeInTheDocument();
+    });
+
+    it('does not render unread dot for read notifications', () => {
+      const notif = makeNotification({ readAt: '2026-01-01T00:00:00.000Z' });
+      renderPanel([notif]);
+      expect(screen.queryByLabelText('unread')).not.toBeInTheDocument();
+    });
+
+    it('renders multiple notifications', () => {
+      const notifications = [
+        makeNotification({ id: 'n1', title: 'First' }),
+        makeNotification({ id: 'n2', title: 'Second' }),
+      ];
+      renderPanel(notifications);
+      expect(screen.getByText('First')).toBeInTheDocument();
+      expect(screen.getByText('Second')).toBeInTheDocument();
+    });
+  });
+
+  describe('interactions', () => {
+    it('calls onMarkRead with notification id on row click', async () => {
+      const user = userEvent.setup();
+      const notif = makeNotification({ id: 'notif-abc' });
+      const { onMarkRead } = renderPanel([notif]);
+
+      await user.click(screen.getByText(notif.title));
+      expect(onMarkRead).toHaveBeenCalledWith('notif-abc');
+    });
+
+    it('navigates to data.url on row click when url is present', async () => {
+      const user = userEvent.setup();
+      const notif = makeNotification({ data: { url: '/trips/t1' } });
+      renderPanel([notif]);
+
+      await user.click(screen.getByText(notif.title));
+      expect(mocks.mockRouterPush).toHaveBeenCalledWith('/trips/t1');
+    });
+
+    it('does not navigate when data.url is absent', async () => {
+      const user = userEvent.setup();
+      const notif = makeNotification({ data: null });
+      renderPanel([notif]);
+
+      await user.click(screen.getByText(notif.title));
+      expect(mocks.mockRouterPush).not.toHaveBeenCalled();
+    });
+
+    it('does not navigate when data.url is not a string', async () => {
+      const user = userEvent.setup();
+      const notif = makeNotification({ data: { tripId: 'some-id' } });
+      renderPanel([notif]);
+
+      await user.click(screen.getByText(notif.title));
+      expect(mocks.mockRouterPush).not.toHaveBeenCalled();
+    });
+
+    it('calls onMarkAllRead when "mark all" button is clicked', async () => {
+      const user = userEvent.setup();
+      const notif = makeNotification({ readAt: null });
+      const { onMarkAllRead } = renderPanel([notif]);
+
+      await user.click(screen.getByText('notifications.markAllRead'));
+      expect(onMarkAllRead).toHaveBeenCalledOnce();
+    });
+
+    it('"mark all" button is disabled when all notifications are already read', () => {
+      const notif = makeNotification({ readAt: '2026-01-01T00:00:00.000Z' });
+      renderPanel([notif]);
+      expect(screen.getByText('notifications.markAllRead')).toBeDisabled();
+    });
+
+    it('"mark all" button is not disabled when there are unread notifications', () => {
+      const notif = makeNotification({ readAt: null });
+      renderPanel([notif]);
+      expect(screen.getByText('notifications.markAllRead')).not.toBeDisabled();
+    });
+  });
+
+  describe('panel header', () => {
+    it('renders the notifications title', () => {
+      renderPanel([]);
+      expect(screen.getByText('notifications.title')).toBeInTheDocument();
+    });
+
+    it('renders the mark all read button', () => {
+      renderPanel([]);
+      expect(screen.getByText('notifications.markAllRead')).toBeInTheDocument();
+    });
+  });
+
+  describe('relative timestamp formatting', () => {
+    it('shows seconds for recent notifications', () => {
+      const notif = makeNotification({ createdAt: new Date(Date.now() - 30_000).toISOString() });
+      renderPanel([notif]);
+      expect(screen.getByText('30s')).toBeInTheDocument();
+    });
+
+    it('shows minutes for notifications older than a minute', () => {
+      const notif = makeNotification({
+        createdAt: new Date(Date.now() - 5 * 60_000).toISOString(),
+      });
+      renderPanel([notif]);
+      expect(screen.getByText('5m')).toBeInTheDocument();
+    });
+
+    it('shows hours for notifications older than an hour', () => {
+      const notif = makeNotification({
+        createdAt: new Date(Date.now() - 3 * 60 * 60_000).toISOString(),
+      });
+      renderPanel([notif]);
+      expect(screen.getByText('3h')).toBeInTheDocument();
+    });
+
+    it('shows days for notifications older than a day', () => {
+      const notif = makeNotification({
+        createdAt: new Date(Date.now() - 2 * 24 * 60 * 60_000).toISOString(),
+      });
+      renderPanel([notif]);
+      expect(screen.getByText('2d')).toBeInTheDocument();
+    });
+  });
+
+  describe('notification types', () => {
+    const allTypes = [
+      NotificationType.TRIP_INVITATION,
+      NotificationType.TRIP_ANNOUNCEMENT,
+      NotificationType.TRIP_KEY_DATE_REMINDER,
+      NotificationType.TRIP_COMPLETED,
+      NotificationType.GROUP_INVITATION,
+      NotificationType.GROUP_JOIN_ACCEPTED,
+      NotificationType.GROUP_ANNOUNCEMENT,
+      NotificationType.PASSPORT_EXPIRING_SOON,
+      NotificationType.PASSPORT_EXPIRED,
+      NotificationType.ACHIEVEMENT_UNLOCKED,
+    ];
+
+    allTypes.forEach((type) => {
+      it(`renders icon for ${type}`, () => {
+        const notif = makeNotification({ type, title: `Notif ${type}` });
+        renderPanel([notif]);
+        expect(screen.getByText(`Notif ${type}`)).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/apps/web/src/components/header/NotificationPanel.tsx
+++ b/apps/web/src/components/header/NotificationPanel.tsx
@@ -126,7 +126,10 @@ export function NotificationPanel({
                 <div className="flex-1 min-w-0">
                   <div className="flex items-start justify-between gap-2">
                     <span
-                      className={`text-sm truncate ${isUnread ? 'font-semibold text-foreground' : 'font-medium text-foreground'}`}
+                      className={cn(
+                        'text-sm truncate text-foreground',
+                        isUnread ? 'font-semibold' : 'font-medium',
+                      )}
                     >
                       {notif.title}
                     </span>

--- a/apps/web/src/components/header/NotificationPanel.tsx
+++ b/apps/web/src/components/header/NotificationPanel.tsx
@@ -2,6 +2,7 @@
 
 import { useRouter } from 'next/navigation';
 import { useTranslation } from 'react-i18next';
+import { cn } from '@/lib/utils';
 import {
   AirplaneIcon,
   BellIcon,
@@ -34,7 +35,7 @@ const TYPE_ICONS: Record<NotificationType, Icon> = {
 
 function formatRelativeTime(isoString: string): string {
   const diffMs = Date.now() - new Date(isoString).getTime();
-  const diffSec = Math.floor(diffMs / 1_000);
+  const diffSec = Math.max(0, Math.floor(diffMs / 1_000));
 
   if (diffSec < 60) return `${diffSec}s`;
   const diffMin = Math.floor(diffSec / 60);
@@ -110,12 +111,12 @@ export function NotificationPanel({
               <button
                 key={notif.id}
                 onClick={() => handleItemClick(notif)}
-                className={[
+                className={cn(
                   'w-full flex items-start gap-3 px-4 py-3 text-left',
                   'hover:bg-muted transition-colors',
                   'focus-visible:outline-none focus-visible:bg-muted',
-                  isUnread ? 'bg-primary/5' : '',
-                ].join(' ')}
+                  isUnread && 'bg-primary/5',
+                )}
               >
                 <TypeIcon
                   className="size-5 shrink-0 mt-0.5 text-muted-foreground"

--- a/apps/web/src/components/header/NotificationPanel.tsx
+++ b/apps/web/src/components/header/NotificationPanel.tsx
@@ -1,0 +1,155 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useTranslation } from 'react-i18next';
+import {
+  AirplaneIcon,
+  BellIcon,
+  CalendarBlankIcon,
+  CheckCircleIcon,
+  MegaphoneIcon,
+  TrophyIcon,
+  UserCheckIcon,
+  UsersThreeIcon,
+  WarningCircleIcon,
+  WarningIcon,
+  type Icon,
+} from '@phosphor-icons/react';
+
+import { NotificationType } from '@chamuco/shared-types';
+import type { NotificationItem } from '@/hooks/useNotifications';
+
+const TYPE_ICONS: Record<NotificationType, Icon> = {
+  [NotificationType.TRIP_INVITATION]: AirplaneIcon,
+  [NotificationType.TRIP_ANNOUNCEMENT]: MegaphoneIcon,
+  [NotificationType.TRIP_KEY_DATE_REMINDER]: CalendarBlankIcon,
+  [NotificationType.TRIP_COMPLETED]: CheckCircleIcon,
+  [NotificationType.GROUP_INVITATION]: UsersThreeIcon,
+  [NotificationType.GROUP_JOIN_ACCEPTED]: UserCheckIcon,
+  [NotificationType.GROUP_ANNOUNCEMENT]: MegaphoneIcon,
+  [NotificationType.PASSPORT_EXPIRING_SOON]: WarningIcon,
+  [NotificationType.PASSPORT_EXPIRED]: WarningCircleIcon,
+  [NotificationType.ACHIEVEMENT_UNLOCKED]: TrophyIcon,
+};
+
+function formatRelativeTime(isoString: string): string {
+  const diffMs = Date.now() - new Date(isoString).getTime();
+  const diffSec = Math.floor(diffMs / 1_000);
+
+  if (diffSec < 60) return `${diffSec}s`;
+  const diffMin = Math.floor(diffSec / 60);
+  if (diffMin < 60) return `${diffMin}m`;
+  const diffHr = Math.floor(diffMin / 60);
+  if (diffHr < 24) return `${diffHr}h`;
+  return `${Math.floor(diffHr / 24)}d`;
+}
+
+export interface NotificationPanelProps {
+  notifications: NotificationItem[];
+  isLoading: boolean;
+  onMarkRead: (id: string) => void;
+  onMarkAllRead: () => void;
+}
+
+export function NotificationPanel({
+  notifications,
+  isLoading,
+  onMarkRead,
+  onMarkAllRead,
+}: NotificationPanelProps) {
+  const { t } = useTranslation();
+  const router = useRouter();
+
+  function handleItemClick(notif: NotificationItem) {
+    onMarkRead(notif.id);
+    const url = typeof notif.data?.url === 'string' ? notif.data.url : null;
+    if (url) {
+      router.push(url);
+    }
+  }
+
+  return (
+    <div className="flex flex-col">
+      {/* Panel header */}
+      <div className="flex items-center justify-between px-4 py-3 border-b border-border">
+        <span className="text-sm font-semibold text-foreground">{t('notifications.title')}</span>
+        <button
+          onClick={onMarkAllRead}
+          className="text-xs text-primary hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded"
+          disabled={notifications.every((n) => n.readAt !== null)}
+        >
+          {t('notifications.markAllRead')}
+        </button>
+      </div>
+
+      {/* Notification list */}
+      <div className="max-h-80 overflow-y-auto">
+        {isLoading && notifications.length === 0 ? (
+          <div className="flex flex-col gap-2 p-4" aria-label="loading">
+            {[1, 2, 3].map((i) => (
+              <div key={i} className="flex gap-3 animate-pulse">
+                <div className="size-8 rounded-full bg-muted shrink-0" />
+                <div className="flex-1 space-y-2">
+                  <div className="h-3 bg-muted rounded w-3/4" />
+                  <div className="h-3 bg-muted rounded w-full" />
+                </div>
+              </div>
+            ))}
+          </div>
+        ) : notifications.length === 0 ? (
+          <div className="flex flex-col items-center justify-center py-10 text-muted-foreground text-sm gap-2">
+            <BellIcon className="size-8" weight="light" aria-hidden="true" />
+            <span>{t('notifications.empty')}</span>
+          </div>
+        ) : (
+          notifications.map((notif) => {
+            const TypeIcon = TYPE_ICONS[notif.type] ?? BellIcon;
+            const isUnread = notif.readAt === null;
+
+            return (
+              <button
+                key={notif.id}
+                onClick={() => handleItemClick(notif)}
+                className={[
+                  'w-full flex items-start gap-3 px-4 py-3 text-left',
+                  'hover:bg-muted transition-colors',
+                  'focus-visible:outline-none focus-visible:bg-muted',
+                  isUnread ? 'bg-primary/5' : '',
+                ].join(' ')}
+              >
+                <TypeIcon
+                  className="size-5 shrink-0 mt-0.5 text-muted-foreground"
+                  weight="regular"
+                  aria-hidden="true"
+                />
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-start justify-between gap-2">
+                    <span
+                      className={`text-sm truncate ${isUnread ? 'font-semibold text-foreground' : 'font-medium text-foreground'}`}
+                    >
+                      {notif.title}
+                    </span>
+                    <span className="text-xs text-muted-foreground shrink-0">
+                      {formatRelativeTime(notif.createdAt)}
+                    </span>
+                  </div>
+                  <div className="flex items-center justify-between gap-2">
+                    <p className="text-xs text-muted-foreground line-clamp-2 mt-0.5">
+                      {notif.body}
+                    </p>
+                    {isUnread && (
+                      <span
+                        className="size-2 rounded-full bg-primary shrink-0 mt-1"
+                        aria-label="unread"
+                      />
+                    )}
+                  </div>
+                </div>
+              </button>
+            );
+          })
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/header/index.ts
+++ b/apps/web/src/components/header/index.ts
@@ -1,3 +1,4 @@
 export { Header } from './Header';
 export { Logo } from './Logo';
+export { NotificationBell } from './NotificationBell';
 export { UserAvatar } from './UserAvatar';

--- a/apps/web/src/hooks/useNotifications.test.ts
+++ b/apps/web/src/hooks/useNotifications.test.ts
@@ -1,0 +1,183 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { NotificationType } from '@chamuco/shared-types';
+import { useNotifications, type NotificationItem } from './useNotifications';
+
+vi.mock('@/services/api-client', () => ({
+  apiClient: { get: vi.fn(), patch: vi.fn() },
+}));
+
+import { apiClient } from '@/services/api-client';
+const mockGet = vi.mocked(apiClient.get);
+const mockPatch = vi.mocked(apiClient.patch);
+
+function makeNotification(overrides: Partial<NotificationItem> = {}): NotificationItem {
+  return {
+    id: 'notif-1',
+    type: NotificationType.TRIP_INVITATION,
+    title: 'New trip invitation',
+    body: 'You have been invited to join Summer Trip 2026.',
+    readAt: null,
+    data: { url: '/trips/trip-1' },
+    createdAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function pageResponse(notifications: NotificationItem[] = [], unreadCount = 0) {
+  return Promise.resolve({
+    data: { data: notifications, nextCursor: null, unreadCount },
+  });
+}
+
+beforeEach(() => {
+  mockGet.mockReset();
+  mockPatch.mockReset();
+  mockGet.mockReturnValue(pageResponse());
+  mockPatch.mockResolvedValue({ data: undefined });
+});
+
+describe('useNotifications', () => {
+  it('fetches notifications on mount', async () => {
+    const notif = makeNotification();
+    mockGet.mockReturnValue(pageResponse([notif], 1));
+
+    const { result } = renderHook(() => useNotifications());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(mockGet).toHaveBeenCalledWith(
+      '/v1/notifications',
+      expect.objectContaining({ params: { limit: 20 } }),
+    );
+    expect(result.current.notifications).toHaveLength(1);
+    expect(result.current.unreadCount).toBe(1);
+  });
+
+  it('starts with isLoading true on mount', () => {
+    mockGet.mockReturnValue(new Promise(() => {}));
+    const { result } = renderHook(() => useNotifications());
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it('polls every 30 seconds', async () => {
+    vi.useFakeTimers();
+    mockGet.mockReturnValue(pageResponse());
+
+    const { unmount } = renderHook(() => useNotifications());
+
+    // flush initial fetch promise
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const callCountAfterMount = mockGet.mock.calls.length;
+    mockGet.mockReturnValue(pageResponse([makeNotification()], 1));
+
+    await act(async () => {
+      vi.advanceTimersByTime(30_000);
+      await Promise.resolve();
+    });
+
+    expect(mockGet.mock.calls.length).toBeGreaterThan(callCountAfterMount);
+
+    unmount();
+    vi.useRealTimers();
+  });
+
+  it('cancels polling on unmount', async () => {
+    vi.useFakeTimers();
+    mockGet.mockReturnValue(pageResponse());
+
+    const { unmount } = renderHook(() => useNotifications());
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const callCountBeforeUnmount = mockGet.mock.calls.length;
+    unmount();
+
+    await act(async () => {
+      vi.advanceTimersByTime(60_000);
+      await Promise.resolve();
+    });
+
+    expect(mockGet.mock.calls.length).toBe(callCountBeforeUnmount);
+    vi.useRealTimers();
+  });
+
+  describe('markRead', () => {
+    it('optimistically marks notification as read', async () => {
+      const notif = makeNotification({ id: 'notif-1', readAt: null });
+      mockGet.mockReturnValue(pageResponse([notif], 1));
+
+      const { result } = renderHook(() => useNotifications());
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      act(() => {
+        result.current.markRead('notif-1');
+      });
+
+      expect(result.current.notifications[0]!.readAt).not.toBeNull();
+      expect(result.current.unreadCount).toBe(0);
+    });
+
+    it('does not decrement unreadCount for already-read notifications', async () => {
+      const notif = makeNotification({ id: 'notif-1', readAt: '2026-01-01T00:00:00.000Z' });
+      mockGet.mockReturnValue(pageResponse([notif], 0));
+
+      const { result } = renderHook(() => useNotifications());
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      act(() => {
+        result.current.markRead('notif-1');
+      });
+
+      expect(result.current.unreadCount).toBe(0);
+    });
+
+    it('calls PATCH /v1/notifications/:id/read', async () => {
+      const notif = makeNotification({ id: 'notif-abc' });
+      mockGet.mockReturnValue(pageResponse([notif], 1));
+
+      const { result } = renderHook(() => useNotifications());
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      act(() => {
+        result.current.markRead('notif-abc');
+      });
+
+      expect(mockPatch).toHaveBeenCalledWith('/v1/notifications/notif-abc/read');
+    });
+  });
+
+  describe('markAllRead', () => {
+    it('optimistically marks all notifications as read', async () => {
+      const notifications = [makeNotification({ id: 'n1' }), makeNotification({ id: 'n2' })];
+      mockGet.mockReturnValue(pageResponse(notifications, 2));
+
+      const { result } = renderHook(() => useNotifications());
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      act(() => {
+        result.current.markAllRead();
+      });
+
+      expect(result.current.notifications.every((n) => n.readAt !== null)).toBe(true);
+      expect(result.current.unreadCount).toBe(0);
+    });
+
+    it('calls PATCH /v1/notifications/read-all', async () => {
+      mockGet.mockReturnValue(pageResponse([makeNotification()], 1));
+
+      const { result } = renderHook(() => useNotifications());
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      act(() => {
+        result.current.markAllRead();
+      });
+
+      expect(mockPatch).toHaveBeenCalledWith('/v1/notifications/read-all');
+    });
+  });
+});

--- a/apps/web/src/hooks/useNotifications.test.ts
+++ b/apps/web/src/hooks/useNotifications.test.ts
@@ -122,9 +122,11 @@ describe('useNotifications', () => {
       expect(result.current.unreadCount).toBe(0);
     });
 
-    it('does not decrement unreadCount for already-read notifications', async () => {
-      const notif = makeNotification({ id: 'notif-1', readAt: '2026-01-01T00:00:00.000Z' });
-      mockGet.mockReturnValue(pageResponse([notif], 0));
+    it('does not decrement unreadCount when notification is already read', async () => {
+      const readNotif = makeNotification({ id: 'notif-1', readAt: '2026-01-01T00:00:00.000Z' });
+      const unreadNotif = makeNotification({ id: 'notif-2', readAt: null });
+      // unreadCount=1 (only notif-2 is unread); marking the already-read notif-1 must leave it at 1
+      mockGet.mockReturnValue(pageResponse([readNotif, unreadNotif], 1));
 
       const { result } = renderHook(() => useNotifications());
       await waitFor(() => expect(result.current.isLoading).toBe(false));
@@ -133,7 +135,7 @@ describe('useNotifications', () => {
         result.current.markRead('notif-1');
       });
 
-      expect(result.current.unreadCount).toBe(0);
+      expect(result.current.unreadCount).toBe(1);
     });
 
     it('calls PATCH /v1/notifications/:id/read', async () => {

--- a/apps/web/src/hooks/useNotifications.test.ts
+++ b/apps/web/src/hooks/useNotifications.test.ts
@@ -25,7 +25,7 @@ function makeNotification(overrides: Partial<NotificationItem> = {}): Notificati
 
 function pageResponse(notifications: NotificationItem[] = [], unreadCount = 0) {
   return Promise.resolve({
-    data: { data: notifications, nextCursor: null, unreadCount },
+    data: { data: notifications, unreadCount },
   });
 }
 

--- a/apps/web/src/hooks/useNotifications.ts
+++ b/apps/web/src/hooks/useNotifications.ts
@@ -58,19 +58,22 @@ export function useNotifications() {
     };
   }, [fetchNotifications]);
 
-  const markRead = useCallback((id: string) => {
-    setNotifications((prev) => {
-      const wasUnread = prev.find((n) => n.id === id)?.readAt === null;
-      if (wasUnread) setUnreadCount((c) => Math.max(0, c - 1));
-      return prev.map((n) =>
-        n.id === id && n.readAt === null ? { ...n, readAt: new Date().toISOString() } : n,
+  const markRead = useCallback(
+    (id: string) => {
+      const wasUnread = notifications.find((n) => n.id === id)?.readAt === null;
+      setNotifications((prev) =>
+        prev.map((n) =>
+          n.id === id && n.readAt === null ? { ...n, readAt: new Date().toISOString() } : n,
+        ),
       );
-    });
+      if (wasUnread) setUnreadCount((c) => Math.max(0, c - 1));
 
-    apiClient.patch(`/v1/notifications/${id}/read`).catch(() => {
-      // Badge re-syncs on next poll
-    });
-  }, []);
+      apiClient.patch(`/v1/notifications/${id}/read`).catch(() => {
+        // Badge re-syncs on next poll
+      });
+    },
+    [notifications],
+  );
 
   const markAllRead = useCallback(() => {
     setNotifications((prev) =>

--- a/apps/web/src/hooks/useNotifications.ts
+++ b/apps/web/src/hooks/useNotifications.ts
@@ -16,7 +16,6 @@ export interface NotificationItem {
 
 interface NotificationsPage {
   data: NotificationItem[];
-  nextCursor: string | null;
   unreadCount: number;
 }
 
@@ -60,12 +59,13 @@ export function useNotifications() {
   }, [fetchNotifications]);
 
   const markRead = useCallback((id: string) => {
-    setNotifications((prev) =>
-      prev.map((n) =>
+    setNotifications((prev) => {
+      const wasUnread = prev.find((n) => n.id === id)?.readAt === null;
+      if (wasUnread) setUnreadCount((c) => Math.max(0, c - 1));
+      return prev.map((n) =>
         n.id === id && n.readAt === null ? { ...n, readAt: new Date().toISOString() } : n,
-      ),
-    );
-    setUnreadCount((prev) => Math.max(0, prev - 1));
+      );
+    });
 
     apiClient.patch(`/v1/notifications/${id}/read`).catch(() => {
       // Badge re-syncs on next poll

--- a/apps/web/src/hooks/useNotifications.ts
+++ b/apps/web/src/hooks/useNotifications.ts
@@ -1,0 +1,87 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import axios from 'axios';
+
+import { NotificationType } from '@chamuco/shared-types';
+import { apiClient } from '@/services/api-client';
+
+export interface NotificationItem {
+  id: string;
+  type: NotificationType;
+  title: string;
+  body: string;
+  readAt: string | null;
+  data: Record<string, unknown> | null;
+  createdAt: string;
+}
+
+interface NotificationsPage {
+  data: NotificationItem[];
+  nextCursor: string | null;
+  unreadCount: number;
+}
+
+const POLL_INTERVAL_MS = 30_000;
+
+export function useNotifications() {
+  const [notifications, setNotifications] = useState<NotificationItem[]>([]);
+  const [unreadCount, setUnreadCount] = useState(0);
+  const [isLoading, setIsLoading] = useState(false);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const fetchNotifications = useCallback(async () => {
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    try {
+      const { data } = await apiClient.get<NotificationsPage>('/v1/notifications', {
+        params: { limit: 20 },
+        signal: controller.signal,
+      });
+      setNotifications(data.data);
+      setUnreadCount(data.unreadCount);
+    } catch (err: unknown) {
+      if (!axios.isCancel(err)) {
+        // Silently ignore — stale data is better than an error state for a notification feed
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    setIsLoading(true);
+    fetchNotifications().finally(() => setIsLoading(false));
+
+    const intervalId = setInterval(fetchNotifications, POLL_INTERVAL_MS);
+
+    return () => {
+      clearInterval(intervalId);
+      abortRef.current?.abort();
+    };
+  }, [fetchNotifications]);
+
+  const markRead = useCallback((id: string) => {
+    setNotifications((prev) =>
+      prev.map((n) =>
+        n.id === id && n.readAt === null ? { ...n, readAt: new Date().toISOString() } : n,
+      ),
+    );
+    setUnreadCount((prev) => Math.max(0, prev - 1));
+
+    apiClient.patch(`/v1/notifications/${id}/read`).catch(() => {
+      // Badge re-syncs on next poll
+    });
+  }, []);
+
+  const markAllRead = useCallback(() => {
+    setNotifications((prev) =>
+      prev.map((n) => (n.readAt === null ? { ...n, readAt: new Date().toISOString() } : n)),
+    );
+    setUnreadCount(0);
+
+    apiClient.patch('/v1/notifications/read-all').catch(() => {
+      // Badge re-syncs on next poll
+    });
+  }, []);
+
+  return { notifications, unreadCount, isLoading, markRead, markAllRead };
+}

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -85,6 +85,13 @@
       "instruction": "Tap <shareIcon /> then \"Add to Home Screen\"",
       "install": "Install",
       "dismiss": "Not now"
+    },
+    "notifications": {
+      "openLabel": "Open notifications",
+      "title": "Notifications",
+      "markAllRead": "Mark all as read",
+      "empty": "No notifications yet",
+      "unreadBadge": "{{count}} unread notifications"
     }
   },
   "auth": {

--- a/apps/web/src/locales/es.json
+++ b/apps/web/src/locales/es.json
@@ -85,6 +85,13 @@
       "instruction": "Toca <shareIcon /> y luego \"Añadir a la pantalla de inicio\"",
       "install": "Instalar",
       "dismiss": "Ahora no"
+    },
+    "notifications": {
+      "openLabel": "Abrir notificaciones",
+      "title": "Notificaciones",
+      "markAllRead": "Marcar todo como leído",
+      "empty": "Aún no hay notificaciones",
+      "unreadBadge": "{{count}} notificaciones sin leer"
     }
   },
   "auth": {


### PR DESCRIPTION
## Summary

Part of the notifications epic (#8). Implements the in-app notification feed surfaced in the top navigation bar. Users can now see a live unread badge on the bell icon, open a popover panel listing their 20 most recent notifications, mark individual or all notifications as read, and navigate directly to the relevant entity via deep-link.

## Changes

**`useNotifications` hook** — polls `GET /v1/notifications?limit=20` every 30 s while mounted. Applies optimistic updates for `markRead` and `markAllRead` so the badge responds immediately; actual API calls fire in the background and badge re-syncs on the next poll if they fail.

**`NotificationPanel`** — presentational component receiving props from the bell. Renders a scrollable list (max 280 px) with a type-specific icon per `NotificationType`, truncated body, relative timestamp (s / m / h / d), and an unread indicator dot. Shows a skeleton loading state on first load and an empty state when the list is empty. "Mark all as read" button is disabled once all notifications are read.

**`NotificationBell`** — thin wrapper using the existing `Popover` / `PopoverContent` primitives. Renders the bell trigger with an absolute-positioned red badge capped at `99+`. Wires `useNotifications` into `NotificationPanel`.

**Header** — `<NotificationBell />` inserted between `UserAvatar` and `LanguageToggle` in the right-side controls group.

**i18n** — five keys added under `common.notifications.*` in both `en.json` and `es.json`.

## Testing

- `useNotifications`: mount fetch, 30 s interval (fake timers), unmount cancels interval, optimistic `markRead` / `markAllRead`, PATCH calls
- `NotificationPanel`: empty state, loading skeleton, unread dot present/absent, mark-all disabled when all read, click calls `onMarkRead`, navigation to `data.url` (present / absent / non-string), all 10 `NotificationType` icons render, all 4 `formatRelativeTime` branches (s / m / h / d)
- `NotificationBell`: badge hidden at 0, shown with count, capped at `99+`, exact `99` not capped, panel rendered in popover content
- `pnpm validate` passes — 1335 tests, >90% coverage on all metrics

## Notes

Navigation on row click uses `data?.url` (string guard). Rows where `data` is null or the `url` field is not a string mark as read but do not navigate — consistent with the API contract where `data` shape varies by `NotificationType`.

Closes #308