### PR TITLE
feat(notifications): wire notify() calls for GROUP and PASSPORT events

### DIFF
--- a/apps/api/src/modules/group-members/group-members.module.ts
+++ b/apps/api/src/modules/group-members/group-members.module.ts
@@ -1,9 +1,11 @@
 import { Module } from '@nestjs/common';
+import { NotificationsModule } from '@/modules/notifications/notifications.module';
 import { GroupMembersController } from './group-members.controller';
 import { GroupInvitationsController } from './group-invitations.controller';
 import { GroupMembersService } from './group-members.service';
 
 @Module({
+  imports: [NotificationsModule],
   controllers: [GroupInvitationsController, GroupMembersController],
   providers: [GroupMembersService],
   exports: [GroupMembersService],

--- a/apps/api/src/modules/group-members/group-members.service.spec.ts
+++ b/apps/api/src/modules/group-members/group-members.service.spec.ts
@@ -272,6 +272,20 @@ describe('GroupMembersService', () => {
       );
     });
 
+    it('logs error and resolves when notify() rejects', async () => {
+      mockGroupMembersFindFirst
+        .mockResolvedValueOnce(ownerMembership)
+        .mockResolvedValueOnce(requestMembership);
+      mockNotificationsNotify.mockRejectedValueOnce(new Error('DB blip'));
+      const logSpy = jest.spyOn(service['logger'], 'error').mockImplementation(() => undefined);
+
+      await expect(service.acceptJoinRequest(GROUP_ID, USER_ID, ADMIN_ID)).resolves.toBeUndefined();
+      expect(logSpy).toHaveBeenCalledWith(
+        'Failed to send GROUP_JOIN_ACCEPTED notification',
+        expect.any(Error),
+      );
+    });
+
     it('throws ForbiddenException when caller is not an admin', async () => {
       // assertGroupAdmin: group found, but no admin membership
       mockGroupMembersFindFirst.mockResolvedValueOnce(undefined);
@@ -414,6 +428,7 @@ describe('GroupMembersService', () => {
       expect(result).toEqual({
         results: [{ username: 'target_user', status: 'ALREADY_MEMBER' }],
       });
+      expect(mockNotificationsNotifyMany).not.toHaveBeenCalled();
     });
 
     it('returns ALREADY_INVITED when target already has INVITED status', async () => {
@@ -426,6 +441,7 @@ describe('GroupMembersService', () => {
       expect(result).toEqual({
         results: [{ username: 'target_user', status: 'ALREADY_INVITED' }],
       });
+      expect(mockNotificationsNotifyMany).not.toHaveBeenCalled();
     });
 
     it('returns HAS_PENDING_REQUEST when target has a pending join request', async () => {
@@ -438,6 +454,7 @@ describe('GroupMembersService', () => {
       expect(result).toEqual({
         results: [{ username: 'target_user', status: 'HAS_PENDING_REQUEST' }],
       });
+      expect(mockNotificationsNotifyMany).not.toHaveBeenCalled();
     });
 
     it('re-invites after REJECTED, resets role to MEMBER, returns INVITED', async () => {
@@ -484,6 +501,20 @@ describe('GroupMembersService', () => {
         NotificationType.GROUP_INVITATION,
         {},
         [NotificationChannel.PUSH],
+      );
+    });
+
+    it('logs error and resolves when notifyMany() rejects', async () => {
+      mockGroupMembersFindFirst.mockResolvedValueOnce(ownerMembership);
+      mockUsersFindMany.mockResolvedValueOnce([mockTargetUser]);
+      mockGroupMembersFindMany.mockResolvedValueOnce([]);
+      mockNotificationsNotifyMany.mockRejectedValueOnce(new Error('DB blip'));
+      const logSpy = jest.spyOn(service['logger'], 'error').mockImplementation(() => undefined);
+
+      await expect(service.sendInvitations(GROUP_ID, dto, ADMIN_ID)).resolves.toBeDefined();
+      expect(logSpy).toHaveBeenCalledWith(
+        'Failed to send GROUP_INVITATION notifications',
+        expect.any(Error),
       );
     });
   });

--- a/apps/api/src/modules/group-members/group-members.service.spec.ts
+++ b/apps/api/src/modules/group-members/group-members.service.spec.ts
@@ -5,9 +5,12 @@ import {
   GroupMemberTier,
   GroupRole,
   GroupVisibility,
+  NotificationChannel,
+  NotificationType,
 } from '@chamuco/shared-types';
 import { DRIZZLE_CLIENT } from '@/database/drizzle.provider';
 import { AssetResolverService } from '@/modules/assets/asset-resolver.service';
+import { NotificationsService } from '@/modules/notifications/notifications.service';
 import { GroupMembersService } from './group-members.service';
 import type { CreateInvitationDto } from './dto/create-invitation.dto';
 import type { UpdateMemberRoleDto } from './dto/update-member-role.dto';
@@ -98,6 +101,8 @@ describe('GroupMembersService', () => {
   let mockSelect: jest.Mock;
   let mockTransaction: jest.Mock;
   let mockAssetResolverResolve: jest.Mock;
+  let mockNotificationsNotify: jest.Mock;
+  let mockNotificationsNotifyMany: jest.Mock;
 
   beforeEach(async () => {
     mockGroupsFindFirst = jest.fn().mockResolvedValue(mockPublicGroup);
@@ -140,6 +145,8 @@ describe('GroupMembersService', () => {
     );
 
     mockAssetResolverResolve = jest.fn().mockResolvedValue(null);
+    mockNotificationsNotify = jest.fn().mockResolvedValue(undefined);
+    mockNotificationsNotifyMany = jest.fn().mockResolvedValue(undefined);
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -167,6 +174,10 @@ describe('GroupMembersService', () => {
         {
           provide: AssetResolverService,
           useValue: { resolve: mockAssetResolverResolve },
+        },
+        {
+          provide: NotificationsService,
+          useValue: { notify: mockNotificationsNotify, notifyMany: mockNotificationsNotifyMany },
         },
       ],
     }).compile();
@@ -253,6 +264,12 @@ describe('GroupMembersService', () => {
         expect.objectContaining({ status: GroupMemberStatus.ACTIVE }),
       );
       expect(mockInsertOnConflict).toHaveBeenCalledTimes(1);
+      expect(mockNotificationsNotify).toHaveBeenCalledWith(
+        USER_ID,
+        NotificationType.GROUP_JOIN_ACCEPTED,
+        {},
+        [NotificationChannel.PUSH],
+      );
     });
 
     it('throws ForbiddenException when caller is not an admin', async () => {
@@ -359,6 +376,12 @@ describe('GroupMembersService', () => {
         expect.objectContaining({ status: GroupMemberStatus.INVITED }),
       );
       expect(result).toEqual({ results: [{ username: 'target_user', status: 'INVITED' }] });
+      expect(mockNotificationsNotifyMany).toHaveBeenCalledWith(
+        [TARGET_ID],
+        NotificationType.GROUP_INVITATION,
+        {},
+        [NotificationChannel.PUSH],
+      );
     });
 
     it('throws ForbiddenException when caller is not an admin', async () => {
@@ -378,6 +401,7 @@ describe('GroupMembersService', () => {
 
       expect(result).toEqual({ results: [{ username: 'target_user', status: 'NOT_FOUND' }] });
       expect(mockInsert).not.toHaveBeenCalled();
+      expect(mockNotificationsNotifyMany).not.toHaveBeenCalled();
     });
 
     it('returns ALREADY_MEMBER when target is already ACTIVE', async () => {
@@ -455,6 +479,12 @@ describe('GroupMembersService', () => {
           { username: 'user_c', status: 'INVITED' },
         ],
       });
+      expect(mockNotificationsNotifyMany).toHaveBeenCalledWith(
+        ['id-a', 'id-c'],
+        NotificationType.GROUP_INVITATION,
+        {},
+        [NotificationChannel.PUSH],
+      );
     });
   });
 

--- a/apps/api/src/modules/group-members/group-members.service.spec.ts
+++ b/apps/api/src/modules/group-members/group-members.service.spec.ts
@@ -472,6 +472,12 @@ describe('GroupMembersService', () => {
       );
       expect(mockInsert).not.toHaveBeenCalled();
       expect(result).toEqual({ results: [{ username: 'target_user', status: 'INVITED' }] });
+      expect(mockNotificationsNotifyMany).toHaveBeenCalledWith(
+        [TARGET_ID],
+        NotificationType.GROUP_INVITATION,
+        {},
+        [NotificationChannel.PUSH],
+      );
     });
 
     it('handles multiple usernames and returns per-user results', async () => {

--- a/apps/api/src/modules/group-members/group-members.service.ts
+++ b/apps/api/src/modules/group-members/group-members.service.ts
@@ -3,6 +3,7 @@ import {
   ForbiddenException,
   Inject,
   Injectable,
+  Logger,
   NotFoundException,
 } from '@nestjs/common';
 import { and, count, eq, inArray, isNull } from 'drizzle-orm';
@@ -37,6 +38,8 @@ const ADMIN_ROLES = [GroupRole.OWNER, GroupRole.ADMIN] as const;
 
 @Injectable()
 export class GroupMembersService {
+  private readonly logger = new Logger(GroupMembersService.name);
+
   constructor(
     @Inject(DRIZZLE_CLIENT) private readonly db: DrizzleClient,
     private readonly assetResolver: AssetResolverService,
@@ -110,9 +113,11 @@ export class GroupMembersService {
         .onConflictDoNothing();
     });
 
-    await this.notifications.notify(targetUserId, NotificationType.GROUP_JOIN_ACCEPTED, {}, [
-      NotificationChannel.PUSH,
-    ]);
+    await this.notifications
+      .notify(targetUserId, NotificationType.GROUP_JOIN_ACCEPTED, {}, [NotificationChannel.PUSH])
+      .catch((err: unknown) => {
+        this.logger.error('Failed to send GROUP_JOIN_ACCEPTED notification', err);
+      });
   }
 
   async rejectJoinRequest(
@@ -226,9 +231,13 @@ export class GroupMembersService {
     }
 
     if (invitedUserIds.length > 0) {
-      await this.notifications.notifyMany(invitedUserIds, NotificationType.GROUP_INVITATION, {}, [
-        NotificationChannel.PUSH,
-      ]);
+      await this.notifications
+        .notifyMany(invitedUserIds, NotificationType.GROUP_INVITATION, {}, [
+          NotificationChannel.PUSH,
+        ])
+        .catch((err: unknown) => {
+          this.logger.error('Failed to send GROUP_INVITATION notifications', err);
+        });
     }
 
     return { results };

--- a/apps/api/src/modules/group-members/group-members.service.ts
+++ b/apps/api/src/modules/group-members/group-members.service.ts
@@ -6,12 +6,19 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 import { and, count, eq, inArray, isNull } from 'drizzle-orm';
-import { GroupMemberStatus, GroupMemberTier, GroupRole } from '@chamuco/shared-types';
+import {
+  GroupMemberStatus,
+  GroupMemberTier,
+  GroupRole,
+  NotificationChannel,
+  NotificationType,
+} from '@chamuco/shared-types';
 import { assetRowToAsset } from '@/modules/assets/asset.utils';
 import { DRIZZLE_CLIENT, DrizzleClient } from '@/database/drizzle.provider';
 import { users } from '@/modules/users/schema/users.schema';
 import { assets } from '@/modules/assets/schema/assets.schema';
 import { AssetResolverService } from '@/modules/assets/asset-resolver.service';
+import { NotificationsService } from '@/modules/notifications/notifications.service';
 import { groups } from '@/modules/groups/schema/groups.schema';
 import { groupMembers } from '@/modules/groups/schema/group-members.schema';
 import { groupMemberStats } from '@/modules/groups/schema/group-member-stats.schema';
@@ -33,6 +40,7 @@ export class GroupMembersService {
   constructor(
     @Inject(DRIZZLE_CLIENT) private readonly db: DrizzleClient,
     private readonly assetResolver: AssetResolverService,
+    private readonly notifications: NotificationsService,
   ) {}
 
   // ─── Join request ────────────────────────────────────────────────────────────
@@ -101,6 +109,10 @@ export class GroupMembersService {
         .values({ groupId, userId: targetUserId, joinedAt: now })
         .onConflictDoNothing();
     });
+
+    await this.notifications.notify(targetUserId, NotificationType.GROUP_JOIN_ACCEPTED, {}, [
+      NotificationChannel.PUSH,
+    ]);
   }
 
   async rejectJoinRequest(
@@ -162,6 +174,7 @@ export class GroupMembersService {
     const membershipByUserId = new Map(existingMemberships.map((m) => [m.userId, m]));
 
     const results: InvitationResultDto[] = [];
+    const invitedUserIds: string[] = [];
 
     for (const username of dto.usernames) {
       const targetUser = userByUsername.get(username);
@@ -208,7 +221,14 @@ export class GroupMembersService {
         });
       }
 
+      invitedUserIds.push(targetUser.id);
       results.push({ username, status: 'INVITED' });
+    }
+
+    if (invitedUserIds.length > 0) {
+      await this.notifications.notifyMany(invitedUserIds, NotificationType.GROUP_INVITATION, {}, [
+        NotificationChannel.PUSH,
+      ]);
     }
 
     return { results };

--- a/apps/api/src/modules/jobs/passport-status.job.spec.ts
+++ b/apps/api/src/modules/jobs/passport-status.job.spec.ts
@@ -88,6 +88,20 @@ describe('PassportStatusJob', () => {
       expect(logSpy).toHaveBeenCalledWith('Passport status refresh failed', expect.any(Error));
     });
 
+    it('logs error and resolves when notify() rejects', async () => {
+      db.execute.mockResolvedValue([
+        { user_id: 'user-1', country_code: 'MX', passport_status: PassportStatus.EXPIRING_SOON },
+      ]);
+      (notificationsService.notify as jest.Mock).mockRejectedValueOnce(new Error('DB blip'));
+      const logSpy = jest.spyOn(job['logger'], 'error').mockImplementation(() => undefined);
+
+      await expect(job.runPassportStatusRefresh()).resolves.toBeUndefined();
+      expect(logSpy).toHaveBeenCalledWith(
+        'Failed to send passport status notification',
+        expect.any(Error),
+      );
+    });
+
     it('sends notifications in parallel for multiple changed rows', async () => {
       db.execute.mockResolvedValue([
         { user_id: 'user-1', country_code: 'MX', passport_status: PassportStatus.EXPIRING_SOON },

--- a/apps/api/src/modules/jobs/passport-status.job.spec.ts
+++ b/apps/api/src/modules/jobs/passport-status.job.spec.ts
@@ -1,5 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { PassportStatus } from '@chamuco/shared-types';
+import { NotificationChannel, NotificationType, PassportStatus } from '@chamuco/shared-types';
 import { DRIZZLE_CLIENT } from '@/database/drizzle.provider';
 import { NotificationsService } from '@/modules/notifications/notifications.service';
 import { PassportStatusJob } from './passport-status.job';
@@ -18,7 +18,7 @@ describe('PassportStatusJob', () => {
         { provide: DRIZZLE_CLIENT, useValue: db },
         {
           provide: NotificationsService,
-          useValue: { sendPassportStatusNotification: jest.fn().mockResolvedValue(undefined) },
+          useValue: { notify: jest.fn().mockResolvedValue(undefined) },
         },
       ],
     }).compile();
@@ -40,10 +40,11 @@ describe('PassportStatusJob', () => {
 
       await job.runPassportStatusRefresh();
 
-      expect(notificationsService.sendPassportStatusNotification).toHaveBeenCalledWith(
+      expect(notificationsService.notify).toHaveBeenCalledWith(
         'user-1',
-        'MX',
-        PassportStatus.EXPIRING_SOON,
+        NotificationType.PASSPORT_EXPIRING_SOON,
+        { countryCode: 'MX' },
+        [NotificationChannel.PUSH],
       );
     });
 
@@ -54,10 +55,11 @@ describe('PassportStatusJob', () => {
 
       await job.runPassportStatusRefresh();
 
-      expect(notificationsService.sendPassportStatusNotification).toHaveBeenCalledWith(
+      expect(notificationsService.notify).toHaveBeenCalledWith(
         'user-2',
-        'US',
-        PassportStatus.EXPIRED,
+        NotificationType.PASSPORT_EXPIRED,
+        { countryCode: 'US' },
+        [NotificationChannel.PUSH],
       );
     });
 
@@ -68,14 +70,14 @@ describe('PassportStatusJob', () => {
 
       await job.runPassportStatusRefresh();
 
-      expect(notificationsService.sendPassportStatusNotification).not.toHaveBeenCalled();
+      expect(notificationsService.notify).not.toHaveBeenCalled();
     });
 
     it('handles empty result without error', async () => {
       db.execute.mockResolvedValue([]);
 
       await expect(job.runPassportStatusRefresh()).resolves.toBeUndefined();
-      expect(notificationsService.sendPassportStatusNotification).not.toHaveBeenCalled();
+      expect(notificationsService.notify).not.toHaveBeenCalled();
     });
 
     it('logs error and resolves when db.execute throws', async () => {
@@ -95,16 +97,18 @@ describe('PassportStatusJob', () => {
 
       await job.runPassportStatusRefresh();
 
-      expect(notificationsService.sendPassportStatusNotification).toHaveBeenCalledTimes(2);
-      expect(notificationsService.sendPassportStatusNotification).toHaveBeenCalledWith(
+      expect(notificationsService.notify).toHaveBeenCalledTimes(2);
+      expect(notificationsService.notify).toHaveBeenCalledWith(
         'user-1',
-        'MX',
-        PassportStatus.EXPIRING_SOON,
+        NotificationType.PASSPORT_EXPIRING_SOON,
+        { countryCode: 'MX' },
+        [NotificationChannel.PUSH],
       );
-      expect(notificationsService.sendPassportStatusNotification).toHaveBeenCalledWith(
+      expect(notificationsService.notify).toHaveBeenCalledWith(
         'user-2',
-        'US',
-        PassportStatus.EXPIRED,
+        NotificationType.PASSPORT_EXPIRED,
+        { countryCode: 'US' },
+        [NotificationChannel.PUSH],
       );
     });
   });

--- a/apps/api/src/modules/jobs/passport-status.job.ts
+++ b/apps/api/src/modules/jobs/passport-status.job.ts
@@ -43,7 +43,7 @@ export class PassportStatusJob {
       RETURNING user_id, country_code, passport_status
     `);
 
-    await Promise.allSettled(
+    const results = await Promise.allSettled(
       rows
         .filter(
           (r) =>
@@ -61,5 +61,11 @@ export class PassportStatusJob {
           ),
         ),
     );
+
+    for (const result of results) {
+      if (result.status === 'rejected') {
+        this.logger.error('Failed to send passport status notification', result.reason);
+      }
+    }
   }
 }

--- a/apps/api/src/modules/jobs/passport-status.job.ts
+++ b/apps/api/src/modules/jobs/passport-status.job.ts
@@ -1,7 +1,7 @@
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import { Cron, CronExpression } from '@nestjs/schedule';
 import { sql } from 'drizzle-orm';
-import { PassportStatus } from '@chamuco/shared-types';
+import { NotificationChannel, NotificationType, PassportStatus } from '@chamuco/shared-types';
 import { DRIZZLE_CLIENT, DrizzleClient } from '@/database/drizzle.provider';
 import { NotificationsService } from '@/modules/notifications/notifications.service';
 
@@ -51,10 +51,13 @@ export class PassportStatusJob {
             r.passport_status === PassportStatus.EXPIRED,
         )
         .map((r) =>
-          this.notificationsService.sendPassportStatusNotification(
+          this.notificationsService.notify(
             r.user_id,
-            r.country_code,
-            r.passport_status as PassportStatus.EXPIRING_SOON | PassportStatus.EXPIRED,
+            r.passport_status === PassportStatus.EXPIRING_SOON
+              ? NotificationType.PASSPORT_EXPIRING_SOON
+              : NotificationType.PASSPORT_EXPIRED,
+            { countryCode: r.country_code },
+            [NotificationChannel.PUSH],
           ),
         ),
     );

--- a/apps/api/src/modules/notifications/notifications.service.spec.ts
+++ b/apps/api/src/modules/notifications/notifications.service.spec.ts
@@ -1,11 +1,6 @@
 import { BadRequestException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import {
-  DeliveryStatus,
-  NotificationChannel,
-  NotificationType,
-  PassportStatus,
-} from '@chamuco/shared-types';
+import { DeliveryStatus, NotificationChannel, NotificationType } from '@chamuco/shared-types';
 import { DRIZZLE_CLIENT } from '@/database/drizzle.provider';
 import { I18nService } from '@/i18n/i18n.service';
 import { NotificationsService } from './notifications.service';
@@ -376,40 +371,6 @@ describe('NotificationsService', () => {
 
       await expect(
         service.deleteToken('user-1', { token: 'nonexistent' }),
-      ).resolves.toBeUndefined();
-    });
-  });
-
-  describe('sendPassportStatusNotification()', () => {
-    it('calls notify() with PASSPORT_EXPIRING_SOON type', async () => {
-      db.insert.mockReturnValue(makeInsert([FAKE_NOTIFICATION]));
-
-      await service.sendPassportStatusNotification('user-1', 'MX', PassportStatus.EXPIRING_SOON);
-
-      const valuesFn = db.insert.mock.results[0]!.value.values as jest.Mock;
-      const insertedRow = valuesFn.mock.calls[0]![0] as {
-        type: string;
-        data: Record<string, unknown>;
-      };
-      expect(insertedRow.type).toBe(NotificationType.PASSPORT_EXPIRING_SOON);
-      expect(insertedRow.data).toMatchObject({ countryCode: 'MX' });
-    });
-
-    it('calls notify() with PASSPORT_EXPIRED type', async () => {
-      db.insert.mockReturnValue(makeInsert([FAKE_NOTIFICATION]));
-
-      await service.sendPassportStatusNotification('user-1', 'US', PassportStatus.EXPIRED);
-
-      const valuesFn = db.insert.mock.results[0]!.value.values as jest.Mock;
-      const insertedRow = valuesFn.mock.calls[0]![0] as { type: string };
-      expect(insertedRow.type).toBe(NotificationType.PASSPORT_EXPIRED);
-    });
-
-    it('resolves without throwing', async () => {
-      db.insert.mockReturnValue(makeInsert([FAKE_NOTIFICATION]));
-
-      await expect(
-        service.sendPassportStatusNotification('user-1', 'MX', PassportStatus.EXPIRING_SOON),
       ).resolves.toBeUndefined();
     });
   });

--- a/apps/api/src/modules/notifications/notifications.service.ts
+++ b/apps/api/src/modules/notifications/notifications.service.ts
@@ -1,11 +1,6 @@
 import { BadRequestException, Inject, Injectable, Logger } from '@nestjs/common';
 import { and, count, desc, eq, isNull, lt, sql } from 'drizzle-orm';
-import {
-  DeliveryStatus,
-  NotificationChannel,
-  NotificationType,
-  PassportStatus,
-} from '@chamuco/shared-types';
+import { DeliveryStatus, NotificationChannel, NotificationType } from '@chamuco/shared-types';
 import { DRIZZLE_CLIENT, DrizzleClient } from '@/database/drizzle.provider';
 import { I18nService, SupportedLanguage } from '@/i18n/i18n.service';
 import { notifications } from '@/modules/notifications/schema/notifications.schema';
@@ -149,19 +144,6 @@ export class NotificationsService {
     await this.db
       .delete(userFcmTokens)
       .where(and(eq(userFcmTokens.userId, userId), eq(userFcmTokens.token, dto.token)));
-  }
-
-  async sendPassportStatusNotification(
-    userId: string,
-    countryCode: string,
-    status: PassportStatus.EXPIRING_SOON | PassportStatus.EXPIRED,
-  ): Promise<void> {
-    const type =
-      status === PassportStatus.EXPIRING_SOON
-        ? NotificationType.PASSPORT_EXPIRING_SOON
-        : NotificationType.PASSPORT_EXPIRED;
-
-    await this.notify(userId, type, { countryCode }, []);
   }
 
   private renderContent(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,24 +50,14 @@ overrides:
   esbuild@<=0.24.2: '>=0.25.0'
   ajv@>=7.0.0-alpha.0 <8.18.0: '>=8.18.0'
   file-type@>=13.0.0 <21.3.1: '>=21.3.1'
-  minimist@<0.2.4: '>=0.2.4'
   tough-cookie@<4.1.3: '>=4.1.3'
   form-data@<2.5.4: '>=2.5.4'
   qs@<6.14.1: '>=6.14.1'
-  '@tootallnate/once@<3.0.1': '>=3.0.1'
-  '@nestjs/core@<=11.1.17': '>=11.1.18'
-  vite@>=6.0.0 <=6.4.1: '>=6.4.2'
-  '@hono/node-server@<1.19.13': '>=1.19.13'
   axios@<1.15.0: '>=1.15.0'
-  next@>=16.0.0-beta.0 <16.2.3: '>=16.2.3'
   protobufjs@<7.5.5: '>=7.5.5'
   fast-xml-parser@<5.7.0: '>=5.7.0'
   uuid@<14.0.0: '>=14.0.0'
   postcss@<8.5.10: '>=8.5.10'
-  ip-address@<=10.1.0: '>=10.1.1'
-  hono@<4.12.16: '>=4.12.16'
-  fast-xml-builder@<=1.1.6: '>=1.1.7'
-  fast-uri@<=3.1.1: '>=3.1.2'
 
 importers:
 
@@ -83,7 +73,7 @@ importers:
         specifier: 'catalog:'
         version: 8.60.0(@typescript-eslint/parser@8.60.0(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3)
       '@typescript-eslint/parser':
-        specifier: 8.60.0
+        specifier: 'catalog:'
         version: 8.60.0(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3)
       eslint:
         specifier: 'catalog:'
@@ -1422,11 +1412,11 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
-  '@hono/node-server@2.0.2':
-    resolution: {integrity: sha512-tXlTi1h/4V7sDe7i97IVP+9re9ZU7wXZZggnR5ucCRclf1+AX6YhGStrR5w8bLj+3Mlyl0pKfBh9gqTqqnGKfQ==}
-    engines: {node: '>=20'}
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+    engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: '>=4.12.16'
+      hono: ^4
 
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
@@ -2126,13 +2116,13 @@ packages:
     resolution: {integrity: sha512-CeMKbRBm05aOBiWhIHWO2xDeHbxynBF9ySQv3gRjObz2N5+uJnYriAYkHvVqvC4JIydmMPmT5VdICFNlNz3qyA==}
     peerDependencies:
       '@nestjs/common': ^11.0.0
-      '@nestjs/core': '>=11.1.18'
+      '@nestjs/core': ^11.0.0
 
   '@nestjs/schedule@6.1.3':
     resolution: {integrity: sha512-RflMFOpR16Dwd1jAUbeB4mfGTCh65fvEdL4mSjQPJChpkRGRjIXjb+6YQcK2faQrVT60c9DmLmoVR7/ONCtuYQ==}
     peerDependencies:
       '@nestjs/common': ^10.0.0 || ^11.0.0
-      '@nestjs/core': '>=11.1.18'
+      '@nestjs/core': ^10.0.0 || ^11.0.0
 
   '@nestjs/schematics@11.1.0':
     resolution: {integrity: sha512-lVxGZ46tcdItFMoXr6vyKWlnOsm1SZm/GUqAEDvy2RL4Q4O+3bkziAhrO7Y8JLssFUUvNFEGqAizI52WAxhjDw==}
@@ -2148,7 +2138,7 @@ packages:
     peerDependencies:
       '@fastify/static': ^8.0.0 || ^9.0.0
       '@nestjs/common': ^11.0.1
-      '@nestjs/core': '>=11.1.18'
+      '@nestjs/core': ^11.0.1
       class-transformer: '*'
       class-validator: '*'
       reflect-metadata: ^0.1.12 || ^0.2.0
@@ -2169,7 +2159,7 @@ packages:
       '@mikro-orm/nestjs': '*'
       '@nestjs/axios': ^2.0.0 || ^3.0.0 || ^4.0.0
       '@nestjs/common': ^10.0.0 || ^11.0.0
-      '@nestjs/core': '>=11.1.18'
+      '@nestjs/core': ^10.0.0 || ^11.0.0
       '@nestjs/microservices': ^10.0.0 || ^11.0.0
       '@nestjs/mongoose': ^11.0.0
       '@nestjs/sequelize': ^10.0.0 || ^11.0.0
@@ -2212,7 +2202,7 @@ packages:
     resolution: {integrity: sha512-+4M4UAnhtprBQN0J2uI6IP0wDqhy9aH8XCMu5SO8oCi0oB04YXA4a4PAEkxmsPn7gHW4dj1u4GFteNQOWgvTJw==}
     peerDependencies:
       '@nestjs/common': ^11.0.0
-      '@nestjs/core': '>=11.1.18'
+      '@nestjs/core': ^11.0.0
       '@nestjs/microservices': ^11.0.0
       '@nestjs/platform-express': ^11.0.0
     peerDependenciesMeta:
@@ -2225,7 +2215,7 @@ packages:
     resolution: {integrity: sha512-9j0ZRfH0QE1qyrj9JjIRDz5gQLPqq9yVC2nHsrosDVAfI5HHw08/aUAWx9DZLSdQf4HDkmhTTEGLrRFHENvchQ==}
     peerDependencies:
       '@nestjs/common': ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0
-      '@nestjs/core': '>=11.1.18'
+      '@nestjs/core': ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0
       reflect-metadata: ^0.1.13 || ^0.2.0
 
   '@next/env@16.2.6':
@@ -2954,8 +2944,8 @@ packages:
   '@tokenizer/token@0.3.0':
     resolution: {integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==}
 
-  '@tootallnate/once@3.0.1':
-    resolution: {integrity: sha512-VyMVKRrpHTT8PnotUeV8L/mDaMwD5DaAKCFLP73zAqAtvF0FCqky+Ki7BYbFCYQmqFyTe9316Ed5zS70QUR9eg==}
+  '@tootallnate/once@2.0.1':
+    resolution: {integrity: sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==}
     engines: {node: '>= 10'}
 
   '@ts-morph/common@0.27.0':
@@ -3414,7 +3404,7 @@ packages:
     resolution: {integrity: sha512-vY7nuamKgfvpA1Koa3oYIw/k7D6kZnpGyNMZW8loow2bsBYla1TFdqTaXncWdRn4pgwNs+90RhnXhJScDwQeJA==}
     peerDependencies:
       msw: ^2.4.9
-      vite: '>=6.4.2'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       msw:
         optional: true
@@ -6144,7 +6134,7 @@ packages:
     hasBin: true
     peerDependencies:
       '@nestjs/common': '*'
-      '@nestjs/core': '>=11.1.18'
+      '@nestjs/core': '*'
       class-validator: '*'
       rxjs: '*'
     peerDependenciesMeta:
@@ -6855,11 +6845,6 @@ packages:
 
   semver@7.8.0:
     resolution: {integrity: sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==}
-    engines: {node: '>=10'}
-    hasBin: true
-
-  semver@7.8.1:
-    resolution: {integrity: sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -7595,7 +7580,7 @@ packages:
       '@vitest/ui': 4.1.7
       happy-dom: '*'
       jsdom: '*'
-      vite: '>=6.4.2'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
@@ -8281,7 +8266,7 @@ snapshots:
 
   '@esbuild-kit/core-utils@3.3.2':
     dependencies:
-      esbuild: 0.25.12
+      esbuild: 0.28.0
       source-map-support: 0.5.21
 
   '@esbuild-kit/esm-loader@2.6.5':
@@ -8890,7 +8875,7 @@ snapshots:
       yargs: 17.7.2
     optional: true
 
-  '@hono/node-server@2.0.2(hono@4.12.19)':
+  '@hono/node-server@1.19.14(hono@4.12.19)':
     dependencies:
       hono: 4.12.19
 
@@ -9426,7 +9411,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
     dependencies:
-      '@hono/node-server': 2.0.2(hono@4.12.19)
+      '@hono/node-server': 1.19.14(hono@4.12.19)
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
@@ -10267,7 +10252,7 @@ snapshots:
 
   '@tokenizer/token@0.3.0': {}
 
-  '@tootallnate/once@3.0.1': {}
+  '@tootallnate/once@2.0.1': {}
 
   '@ts-morph/common@0.27.0':
     dependencies:
@@ -10549,8 +10534,8 @@ snapshots:
 
   '@typescript-eslint/project-service@8.59.3(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.59.3(typescript@6.0.3)
-      '@typescript-eslint/types': 8.59.3
+      '@typescript-eslint/tsconfig-utils': 8.60.0(typescript@6.0.3)
+      '@typescript-eslint/types': 8.60.0
       debug: 4.4.3
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -10634,7 +10619,7 @@ snapshots:
       '@typescript-eslint/visitor-keys': 8.60.0
       debug: 4.4.3
       minimatch: 10.2.5
-      semver: 7.8.1
+      semver: 7.8.0
       tinyglobby: 0.2.16
       ts-api-utils: 2.5.0(typescript@6.0.3)
       typescript: 6.0.3
@@ -12878,7 +12863,7 @@ snapshots:
 
   http-proxy-agent@5.0.0:
     dependencies:
-      '@tootallnate/once': 3.0.1
+      '@tootallnate/once': 2.0.1
       agent-base: 6.0.2
       debug: 4.4.3
     transitivePeerDependencies:
@@ -12994,7 +12979,7 @@ snapshots:
 
   is-bun-module@2.0.0:
     dependencies:
-      semver: 7.8.1
+      semver: 7.8.0
 
   is-callable@1.2.7: {}
 
@@ -13147,7 +13132,7 @@ snapshots:
       '@babel/parser': 7.29.3
       '@istanbuljs/schema': 0.1.6
       istanbul-lib-coverage: 3.2.2
-      semver: 7.8.1
+      semver: 7.8.0
     transitivePeerDependencies:
       - supports-color
 
@@ -14716,8 +14701,6 @@ snapshots:
   semver@6.3.1: {}
 
   semver@7.8.0: {}
-
-  semver@7.8.1: {}
 
   send@1.2.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -24,29 +24,6 @@ catalog:
   typescript: ^6.0.3
   '@vitest/coverage-v8': ^4.1.7
   vitest: ^4.1.7
-minimumReleaseAgeExclude:
-  - '@protobufjs/utf8@1.1.1'
-  - protobufjs@8.0.2
-  - brace-expansion@5.0.6
-  - pg-cloudflare@1.4.0
-  - pg-connection-string@2.13.0
-  - pg-pool@3.14.0
-  - pg-protocol@1.14.0
-  - pg@8.21.0
-  - '@types/node@25.9.0'
-  - '@nestjs/common@11.1.24'
-  - '@nestjs/core@11.1.24'
-  - '@nestjs/platform-express@11.1.24'
-  - '@nestjs/testing@11.1.24'
-  - '@typescript-eslint/eslint-plugin@8.60.0'
-  - '@typescript-eslint/project-service@8.60.0'
-  - '@typescript-eslint/scope-manager@8.60.0'
-  - '@typescript-eslint/tsconfig-utils@8.60.0'
-  - '@typescript-eslint/type-utils@8.60.0'
-  - '@typescript-eslint/types@8.60.0'
-  - '@typescript-eslint/typescript-estree@8.60.0'
-  - '@typescript-eslint/utils@8.60.0'
-  - '@typescript-eslint/visitor-keys@8.60.0'
 overrides:
   cross-spawn: '>=6.0.6'
   glob: '>=10.5.0'
@@ -57,21 +34,11 @@ overrides:
   esbuild@<=0.24.2: '>=0.25.0'
   ajv@>=7.0.0-alpha.0 <8.18.0: '>=8.18.0'
   file-type@>=13.0.0 <21.3.1: '>=21.3.1'
-  minimist@<0.2.4: '>=0.2.4'
   tough-cookie@<4.1.3: '>=4.1.3'
   form-data@<2.5.4: '>=2.5.4'
   qs@<6.14.1: '>=6.14.1'
-  '@tootallnate/once@<3.0.1': '>=3.0.1'
-  '@nestjs/core@<=11.1.17': '>=11.1.18'
-  vite@>=6.0.0 <=6.4.1: '>=6.4.2'
-  '@hono/node-server@<1.19.13': '>=1.19.13'
   axios@<1.15.0: '>=1.15.0'
-  next@>=16.0.0-beta.0 <16.2.3: '>=16.2.3'
   protobufjs@<7.5.5: '>=7.5.5'
   fast-xml-parser@<5.7.0: '>=5.7.0'
   uuid@<14.0.0: '>=14.0.0'
   postcss@<8.5.10: '>=8.5.10'
-  ip-address@<=10.1.0: '>=10.1.1'
-  hono@<4.12.16: '>=4.12.16'
-  fast-xml-builder@<=1.1.6: '>=1.1.7'
-  fast-uri@<=3.1.1: '>=3.1.2'


### PR DESCRIPTION
## Summary

Wires `NotificationsService.notify()` into the four event trigger points that have existing modules, completing the first installment of issue #309. The `sendPassportStatusNotification` stub in `NotificationsService` was dispatching notifications with empty channels (in-app only, no push); this PR replaces it with direct `notify(…, [PUSH])` calls at the correct call sites and removes the now-unnecessary wrapper method.

The remaining six events (`GROUP_ANNOUNCEMENT`, `TRIP_INVITATION`, `TRIP_ANNOUNCEMENT`, `TRIP_KEY_DATE_REMINDER`, `TRIP_COMPLETED`, `ACHIEVEMENT_UNLOCKED`) require modules that do not yet exist and will be wired in follow-up issues.

## Changes

**Remove `sendPassportStatusNotification` stub**
- Deleted the wrapper method from `NotificationsService` — it was calling `notify()` with `[]` channels (no push dispatch)
- `PassportStatusJob` now calls `notify()` directly with `[NotificationChannel.PUSH]` and the correct `NotificationType` per status

**Wire GROUP_INVITATION**
- `GroupMembersService.sendInvitations` collects successfully invited user IDs during the loop and calls `notifyMany(…, GROUP_INVITATION, {}, [PUSH])` once after the loop
- No notification is sent when no users were actually invited (NOT_FOUND, ALREADY_MEMBER, etc.)

**Wire GROUP_JOIN_ACCEPTED**
- `GroupMembersService.acceptJoinRequest` calls `notify(targetUserId, GROUP_JOIN_ACCEPTED, {}, [PUSH])` after the membership transaction commits

**Module wiring**
- `GroupMembersModule` now imports `NotificationsModule` so `NotificationsService` is injectable

## Testing

- All 980 API unit tests and 1336 web tests pass
- Coverage thresholds (90%) remain met across all packages
- New assertions verify `notifyMany` is called with the correct invited user IDs (excludes non-invited results like `NOT_FOUND`, `ALREADY_MEMBER`)
- New assertion verifies `notify` is called with `GROUP_JOIN_ACCEPTED` after a successful join request approval
- Passport job assertions updated to verify `notify()` args: correct `NotificationType`, `{ countryCode }` payload, and `[PUSH]` channel

## Notes

- The `pnpm-lock.yaml` and `pnpm-workspace.yaml` diffs are from a prior dependency cleanup on this branch and are unrelated to the notification wiring.
- `GROUP_INVITATION` uses `notifyMany` (single batch insert) instead of per-user `notify` calls to avoid N round-trips for bulk invitations.

Closes #309