### PR TITLE
feat(notifications): clean rendering, payload enrichment, and deep-link url

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -71,6 +71,7 @@ jobs:
       - name: Build Next.js application
         env:
           NEXT_TELEMETRY_DISABLED: 1
+          NODE_OPTIONS: '--max-old-space-size=4096'
           NEXT_PUBLIC_FIREBASE_API_KEY: ${{ secrets.NEXT_PUBLIC_FIREBASE_API_KEY }}
           NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN: ${{ secrets.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN }}
           NEXT_PUBLIC_FIREBASE_PROJECT_ID: ${{ secrets.NEXT_PUBLIC_FIREBASE_PROJECT_ID }}
@@ -172,6 +173,9 @@ jobs:
             --image=${{ env.ARTIFACT_REGISTRY }}/web:${{ github.sha }} \
             --region=${{ env.GCP_REGION }} \
             --platform=managed \
+            --execution-environment=gen2 \
+            --no-use-http2 \
+            --memory=1Gi \
             --set-env-vars="NODE_ENV=production" \
             --clear-secrets \
             --quiet

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -435,18 +435,26 @@ await db.update(users).set({ avatar: newAssetId }).where(eq(users.id, userId));
 
 ### 8. Cloud Run deployment — invariants that must never be dropped
 
-When modifying `.github/workflows/api.yml` or any `gcloud run deploy` command, the following flags are **required**. Omitting them silently reverts Cloud Run to defaults on every deploy.
+When modifying `.github/workflows/api.yml`, `.github/workflows/web.yml`, or any `gcloud run deploy` command, the following flags are **required**. Omitting them silently reverts Cloud Run to defaults on every deploy.
 
-| Flag                      | Value  | Why                                               |
-| ------------------------- | ------ | ------------------------------------------------- |
-| `--execution-environment` | `gen2` | Faster cold starts, better Unix socket support    |
-| `--no-use-http2`          | (flag) | Required for NestJS WebSocket / SSE compatibility |
+| Flag                      | Value  | Applies to | Why                                                    |
+| ------------------------- | ------ | ---------- | ------------------------------------------------------ |
+| `--execution-environment` | `gen2` | api, web   | Faster cold starts, better Unix socket support         |
+| `--no-use-http2`          | (flag) | api, web   | Required for NestJS WebSocket / SSE compatibility      |
+| `--memory`                | `1Gi`  | web        | Next.js SSR requires >256 Mi default; OOM without this |
 
 ```bash
-# ✅ Must always be present in gcloud run deploy
+# ✅ Must always be present in gcloud run deploy (api)
 gcloud run deploy chamuco-api \
   --execution-environment=gen2 \
   --no-use-http2 \
+  ...
+
+# ✅ Must always be present in gcloud run deploy (web)
+gcloud run deploy chamuco-web \
+  --execution-environment=gen2 \
+  --no-use-http2 \
+  --memory=1Gi \
   ...
 ```
 

--- a/apps/api/src/database/migrations/0024_good_colonel_america.sql
+++ b/apps/api/src/database/migrations/0024_good_colonel_america.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "notifications" DROP COLUMN "title";--> statement-breakpoint
+ALTER TABLE "notifications" DROP COLUMN "body";

--- a/apps/api/src/database/migrations/meta/0024_snapshot.json
+++ b/apps/api/src/database/migrations/meta/0024_snapshot.json
@@ -1,0 +1,1867 @@
+{
+  "id": "5519c3cb-d5bc-4226-887a-78d6b4a93a50",
+  "prevId": "57c58aa3-de79-4694-9ac5-c306465b630f",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.assets": {
+      "name": "assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "asset_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "asset_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target": {
+          "name": "target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_announcements": {
+      "name": "group_announcements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_group_announcements_group_id": {
+          "name": "idx_group_announcements_group_id",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "group_announcements_group_id_groups_id_fk": {
+          "name": "group_announcements_group_id_groups_id_fk",
+          "tableFrom": "group_announcements",
+          "tableTo": "groups",
+          "columnsFrom": ["group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "group_announcements_created_by_users_id_fk": {
+          "name": "group_announcements_created_by_users_id_fk",
+          "tableFrom": "group_announcements",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_member_stats": {
+      "name": "group_member_stats",
+      "schema": "",
+      "columns": {
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tier": {
+          "name": "tier",
+          "type": "group_member_tier",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'NEWCOMER'"
+        },
+        "group_trips_completed": {
+          "name": "group_trips_completed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_streak": {
+          "name": "active_streak",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "group_member_stats_group_id_groups_id_fk": {
+          "name": "group_member_stats_group_id_groups_id_fk",
+          "tableFrom": "group_member_stats",
+          "tableTo": "groups",
+          "columnsFrom": ["group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_member_stats_user_id_users_id_fk": {
+          "name": "group_member_stats_user_id_users_id_fk",
+          "tableFrom": "group_member_stats",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "group_member_stats_group_id_user_id_pk": {
+          "name": "group_member_stats_group_id_user_id_pk",
+          "columns": ["group_id", "user_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_members": {
+      "name": "group_members",
+      "schema": "",
+      "columns": {
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "group_member_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "group_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'MEMBER'"
+        },
+        "initiated_at": {
+          "name": "initiated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "responded_at": {
+          "name": "responded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "initiated_by": {
+          "name": "initiated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decided_by": {
+          "name": "decided_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_group_members_user_id_status": {
+          "name": "idx_group_members_user_id_status",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_members_group_id_status": {
+          "name": "idx_group_members_group_id_status",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "group_members_group_id_groups_id_fk": {
+          "name": "group_members_group_id_groups_id_fk",
+          "tableFrom": "group_members",
+          "tableTo": "groups",
+          "columnsFrom": ["group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "group_members_user_id_users_id_fk": {
+          "name": "group_members_user_id_users_id_fk",
+          "tableFrom": "group_members",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "group_members_initiated_by_users_id_fk": {
+          "name": "group_members_initiated_by_users_id_fk",
+          "tableFrom": "group_members",
+          "tableTo": "users",
+          "columnsFrom": ["initiated_by"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "group_members_decided_by_users_id_fk": {
+          "name": "group_members_decided_by_users_id_fk",
+          "tableFrom": "group_members",
+          "tableTo": "users",
+          "columnsFrom": ["decided_by"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "group_members_group_id_user_id_pk": {
+          "name": "group_members_group_id_user_id_pk",
+          "columns": ["group_id", "user_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.groups": {
+      "name": "groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover": {
+          "name": "cover",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "group_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "groups_cover_assets_id_fk": {
+          "name": "groups_cover_assets_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "assets",
+          "columnsFrom": ["cover"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "groups_created_by_users_id_fk": {
+          "name": "groups_created_by_users_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_deliveries": {
+      "name": "notification_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "notification_id": {
+          "name": "notification_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "notification_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "delivery_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_notification_deliveries_status": {
+          "name": "idx_notification_deliveries_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_deliveries_notification_id_notifications_id_fk": {
+          "name": "notification_deliveries_notification_id_notifications_id_fk",
+          "tableFrom": "notification_deliveries",
+          "tableTo": "notifications",
+          "columnsFrom": ["notification_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "notification_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_notifications_user_id_created_at": {
+          "name": "idx_notifications_user_id_created_at",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_users_id_fk": {
+          "name": "notifications_user_id_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_fcm_tokens": {
+      "name": "user_fcm_tokens",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_hint": {
+          "name": "device_hint",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_user_fcm_tokens_user_id": {
+          "name": "idx_user_fcm_tokens_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_fcm_tokens_user_id_users_id_fk": {
+          "name": "user_fcm_tokens_user_id_users_id_fk",
+          "tableFrom": "user_fcm_tokens",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_fcm_tokens_user_id_token_pk": {
+          "name": "user_fcm_tokens_user_id_token_pk",
+          "columns": ["user_id", "token"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.support_admin_audit_log": {
+      "name": "support_admin_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "admin_user_id": {
+          "name": "admin_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_table": {
+          "name": "target_table",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "before_state": {
+          "name": "before_state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "after_state": {
+          "name": "after_state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "performed_at": {
+          "name": "performed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "support_admin_audit_log_admin_user_id_idx": {
+          "name": "support_admin_audit_log_admin_user_id_idx",
+          "columns": [
+            {
+              "expression": "admin_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "support_admin_audit_log_performed_at_idx": {
+          "name": "support_admin_audit_log_performed_at_idx",
+          "columns": [
+            {
+              "expression": "performed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "support_admin_audit_log_admin_user_id_users_id_fk": {
+          "name": "support_admin_audit_log_admin_user_id_users_id_fk",
+          "tableFrom": "support_admin_audit_log",
+          "tableTo": "users",
+          "columnsFrom": ["admin_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_etas": {
+      "name": "user_etas",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_nationality_id": {
+          "name": "user_nationality_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "passport_number": {
+          "name": "passport_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination_country": {
+          "name": "destination_country",
+          "type": "char(2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authorization_number": {
+          "name": "authorization_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "eta_type": {
+          "name": "eta_type",
+          "type": "eta_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entries": {
+          "name": "entries",
+          "type": "visa_entries",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiry_date": {
+          "name": "expiry_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "eta_status": {
+          "name": "eta_status",
+          "type": "eta_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_etas_user_nationality_id_idx": {
+          "name": "user_etas_user_nationality_id_idx",
+          "columns": [
+            {
+              "expression": "user_nationality_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_etas_eta_status_idx": {
+          "name": "user_etas_eta_status_idx",
+          "columns": [
+            {
+              "expression": "eta_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_etas_passport_number_idx": {
+          "name": "user_etas_passport_number_idx",
+          "columns": [
+            {
+              "expression": "passport_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_etas_user_nationality_id_user_nationalities_id_fk": {
+          "name": "user_etas_user_nationality_id_user_nationalities_id_fk",
+          "tableFrom": "user_etas",
+          "tableTo": "user_nationalities",
+          "columnsFrom": ["user_nationality_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_nationalities": {
+      "name": "user_nationalities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country_code": {
+          "name": "country_code",
+          "type": "char(2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "national_id_number": {
+          "name": "national_id_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "passport_number": {
+          "name": "passport_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "passport_issue_date": {
+          "name": "passport_issue_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "passport_expiry_date": {
+          "name": "passport_expiry_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "passport_status": {
+          "name": "passport_status",
+          "type": "passport_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_nationalities_user_id_idx": {
+          "name": "user_nationalities_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_nationalities_one_primary_per_user": {
+          "name": "user_nationalities_one_primary_per_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"user_nationalities\".\"is_primary\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_nationalities_user_id_users_id_fk": {
+          "name": "user_nationalities_user_id_users_id_fk",
+          "tableFrom": "user_nationalities",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_nationalities_user_id_country_code_unique": {
+          "name": "user_nationalities_user_id_country_code_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id", "country_code"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "passport_data_consistency": {
+          "name": "passport_data_consistency",
+          "value": "(\"user_nationalities\".\"passport_status\" = 'OMITTED'\n        AND \"user_nationalities\".\"passport_number\" IS NULL\n        AND \"user_nationalities\".\"passport_issue_date\" IS NULL\n        AND \"user_nationalities\".\"passport_expiry_date\" IS NULL)\n      OR\n      (\"user_nationalities\".\"passport_status\" <> 'OMITTED'\n        AND \"user_nationalities\".\"passport_number\" IS NOT NULL\n        AND \"user_nationalities\".\"passport_issue_date\" IS NOT NULL\n        AND \"user_nationalities\".\"passport_expiry_date\" IS NOT NULL)"
+        },
+        "national_id_number_format": {
+          "name": "national_id_number_format",
+          "value": "\"user_nationalities\".\"national_id_number\" IS NULL OR \"user_nationalities\".\"national_id_number\" ~ '^[A-Z0-9]([A-Z0-9-]*[A-Z0-9])?$'"
+        },
+        "passport_number_format": {
+          "name": "passport_number_format",
+          "value": "\"user_nationalities\".\"passport_number\" IS NULL OR \"user_nationalities\".\"passport_number\" ~ '^[A-Z0-9]([A-Z0-9-]*[A-Z0-9])?$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_preferences": {
+      "name": "user_preferences",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "app_language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ES'"
+        },
+        "currency": {
+          "name": "currency",
+          "type": "app_currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'COP'"
+        },
+        "theme": {
+          "name": "theme",
+          "type": "app_theme",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'SYSTEM'"
+        },
+        "notification_opt_outs": {
+          "name": "notification_opt_outs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_preferences_user_id_users_id_fk": {
+          "name": "user_preferences_user_id_users_id_fk",
+          "tableFrom": "user_preferences",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_profiles": {
+      "name": "user_profiles",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_of_birth": {
+          "name": "date_of_birth",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "birth_country": {
+          "name": "birth_country",
+          "type": "char(2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "birth_city": {
+          "name": "birth_city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "home_country": {
+          "name": "home_country",
+          "type": "char(2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "home_city": {
+          "name": "home_city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "phone_country_code": {
+          "name": "phone_country_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone_local_number": {
+          "name": "phone_local_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone_verified": {
+          "name": "phone_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blood_type": {
+          "name": "blood_type",
+          "type": "blood_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dietary_preference": {
+          "name": "dietary_preference",
+          "type": "dietary_preference",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'OMNIVORE'"
+        },
+        "dietary_notes": {
+          "name": "dietary_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "general_medical_notes": {
+          "name": "general_medical_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "food_allergies": {
+          "name": "food_allergies",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "phobias": {
+          "name": "phobias",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "physical_limitations": {
+          "name": "physical_limitations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "medical_conditions": {
+          "name": "medical_conditions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "emergency_contacts": {
+          "name": "emergency_contacts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "loyalty_programs": {
+          "name": "loyalty_programs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_profiles_user_id_users_id_fk": {
+          "name": "user_profiles_user_id_users_id_fk",
+          "tableFrom": "user_profiles",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_visas": {
+      "name": "user_visas",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "nationality_id": {
+          "name": "nationality_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "coverage_type": {
+          "name": "coverage_type",
+          "type": "visa_coverage_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country_code": {
+          "name": "country_code",
+          "type": "char(2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visa_zone": {
+          "name": "visa_zone",
+          "type": "visa_zone",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visa_type": {
+          "name": "visa_type",
+          "type": "visa_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entries": {
+          "name": "entries",
+          "type": "visa_entries",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiry_date": {
+          "name": "expiry_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visa_status": {
+          "name": "visa_status",
+          "type": "visa_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_visas_nationality_id_idx": {
+          "name": "user_visas_nationality_id_idx",
+          "columns": [
+            {
+              "expression": "nationality_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_visas_visa_status_idx": {
+          "name": "user_visas_visa_status_idx",
+          "columns": [
+            {
+              "expression": "visa_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_visas_nationality_id_user_nationalities_id_fk": {
+          "name": "user_visas_nationality_id_user_nationalities_id_fk",
+          "tableFrom": "user_visas",
+          "tableTo": "user_nationalities",
+          "columnsFrom": ["nationality_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "visa_coverage_consistency": {
+          "name": "visa_coverage_consistency",
+          "value": "(\"user_visas\".\"coverage_type\" = 'COUNTRY' AND \"user_visas\".\"country_code\" IS NOT NULL AND \"user_visas\".\"visa_zone\" IS NULL)\n      OR\n      (\"user_visas\".\"coverage_type\" = 'ZONE' AND \"user_visas\".\"visa_zone\" IS NOT NULL AND \"user_visas\".\"country_code\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_provider": {
+          "name": "auth_provider",
+          "type": "auth_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "firebase_uid": {
+          "name": "firebase_uid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "platform_role": {
+          "name": "platform_role",
+          "type": "platform_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'USER'"
+        },
+        "profile_visibility": {
+          "name": "profile_visibility",
+          "type": "profile_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PRIVATE'"
+        },
+        "agency_id": {
+          "name": "agency_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_avatar_assets_id_fk": {
+          "name": "users_avatar_assets_id_fk",
+          "tableFrom": "users",
+          "tableTo": "assets",
+          "columnsFrom": ["avatar"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": ["username"]
+        },
+        "users_firebase_uid_unique": {
+          "name": "users_firebase_uid_unique",
+          "nullsNotDistinct": false,
+          "columns": ["firebase_uid"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "users_username_format": {
+          "name": "users_username_format",
+          "value": "\"users\".\"username\" ~ '^[a-z0-9_-]{3,30}$'"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.asset_source": {
+      "name": "asset_source",
+      "schema": "public",
+      "values": ["gcs", "url", "emoji", "text"]
+    },
+    "public.asset_type": {
+      "name": "asset_type",
+      "schema": "public",
+      "values": ["image", "video", "file", "link", "text"]
+    },
+    "public.group_member_tier": {
+      "name": "group_member_tier",
+      "schema": "public",
+      "values": ["NEWCOMER", "NOVICE", "EXPLORER", "VETERAN"]
+    },
+    "public.group_member_status": {
+      "name": "group_member_status",
+      "schema": "public",
+      "values": ["REQUEST", "INVITED", "ACTIVE", "REJECTED", "REMOVED", "LEFT"]
+    },
+    "public.group_role": {
+      "name": "group_role",
+      "schema": "public",
+      "values": ["OWNER", "ADMIN", "MEMBER"]
+    },
+    "public.group_visibility": {
+      "name": "group_visibility",
+      "schema": "public",
+      "values": ["PUBLIC", "PRIVATE"]
+    },
+    "public.delivery_status": {
+      "name": "delivery_status",
+      "schema": "public",
+      "values": ["PENDING", "SENT", "FAILED"]
+    },
+    "public.notification_channel": {
+      "name": "notification_channel",
+      "schema": "public",
+      "values": ["PUSH", "EMAIL", "SMS"]
+    },
+    "public.notification_type": {
+      "name": "notification_type",
+      "schema": "public",
+      "values": [
+        "GROUP_INVITATION",
+        "GROUP_JOIN_ACCEPTED",
+        "GROUP_ANNOUNCEMENT",
+        "TRIP_INVITATION",
+        "TRIP_ANNOUNCEMENT",
+        "TRIP_KEY_DATE_REMINDER",
+        "TRIP_COMPLETED",
+        "PASSPORT_EXPIRING_SOON",
+        "PASSPORT_EXPIRED",
+        "ACHIEVEMENT_UNLOCKED"
+      ]
+    },
+    "public.eta_status": {
+      "name": "eta_status",
+      "schema": "public",
+      "values": ["ACTIVE", "EXPIRING_SOON", "EXPIRED"]
+    },
+    "public.eta_type": {
+      "name": "eta_type",
+      "schema": "public",
+      "values": ["TOURIST", "TRANSIT"]
+    },
+    "public.passport_status": {
+      "name": "passport_status",
+      "schema": "public",
+      "values": ["OMITTED", "ACTIVE", "EXPIRING_SOON", "EXPIRED"]
+    },
+    "public.app_currency": {
+      "name": "app_currency",
+      "schema": "public",
+      "values": ["COP", "USD"]
+    },
+    "public.app_language": {
+      "name": "app_language",
+      "schema": "public",
+      "values": ["ES", "EN"]
+    },
+    "public.app_theme": {
+      "name": "app_theme",
+      "schema": "public",
+      "values": ["LIGHT", "DARK", "SYSTEM"]
+    },
+    "public.blood_type": {
+      "name": "blood_type",
+      "schema": "public",
+      "values": [
+        "A_POSITIVE",
+        "A_NEGATIVE",
+        "B_POSITIVE",
+        "B_NEGATIVE",
+        "AB_POSITIVE",
+        "AB_NEGATIVE",
+        "O_POSITIVE",
+        "O_NEGATIVE"
+      ]
+    },
+    "public.dietary_preference": {
+      "name": "dietary_preference",
+      "schema": "public",
+      "values": ["OMNIVORE", "VEGETARIAN", "VEGAN", "PESCATARIAN", "GLUTEN_FREE", "OTHER"]
+    },
+    "public.food_allergen": {
+      "name": "food_allergen",
+      "schema": "public",
+      "values": [
+        "GLUTEN",
+        "CRUSTACEANS",
+        "EGGS",
+        "FISH",
+        "PEANUTS",
+        "SOYBEANS",
+        "MILK",
+        "TREE_NUTS",
+        "CELERY",
+        "MUSTARD",
+        "SESAME",
+        "SULPHITES",
+        "LUPIN",
+        "MOLLUSCS",
+        "OTHER"
+      ]
+    },
+    "public.medical_condition_type": {
+      "name": "medical_condition_type",
+      "schema": "public",
+      "values": [
+        "DIABETES",
+        "EPILEPSY",
+        "SEVERE_ALLERGY_EPIPEN",
+        "ASTHMA",
+        "HEART_CONDITION",
+        "HYPERTENSION",
+        "BLOOD_CLOTTING_DISORDER",
+        "MENTAL_HEALTH_CONDITION",
+        "OTHER"
+      ]
+    },
+    "public.phobia_type": {
+      "name": "phobia_type",
+      "schema": "public",
+      "values": [
+        "HEIGHTS",
+        "ENCLOSED_SPACES",
+        "FLYING",
+        "DEEP_WATER",
+        "OPEN_WATER",
+        "ANIMALS",
+        "INSECTS",
+        "SNAKES",
+        "SPIDERS",
+        "DARKNESS",
+        "CROWDS",
+        "MOTION_SICKNESS",
+        "OTHER"
+      ]
+    },
+    "public.physical_limitation_type": {
+      "name": "physical_limitation_type",
+      "schema": "public",
+      "values": [
+        "WHEELCHAIR_USER",
+        "REDUCED_MOBILITY",
+        "CANNOT_USE_STAIRS",
+        "HEARING_IMPAIRMENT",
+        "VISUAL_IMPAIRMENT",
+        "REQUIRES_OXYGEN",
+        "REQUIRES_CPAP",
+        "CHRONIC_PAIN",
+        "JOINT_CONDITION",
+        "CARDIAC_CONDITION",
+        "RESPIRATORY_CONDITION",
+        "PREGNANCY",
+        "OTHER"
+      ]
+    },
+    "public.visa_coverage_type": {
+      "name": "visa_coverage_type",
+      "schema": "public",
+      "values": ["COUNTRY", "ZONE"]
+    },
+    "public.visa_entries": {
+      "name": "visa_entries",
+      "schema": "public",
+      "values": ["SINGLE", "DOUBLE", "MULTIPLE"]
+    },
+    "public.visa_status": {
+      "name": "visa_status",
+      "schema": "public",
+      "values": ["ACTIVE", "EXPIRING_SOON", "EXPIRED"]
+    },
+    "public.visa_type": {
+      "name": "visa_type",
+      "schema": "public",
+      "values": ["TOURIST", "BUSINESS", "TRANSIT", "WORK", "STUDENT", "DIGITAL_NOMAD", "OTHER"]
+    },
+    "public.visa_zone": {
+      "name": "visa_zone",
+      "schema": "public",
+      "values": ["SCHENGEN", "GCC", "CARICOM", "EAC", "CAN", "MERCOSUR", "ECOWAS"]
+    },
+    "public.auth_provider": {
+      "name": "auth_provider",
+      "schema": "public",
+      "values": ["GOOGLE", "FACEBOOK"]
+    },
+    "public.platform_role": {
+      "name": "platform_role",
+      "schema": "public",
+      "values": ["USER", "SUPPORT_ADMIN"]
+    },
+    "public.profile_visibility": {
+      "name": "profile_visibility",
+      "schema": "public",
+      "values": ["PRIVATE", "CONNECTIONS_ONLY", "MEMBERS_ONLY", "PUBLIC"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/src/database/migrations/meta/_journal.json
+++ b/apps/api/src/database/migrations/meta/_journal.json
@@ -169,6 +169,13 @@
       "when": 1779841987727,
       "tag": "0023_moaning_the_phantom",
       "breakpoints": true
+    },
+    {
+      "idx": 24,
+      "version": "7",
+      "when": 1779930776582,
+      "tag": "0024_good_colonel_america",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/i18n/CLAUDE.md
+++ b/apps/api/src/i18n/CLAUDE.md
@@ -38,7 +38,7 @@ Keys follow **camelCase dot-notation** with a feature namespace prefix:
 1. **Keys are always in English**, even if the translated value is in Spanish
 2. **Use camelCase** for multi-word identifiers (no snake_case, no hyphens)
 3. **Describe context and role**, not content (e.g., `errors.notFound` not `errors.recursoNoEncontrado`)
-4. **Interpolation variables** use double-brace syntax: `{{variableName}}` (also in English and camelCase)
+4. **Interpolation variables** use single-brace syntax: `{variableName}` (also in English and camelCase). `{{variableName}}` is an escape sequence in `string-format` (the default nestjs-i18n formatter) and outputs a literal `{variableName}` without substitution — never use double braces.
 
 ### Examples
 
@@ -53,6 +53,27 @@ Keys follow **camelCase dot-notation** with a feature namespace prefix:
 'common.validation.campo_requerido'; // Spanish content in key
 'errors.not-found'; // Hyphens instead of camelCase
 'ERRORS.NOT_FOUND'; // All caps
+```
+
+### Interpolation syntax
+
+nestjs-i18n uses `string-format` as the default formatter, which uses **single-brace** syntax:
+
+```json
+// ✅ Correct — single braces
+{ "body": "You've been invited to join {groupName}." }
+
+// ❌ Wrong — double braces are an escape sequence, output literal {groupName}
+{ "body": "You've been invited to join {{groupName}}." }
+```
+
+```typescript
+// Usage in code
+this.i18n.translate('notifications.groupInvitation.body', {
+  lang: 'es',
+  args: { groupName: 'Mountain Crew' },
+});
+// => "Has sido invitado a unirte a Mountain Crew."
 ```
 
 ## Namespaces

--- a/apps/api/src/i18n/en/common.json
+++ b/apps/api/src/i18n/en/common.json
@@ -2,8 +2,8 @@
   "validation": {
     "required": "This field is required",
     "invalidEmail": "Please enter a valid email address",
-    "minLength": "Minimum length is {{count}} characters",
-    "maxLength": "Maximum length is {{count}} characters",
+    "minLength": "Minimum length is {count} characters",
+    "maxLength": "Maximum length is {count} characters",
     "invalidFormat": "Invalid format",
     "mustBePositive": "Value must be positive",
     "mustBeInteger": "Value must be an integer"

--- a/apps/api/src/i18n/en/notifications.json
+++ b/apps/api/src/i18n/en/notifications.json
@@ -1,28 +1,23 @@
 {
-  "invitationReceived": "{{organizer}} invited you to the trip \"{{trip}}\"",
-  "taskDueSoon": "The task \"{{task}}\" is due in {{days}} days",
-  "tripStartingSoon": "Your trip \"{{trip}}\" starts in {{days}} days",
-  "expenseAdded": "{{user}} added an expense: {{description}}",
-  "participantJoined": "{{user}} joined the trip \"{{trip}}\"",
   "passportExpiringSoon": {
     "title": "Passport Expiring Soon",
-    "body": "Your passport for {{countryCode}} is expiring soon."
+    "body": "Your passport for {countryCode} is expiring soon."
   },
   "passportExpired": {
     "title": "Passport Expired",
-    "body": "Your passport for {{countryCode}} has expired."
+    "body": "Your passport for {countryCode} has expired."
   },
   "groupInvitation": {
     "title": "Group Invitation",
-    "body": "You have been invited to join a group."
+    "body": "You've been invited to join {groupName}."
   },
   "groupJoinAccepted": {
     "title": "Join Request Accepted",
-    "body": "Your request to join the group has been accepted."
+    "body": "Your request to join {groupName} has been accepted."
   },
   "groupAnnouncement": {
-    "title": "New Group Announcement",
-    "body": "Your group has a new announcement."
+    "title": "New announcement in {groupName}",
+    "body": "@{senderUsername} posted a new announcement."
   },
   "tripInvitation": {
     "title": "Trip Invitation",
@@ -34,7 +29,7 @@
   },
   "tripKeyDateReminder": {
     "title": "Trip Date Reminder",
-    "body": "Reminder: {{description}} is coming up."
+    "body": "Reminder: {description} is coming up."
   },
   "tripCompleted": {
     "title": "Trip Completed",
@@ -42,6 +37,6 @@
   },
   "achievementUnlocked": {
     "title": "Achievement Unlocked",
-    "body": "You unlocked a new achievement: {{achievementName}}."
+    "body": "You unlocked a new achievement: {achievementName}."
   }
 }

--- a/apps/api/src/i18n/es/common.json
+++ b/apps/api/src/i18n/es/common.json
@@ -2,8 +2,8 @@
   "validation": {
     "required": "Este campo es obligatorio",
     "invalidEmail": "Por favor ingrese un correo electrónico válido",
-    "minLength": "La longitud mínima es {{count}} caracteres",
-    "maxLength": "La longitud máxima es {{count}} caracteres",
+    "minLength": "La longitud mínima es {count} caracteres",
+    "maxLength": "La longitud máxima es {count} caracteres",
     "invalidFormat": "Formato inválido",
     "mustBePositive": "El valor debe ser positivo",
     "mustBeInteger": "El valor debe ser un número entero"

--- a/apps/api/src/i18n/es/notifications.json
+++ b/apps/api/src/i18n/es/notifications.json
@@ -1,28 +1,23 @@
 {
-  "invitationReceived": "{{organizer}} te invitó al viaje \"{{trip}}\"",
-  "taskDueSoon": "La tarea \"{{task}}\" vence en {{days}} días",
-  "tripStartingSoon": "Tu viaje \"{{trip}}\" comienza en {{days}} días",
-  "expenseAdded": "{{user}} agregó un gasto: {{description}}",
-  "participantJoined": "{{user}} se unió al viaje \"{{trip}}\"",
   "passportExpiringSoon": {
     "title": "Pasaporte por Vencer",
-    "body": "Tu pasaporte de {{countryCode}} está por vencer."
+    "body": "Tu pasaporte de {countryCode} está por vencer."
   },
   "passportExpired": {
     "title": "Pasaporte Vencido",
-    "body": "Tu pasaporte de {{countryCode}} ha vencido."
+    "body": "Tu pasaporte de {countryCode} ha vencido."
   },
   "groupInvitation": {
     "title": "Invitación a Grupo",
-    "body": "Has sido invitado a unirte a un grupo."
+    "body": "Has sido invitado a unirte a {groupName}."
   },
   "groupJoinAccepted": {
     "title": "Solicitud Aceptada",
-    "body": "Tu solicitud para unirte al grupo ha sido aceptada."
+    "body": "Tu solicitud para unirte a {groupName} ha sido aceptada."
   },
   "groupAnnouncement": {
-    "title": "Nuevo Anuncio del Grupo",
-    "body": "Tu grupo tiene un nuevo anuncio."
+    "title": "Nuevo anuncio en {groupName}",
+    "body": "@{senderUsername} publicó un nuevo anuncio."
   },
   "tripInvitation": {
     "title": "Invitación a Viaje",
@@ -34,7 +29,7 @@
   },
   "tripKeyDateReminder": {
     "title": "Recordatorio de Fecha del Viaje",
-    "body": "Recordatorio: {{description}} se acerca."
+    "body": "Recordatorio: {description} se acerca."
   },
   "tripCompleted": {
     "title": "Viaje Completado",
@@ -42,6 +37,6 @@
   },
   "achievementUnlocked": {
     "title": "Logro Desbloqueado",
-    "body": "Desbloqueaste un nuevo logro: {{achievementName}}."
+    "body": "Desbloqueaste un nuevo logro: {achievementName}."
   }
 }

--- a/apps/api/src/modules/group-announcements/group-announcements.service.ts
+++ b/apps/api/src/modules/group-announcements/group-announcements.service.ts
@@ -43,12 +43,18 @@ export class GroupAnnouncementsService {
 
     if (!inserted) throw new Error('Failed to create announcement');
 
-    const memberRows = await this.db
-      .select({ userId: groupMembers.userId })
-      .from(groupMembers)
-      .where(
-        and(eq(groupMembers.groupId, groupId), eq(groupMembers.status, GroupMemberStatus.ACTIVE)),
-      );
+    const [memberRows, group] = await Promise.all([
+      this.db
+        .select({ userId: groupMembers.userId })
+        .from(groupMembers)
+        .where(
+          and(eq(groupMembers.groupId, groupId), eq(groupMembers.status, GroupMemberStatus.ACTIVE)),
+        ),
+      this.db.query.groups.findFirst({
+        where: and(eq(groups.id, groupId), isNull(groups.deletedAt)),
+        columns: { name: true },
+      }),
+    ]);
 
     const userIds = memberRows.map((r) => r.userId);
 
@@ -56,7 +62,12 @@ export class GroupAnnouncementsService {
       .notifyMany(
         userIds,
         NotificationType.GROUP_ANNOUNCEMENT,
-        { groupId, announcementId: inserted.id },
+        {
+          groupId,
+          groupName: group?.name ?? '',
+          senderUsername: callerUsername,
+          announcementId: inserted.id,
+        },
         [NotificationChannel.PUSH],
       )
       .catch((err: unknown) =>

--- a/apps/api/src/modules/group-members/group-members.service.spec.ts
+++ b/apps/api/src/modules/group-members/group-members.service.spec.ts
@@ -267,7 +267,7 @@ describe('GroupMembersService', () => {
       expect(mockNotificationsNotify).toHaveBeenCalledWith(
         USER_ID,
         NotificationType.GROUP_JOIN_ACCEPTED,
-        {},
+        { groupId: GROUP_ID, groupName: 'Mountain Crew' },
         [NotificationChannel.PUSH],
       );
     });
@@ -393,7 +393,7 @@ describe('GroupMembersService', () => {
       expect(mockNotificationsNotifyMany).toHaveBeenCalledWith(
         [TARGET_ID],
         NotificationType.GROUP_INVITATION,
-        {},
+        { groupId: GROUP_ID, groupName: 'Mountain Crew' },
         [NotificationChannel.PUSH],
       );
     });
@@ -475,7 +475,7 @@ describe('GroupMembersService', () => {
       expect(mockNotificationsNotifyMany).toHaveBeenCalledWith(
         [TARGET_ID],
         NotificationType.GROUP_INVITATION,
-        {},
+        { groupId: GROUP_ID, groupName: 'Mountain Crew' },
         [NotificationChannel.PUSH],
       );
     });
@@ -505,7 +505,7 @@ describe('GroupMembersService', () => {
       expect(mockNotificationsNotifyMany).toHaveBeenCalledWith(
         ['id-a', 'id-c'],
         NotificationType.GROUP_INVITATION,
-        {},
+        { groupId: GROUP_ID, groupName: 'Mountain Crew' },
         [NotificationChannel.PUSH],
       );
     });

--- a/apps/api/src/modules/group-members/group-members.service.ts
+++ b/apps/api/src/modules/group-members/group-members.service.ts
@@ -113,8 +113,17 @@ export class GroupMembersService {
         .onConflictDoNothing();
     });
 
+    const group = await this.db.query.groups.findFirst({
+      where: eq(groups.id, groupId),
+      columns: { name: true },
+    });
     await this.notifications
-      .notify(targetUserId, NotificationType.GROUP_JOIN_ACCEPTED, {}, [NotificationChannel.PUSH])
+      .notify(
+        targetUserId,
+        NotificationType.GROUP_JOIN_ACCEPTED,
+        { groupId, groupName: group?.name ?? '' },
+        [NotificationChannel.PUSH],
+      )
       .catch((err: unknown) => {
         this.logger.error('Failed to send GROUP_JOIN_ACCEPTED notification', err);
       });
@@ -158,6 +167,11 @@ export class GroupMembersService {
     adminUserId: string,
   ): Promise<BulkInvitationResponseDto> {
     await this.assertGroupAdmin(groupId, adminUserId);
+
+    const group = await this.db.query.groups.findFirst({
+      where: eq(groups.id, groupId),
+      columns: { name: true },
+    });
 
     const targetUsers = await this.db.query.users.findMany({
       where: inArray(users.username, dto.usernames),
@@ -232,9 +246,12 @@ export class GroupMembersService {
 
     if (invitedUserIds.length > 0) {
       await this.notifications
-        .notifyMany(invitedUserIds, NotificationType.GROUP_INVITATION, {}, [
-          NotificationChannel.PUSH,
-        ])
+        .notifyMany(
+          invitedUserIds,
+          NotificationType.GROUP_INVITATION,
+          { groupId, groupName: group?.name ?? '' },
+          [NotificationChannel.PUSH],
+        )
         .catch((err: unknown) => {
           this.logger.error('Failed to send GROUP_INVITATION notifications', err);
         });

--- a/apps/api/src/modules/notifications/channel-strategies/channel-strategies.spec.ts
+++ b/apps/api/src/modules/notifications/channel-strategies/channel-strategies.spec.ts
@@ -1,20 +1,17 @@
-import { DeliveryStatus, NotificationType } from '@chamuco/shared-types';
+import { DeliveryStatus } from '@chamuco/shared-types';
 import type { DrizzleClient } from '@/database/drizzle.provider';
 import type { FirebaseAdminService } from '@/modules/auth/firebase-admin.service';
 import { PushChannelStrategy } from './push-channel.strategy';
 import { EmailChannelStrategy } from './email-channel.strategy';
 import { SmsChannelStrategy } from './sms-channel.strategy';
-import type { NotificationRow } from './notification-channel.strategy';
+import type { DispatchableNotification } from './notification-channel.strategy';
 
-const FAKE_NOTIFICATION: NotificationRow = {
+const FAKE_NOTIFICATION: DispatchableNotification = {
   id: 'notif-1',
   userId: 'user-1',
-  type: NotificationType.PASSPORT_EXPIRING_SOON,
   title: 'Test title',
   body: 'Test body',
-  data: {},
-  readAt: null,
-  createdAt: new Date(),
+  url: null,
 };
 
 type SendResponse = { success: boolean; error?: { code: string; message?: string } };
@@ -206,6 +203,36 @@ describe('PushChannelStrategy', () => {
           data: { count: '3', flag: 'true', nested: '{"x":1}' },
         }),
       );
+    });
+  });
+
+  describe('webpush click-action URL', () => {
+    it('sets webpush.fcmOptions.link when notification has a url', async () => {
+      const sendEachForMulticast = jest
+        .fn()
+        .mockResolvedValue(makeBatchResponse([{ success: true }]));
+      const { strategy } = makeContext(['tok-a'], sendEachForMulticast);
+      const notifWithUrl: DispatchableNotification = { ...FAKE_NOTIFICATION, url: '/groups/abc' };
+
+      await strategy.send(notifWithUrl, {});
+
+      expect(sendEachForMulticast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          webpush: { fcmOptions: { link: '/groups/abc' } },
+        }),
+      );
+    });
+
+    it('omits webpush when notification url is null', async () => {
+      const sendEachForMulticast = jest
+        .fn()
+        .mockResolvedValue(makeBatchResponse([{ success: true }]));
+      const { strategy } = makeContext(['tok-a'], sendEachForMulticast);
+
+      await strategy.send(FAKE_NOTIFICATION, {});
+
+      const call = sendEachForMulticast.mock.calls[0]![0] as Record<string, unknown>;
+      expect(call).not.toHaveProperty('webpush');
     });
   });
 });

--- a/apps/api/src/modules/notifications/channel-strategies/email-channel.strategy.ts
+++ b/apps/api/src/modules/notifications/channel-strategies/email-channel.strategy.ts
@@ -1,8 +1,14 @@
 import { Injectable } from '@nestjs/common';
-import type { NotificationChannelStrategy, NotificationRow } from './notification-channel.strategy';
+import type {
+  DispatchableNotification,
+  NotificationChannelStrategy,
+} from './notification-channel.strategy';
 
 @Injectable()
 export class EmailChannelStrategy implements NotificationChannelStrategy {
   // TODO(Epic #8): implement email delivery
-  async send(_notification: NotificationRow, _payload: Record<string, unknown>): Promise<void> {}
+  async send(
+    _notification: DispatchableNotification,
+    _payload: Record<string, unknown>,
+  ): Promise<void> {}
 }

--- a/apps/api/src/modules/notifications/channel-strategies/notification-channel.strategy.ts
+++ b/apps/api/src/modules/notifications/channel-strategies/notification-channel.strategy.ts
@@ -2,6 +2,20 @@ import type { notifications } from '@/modules/notifications/schema/notifications
 
 export type NotificationRow = typeof notifications.$inferSelect;
 
+export interface DispatchableNotification {
+  id: string;
+  userId: string;
+  title: string;
+  body: string;
+  url: string | null;
+}
+
+export type RenderedNotification = NotificationRow & {
+  title: string;
+  body: string;
+  url: string | null;
+};
+
 export interface NotificationChannelStrategy {
-  send(notification: NotificationRow, payload: Record<string, unknown>): Promise<void>;
+  send(notification: DispatchableNotification, payload: Record<string, unknown>): Promise<void>;
 }

--- a/apps/api/src/modules/notifications/channel-strategies/push-channel.strategy.ts
+++ b/apps/api/src/modules/notifications/channel-strategies/push-channel.strategy.ts
@@ -6,7 +6,10 @@ import { DRIZZLE_CLIENT, DrizzleClient } from '@/database/drizzle.provider';
 import { FirebaseAdminService } from '@/modules/auth/firebase-admin.service';
 import { notificationDeliveries } from '@/modules/notifications/schema/notification-deliveries.schema';
 import { userFcmTokens } from '@/modules/notifications/schema/user-fcm-tokens.schema';
-import type { NotificationChannelStrategy, NotificationRow } from './notification-channel.strategy';
+import type {
+  DispatchableNotification,
+  NotificationChannelStrategy,
+} from './notification-channel.strategy';
 
 const STALE_TOKEN_ERROR = 'messaging/registration-token-not-registered';
 
@@ -19,7 +22,10 @@ export class PushChannelStrategy implements NotificationChannelStrategy {
     private readonly firebaseAdmin: FirebaseAdminService,
   ) {}
 
-  async send(notification: NotificationRow, payload: Record<string, unknown>): Promise<void> {
+  async send(
+    notification: DispatchableNotification,
+    payload: Record<string, unknown>,
+  ): Promise<void> {
     const tokenRows = await this.db
       .select({ token: userFcmTokens.token })
       .from(userFcmTokens)
@@ -39,6 +45,7 @@ export class PushChannelStrategy implements NotificationChannelStrategy {
         tokens,
         notification: { title: notification.title, body: notification.body },
         data,
+        ...(notification.url ? { webpush: { fcmOptions: { link: notification.url } } } : {}),
       });
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err);

--- a/apps/api/src/modules/notifications/channel-strategies/sms-channel.strategy.ts
+++ b/apps/api/src/modules/notifications/channel-strategies/sms-channel.strategy.ts
@@ -1,8 +1,14 @@
 import { Injectable } from '@nestjs/common';
-import type { NotificationChannelStrategy, NotificationRow } from './notification-channel.strategy';
+import type {
+  DispatchableNotification,
+  NotificationChannelStrategy,
+} from './notification-channel.strategy';
 
 @Injectable()
 export class SmsChannelStrategy implements NotificationChannelStrategy {
   // TODO(Epic #8): implement SMS delivery
-  async send(_notification: NotificationRow, _payload: Record<string, unknown>): Promise<void> {}
+  async send(
+    _notification: DispatchableNotification,
+    _payload: Record<string, unknown>,
+  ): Promise<void> {}
 }

--- a/apps/api/src/modules/notifications/dto/notification-response.dto.ts
+++ b/apps/api/src/modules/notifications/dto/notification-response.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { NotificationType } from '@chamuco/shared-types';
-import type { NotificationRow } from '@/modules/notifications/channel-strategies/notification-channel.strategy';
+import type { RenderedNotification } from '@/modules/notifications/channel-strategies/notification-channel.strategy';
 
 export class NotificationResponseDto {
   @ApiProperty({ description: 'UUID of the notification.', example: 'a1b2c3d4-...' })
@@ -32,11 +32,20 @@ export class NotificationResponseDto {
 
   @ApiProperty({
     description:
-      'Event payload used for deep-linking — shape depends on `type` (e.g. `{ tripId }` for trip events, `{ countryCode }` for passport events). Null when no payload was stored.',
+      'Deep-link URL for this notification (e.g. `/groups/<id>`, `/profile/passport`). Null when no target applies.',
+    example: '/groups/a1b2c3d4-...',
+    nullable: true,
+    type: String,
+  })
+  url!: string | null;
+
+  @ApiProperty({
+    description:
+      'Event payload used for additional context — shape depends on `type` (e.g. `{ groupId }` for group events, `{ countryCode }` for passport events). Null when no payload was stored.',
     type: 'object',
     additionalProperties: true,
     nullable: true,
-    example: { tripId: 'a1b2c3d4-...' },
+    example: { groupId: 'a1b2c3d4-...' },
   })
   data!: Record<string, unknown> | null;
 
@@ -67,12 +76,13 @@ export class NotificationsPageDto {
   unreadCount!: number;
 }
 
-export function toNotificationResponseDto(row: NotificationRow): NotificationResponseDto {
+export function toNotificationResponseDto(row: RenderedNotification): NotificationResponseDto {
   return {
     id: row.id,
     type: row.type as NotificationType,
     title: row.title,
     body: row.body,
+    url: row.url,
     data: (row.data ?? null) as Record<string, unknown> | null,
     readAt: row.readAt ? row.readAt.toISOString() : null,
     createdAt: row.createdAt.toISOString(),

--- a/apps/api/src/modules/notifications/notification-content.builder.spec.ts
+++ b/apps/api/src/modules/notifications/notification-content.builder.spec.ts
@@ -61,4 +61,52 @@ describe('buildNotificationContent()', () => {
     });
     expect(result.args['achievementName']).toBe('World Traveler');
   });
+
+  describe('url derivation', () => {
+    it('derives /groups/:id url for GROUP_INVITATION when groupId is present', () => {
+      const result = buildNotificationContent(NotificationType.GROUP_INVITATION, {
+        groupId: 'g-123',
+      });
+      expect(result.url).toBe('/groups/g-123');
+    });
+
+    it('derives /groups/:id url for GROUP_JOIN_ACCEPTED', () => {
+      const result = buildNotificationContent(NotificationType.GROUP_JOIN_ACCEPTED, {
+        groupId: 'g-456',
+      });
+      expect(result.url).toBe('/groups/g-456');
+    });
+
+    it('derives /groups/:id url for GROUP_ANNOUNCEMENT', () => {
+      const result = buildNotificationContent(NotificationType.GROUP_ANNOUNCEMENT, {
+        groupId: 'g-789',
+      });
+      expect(result.url).toBe('/groups/g-789');
+    });
+
+    it('returns null for group types when groupId is missing', () => {
+      const result = buildNotificationContent(NotificationType.GROUP_INVITATION, {});
+      expect(result.url).toBeNull();
+    });
+
+    it('derives /profile/passport for PASSPORT_EXPIRING_SOON', () => {
+      const result = buildNotificationContent(NotificationType.PASSPORT_EXPIRING_SOON, {});
+      expect(result.url).toBe('/profile/passport');
+    });
+
+    it('derives /profile/passport for PASSPORT_EXPIRED', () => {
+      const result = buildNotificationContent(NotificationType.PASSPORT_EXPIRED, {});
+      expect(result.url).toBe('/profile/passport');
+    });
+
+    it('derives /profile/achievements for ACHIEVEMENT_UNLOCKED', () => {
+      const result = buildNotificationContent(NotificationType.ACHIEVEMENT_UNLOCKED, {});
+      expect(result.url).toBe('/profile/achievements');
+    });
+
+    it('returns null for types without a dedicated url (e.g. TRIP_COMPLETED)', () => {
+      const result = buildNotificationContent(NotificationType.TRIP_COMPLETED, {});
+      expect(result.url).toBeNull();
+    });
+  });
 });

--- a/apps/api/src/modules/notifications/notification-content.builder.ts
+++ b/apps/api/src/modules/notifications/notification-content.builder.ts
@@ -5,6 +5,7 @@ export interface NotificationContent {
   titleKey: string;
   bodyKey: string;
   args: Record<string, string | number | boolean>;
+  url: string | null;
 }
 
 export function buildNotificationContent(
@@ -16,5 +17,25 @@ export function buildNotificationContent(
     titleKey: `notifications.${prefix}.title`,
     bodyKey: `notifications.${prefix}.body`,
     args: normalizeI18nArgs(payload),
+    url: buildNotificationUrl(type, payload),
   };
+}
+
+function buildNotificationUrl(
+  type: NotificationType,
+  payload: Record<string, unknown>,
+): string | null {
+  switch (type) {
+    case NotificationType.GROUP_INVITATION:
+    case NotificationType.GROUP_JOIN_ACCEPTED:
+    case NotificationType.GROUP_ANNOUNCEMENT:
+      return typeof payload.groupId === 'string' ? `/groups/${payload.groupId}` : null;
+    case NotificationType.PASSPORT_EXPIRING_SOON:
+    case NotificationType.PASSPORT_EXPIRED:
+      return '/profile/passport';
+    case NotificationType.ACHIEVEMENT_UNLOCKED:
+      return '/profile/achievements';
+    default:
+      return null;
+  }
 }

--- a/apps/api/src/modules/notifications/notifications.service.spec.ts
+++ b/apps/api/src/modules/notifications/notifications.service.spec.ts
@@ -11,8 +11,6 @@ const FAKE_NOTIFICATION = {
   id: 'notif-1',
   userId: 'user-1',
   type: NotificationType.PASSPORT_EXPIRING_SOON,
-  title: 'Passport Expiring Soon',
-  body: 'Your passport for MX is expiring soon.',
   data: { countryCode: 'MX' },
   readAt: null,
   createdAt: new Date('2026-01-01T00:00:00.000Z'),
@@ -41,6 +39,16 @@ const makeSelect = (rows: object[]) => ({
         limit: jest.fn().mockResolvedValue(rows),
       }),
     }),
+  }),
+});
+
+// Enrichment queries use select({cols}).from().where() — no orderBy/limit, resolves directly
+const makeEnrichSelect = (rows: object[]) => ({
+  from: jest.fn().mockReturnValue({
+    innerJoin: jest.fn().mockReturnValue({
+      where: jest.fn().mockResolvedValue(rows),
+    }),
+    where: jest.fn().mockResolvedValue(rows),
   }),
 });
 
@@ -132,8 +140,14 @@ describe('NotificationsService', () => {
       );
 
       expect(db.insert).toHaveBeenCalledTimes(2);
-      expect(pushStrategy.send).toHaveBeenCalledWith(FAKE_NOTIFICATION, { countryCode: 'MX' });
-      expect(emailStrategy.send).toHaveBeenCalledWith(FAKE_NOTIFICATION, { countryCode: 'MX' });
+      expect(pushStrategy.send).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'notif-1', userId: 'user-1' }),
+        { countryCode: 'MX' },
+      );
+      expect(emailStrategy.send).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'notif-1', userId: 'user-1' }),
+        { countryCode: 'MX' },
+      );
       expect(smsStrategy.send).not.toHaveBeenCalled();
     });
 
@@ -348,7 +362,10 @@ describe('NotificationsService', () => {
         ]);
 
         expect(pushStrategy.send).toHaveBeenCalledTimes(1);
-        expect(pushStrategy.send).toHaveBeenCalledWith(rows[1], {});
+        expect(pushStrategy.send).toHaveBeenCalledWith(
+          expect.objectContaining({ id: 'notif-2', userId: 'user-2' }),
+          {},
+        );
       });
 
       it('skips dispatch entirely when all users have the channel disabled', async () => {
@@ -433,6 +450,68 @@ describe('NotificationsService', () => {
         BadRequestException,
       );
       expect(db.select).not.toHaveBeenCalled();
+    });
+
+    it('enriches groupName from groupId when missing from payload', async () => {
+      const row = {
+        ...FAKE_NOTIFICATION,
+        type: NotificationType.GROUP_INVITATION,
+        data: { groupId: 'group-1' },
+      };
+      db.select
+        .mockReturnValueOnce(makeSelect([row]))
+        .mockReturnValueOnce(makeEnrichSelect([{ id: 'group-1', name: 'Mountain Crew' }]))
+        .mockReturnValueOnce(makeEnrichSelect([]));
+
+      const result = await service.findAll('user-1');
+
+      const rendered = result.items[0]!;
+      // renderContent receives the enriched payload — i18n.translate is called with groupName in args
+      expect(i18n.translate).toHaveBeenCalledWith(
+        expect.stringContaining('groupInvitation'),
+        expect.objectContaining({ args: expect.objectContaining({ groupName: 'Mountain Crew' }) }),
+      );
+      expect(rendered).toBeDefined();
+    });
+
+    it('enriches senderUsername from announcementId for GROUP_ANNOUNCEMENT when missing', async () => {
+      const row = {
+        ...FAKE_NOTIFICATION,
+        type: NotificationType.GROUP_ANNOUNCEMENT,
+        data: { groupId: 'group-1', announcementId: 'ann-1' },
+      };
+      db.select
+        .mockReturnValueOnce(makeSelect([row]))
+        .mockReturnValueOnce(makeEnrichSelect([{ id: 'group-1', name: 'Road Crew' }]))
+        .mockReturnValueOnce(makeEnrichSelect([{ id: 'ann-1', username: 'alice' }]));
+
+      await service.findAll('user-1');
+
+      expect(i18n.translate).toHaveBeenCalledWith(
+        expect.stringContaining('groupAnnouncement'),
+        expect.objectContaining({
+          args: expect.objectContaining({ groupName: 'Road Crew', senderUsername: 'alice' }),
+        }),
+      );
+    });
+
+    it('does not make enrichment DB calls when payload already has resolved fields', async () => {
+      const row = {
+        ...FAKE_NOTIFICATION,
+        type: NotificationType.GROUP_ANNOUNCEMENT,
+        data: {
+          groupId: 'group-1',
+          groupName: 'Cached Crew',
+          announcementId: 'ann-1',
+          senderUsername: 'bob',
+        },
+      };
+      db.select.mockReturnValueOnce(makeSelect([row]));
+
+      await service.findAll('user-1');
+
+      // Only the main notifications query — no enrichment selects
+      expect(db.select).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/apps/api/src/modules/notifications/notifications.service.spec.ts
+++ b/apps/api/src/modules/notifications/notifications.service.spec.ts
@@ -495,6 +495,49 @@ describe('NotificationsService', () => {
       );
     });
 
+    it('does not set groupName when group lookup returns no rows (soft-deleted group)', async () => {
+      const row = {
+        ...FAKE_NOTIFICATION,
+        type: NotificationType.GROUP_INVITATION,
+        data: { groupId: 'group-deleted' },
+      };
+      db.select
+        .mockReturnValueOnce(makeSelect([row]))
+        .mockReturnValueOnce(makeEnrichSelect([]))
+        .mockReturnValueOnce(makeEnrichSelect([]));
+
+      await service.findAll('user-1');
+
+      // groupName must not be injected as empty string — payload should keep the raw groupId only
+      expect(i18n.translate).toHaveBeenCalledWith(
+        expect.stringContaining('groupInvitation'),
+        expect.objectContaining({
+          args: expect.not.objectContaining({ groupName: '' }),
+        }),
+      );
+    });
+
+    it('does not set senderUsername when announcement lookup returns no rows', async () => {
+      const row = {
+        ...FAKE_NOTIFICATION,
+        type: NotificationType.GROUP_ANNOUNCEMENT,
+        data: { groupId: 'group-1', announcementId: 'ann-deleted' },
+      };
+      db.select
+        .mockReturnValueOnce(makeSelect([row]))
+        .mockReturnValueOnce(makeEnrichSelect([{ id: 'group-1', name: 'Active Crew' }]))
+        .mockReturnValueOnce(makeEnrichSelect([]));
+
+      await service.findAll('user-1');
+
+      expect(i18n.translate).toHaveBeenCalledWith(
+        expect.stringContaining('groupAnnouncement'),
+        expect.objectContaining({
+          args: expect.not.objectContaining({ senderUsername: '' }),
+        }),
+      );
+    });
+
     it('does not make enrichment DB calls when payload already has resolved fields', async () => {
       const row = {
         ...FAKE_NOTIFICATION,

--- a/apps/api/src/modules/notifications/notifications.service.ts
+++ b/apps/api/src/modules/notifications/notifications.service.ts
@@ -98,7 +98,7 @@ export class NotificationsService {
 
     const prefsMap = await this.fetchPrefsMap(userIds);
     // Group rows by effective channel set to minimise dispatchChannels calls
-    const groups = new Map<
+    const groupedByChannel = new Map<
       string,
       { dispatchables: DispatchableNotification[]; channels: NotificationChannel[] }
     >();
@@ -107,11 +107,14 @@ export class NotificationsService {
       const effective = channels.filter((ch) => !disabled.includes(ch));
       if (effective.length === 0) continue;
       const key = [...effective].sort().join(',');
-      if (!groups.has(key)) groups.set(key, { dispatchables: [], channels: effective });
-      groups.get(key)!.dispatchables.push({ id: row.id, userId: row.userId, title, body, url });
+      if (!groupedByChannel.has(key))
+        groupedByChannel.set(key, { dispatchables: [], channels: effective });
+      groupedByChannel
+        .get(key)!
+        .dispatchables.push({ id: row.id, userId: row.userId, title, body, url });
     }
     await Promise.allSettled(
-      Array.from(groups.values()).map((g) =>
+      Array.from(groupedByChannel.values()).map((g) =>
         this.dispatchChannels(g.dispatchables, payload, g.channels),
       ),
     );
@@ -275,10 +278,12 @@ export class NotificationsService {
     for (const row of rows) {
       const enriched = result.get(row.id)!;
       if (groupIdsNeeded.has(enriched.groupId as string)) {
-        enriched.groupName = groupNameMap.get(enriched.groupId as string) ?? '';
+        const name = groupNameMap.get(enriched.groupId as string);
+        if (name !== undefined) enriched.groupName = name;
       }
       if (announcementIdsNeeded.has(enriched.announcementId as string)) {
-        enriched.senderUsername = senderUsernameMap.get(enriched.announcementId as string) ?? '';
+        const username = senderUsernameMap.get(enriched.announcementId as string);
+        if (username !== undefined) enriched.senderUsername = username;
       }
     }
 

--- a/apps/api/src/modules/notifications/notifications.service.ts
+++ b/apps/api/src/modules/notifications/notifications.service.ts
@@ -12,11 +12,15 @@ import { notifications } from '@/modules/notifications/schema/notifications.sche
 import { notificationDeliveries } from '@/modules/notifications/schema/notification-deliveries.schema';
 import { userFcmTokens } from '@/modules/notifications/schema/user-fcm-tokens.schema';
 import { userPreferences } from '@/modules/users/schema/user-preferences.schema';
+import { groups } from '@/modules/groups/schema/groups.schema';
+import { groupAnnouncements } from '@/modules/group-announcements/schema/group-announcements.schema';
+import { users } from '@/modules/users/schema/users.schema';
 import { buildNotificationContent } from './notification-content.builder';
 import { EMAIL_STRATEGY, PUSH_STRATEGY, SMS_STRATEGY } from './notifications.constants';
 import type {
+  DispatchableNotification,
   NotificationChannelStrategy,
-  NotificationRow,
+  RenderedNotification,
 } from './channel-strategies/notification-channel.strategy';
 import type { RegisterFcmTokenDto } from './dto/register-fcm-token.dto';
 import type { DeleteFcmTokenDto } from './dto/delete-fcm-token.dto';
@@ -48,10 +52,10 @@ export class NotificationsService {
     // TODO: replace default with user.preferredLanguage once user language preferences are implemented
     lang: SupportedLanguage = 'es',
   ): Promise<void> {
-    const { title, body } = this.renderContent(type, payload, lang);
-    const [notification] = await this.db
+    const { title, body, url } = this.renderContent(type, payload, lang);
+    const [row] = await this.db
       .insert(notifications)
-      .values({ userId, type, title, body, data: payload })
+      .values({ userId, type, data: payload })
       .returning();
 
     // insert().returning() always yields a row on success — non-null is safe here
@@ -59,7 +63,14 @@ export class NotificationsService {
     const prefsMap = await this.fetchPrefsMap([userId]);
     const disabled = prefsMap.get(userId)?.[type] ?? [];
     const effectiveChannels = channels.filter((ch) => !disabled.includes(ch));
-    await this.dispatchChannels([notification!], payload, effectiveChannels);
+    const dispatchable: DispatchableNotification = {
+      id: row!.id,
+      userId: row!.userId,
+      title,
+      body,
+      url,
+    };
+    await this.dispatchChannels([dispatchable], payload, effectiveChannels);
   }
 
   async notifyMany(
@@ -72,8 +83,8 @@ export class NotificationsService {
   ): Promise<void> {
     if (userIds.length === 0) return;
 
-    const { title, body } = this.renderContent(type, payload, lang);
-    const values = userIds.map((userId) => ({ userId, type, title, body, data: payload }));
+    const { title, body, url } = this.renderContent(type, payload, lang);
+    const values = userIds.map((userId) => ({ userId, type, data: payload }));
 
     // Single batch insert — acceptable at current group/trip scale (~100 members max).
     // If userIds can grow to thousands, chunk into batches of ~500 to avoid Postgres
@@ -87,17 +98,22 @@ export class NotificationsService {
 
     const prefsMap = await this.fetchPrefsMap(userIds);
     // Group rows by effective channel set to minimise dispatchChannels calls
-    const groups = new Map<string, { rows: NotificationRow[]; channels: NotificationChannel[] }>();
+    const groups = new Map<
+      string,
+      { dispatchables: DispatchableNotification[]; channels: NotificationChannel[] }
+    >();
     for (const row of inserted) {
       const disabled = prefsMap.get(row.userId)?.[type] ?? [];
       const effective = channels.filter((ch) => !disabled.includes(ch));
       if (effective.length === 0) continue;
       const key = [...effective].sort().join(',');
-      if (!groups.has(key)) groups.set(key, { rows: [], channels: effective });
-      groups.get(key)!.rows.push(row);
+      if (!groups.has(key)) groups.set(key, { dispatchables: [], channels: effective });
+      groups.get(key)!.dispatchables.push({ id: row.id, userId: row.userId, title, body, url });
     }
     await Promise.allSettled(
-      Array.from(groups.values()).map((g) => this.dispatchChannels(g.rows, payload, g.channels)),
+      Array.from(groups.values()).map((g) =>
+        this.dispatchChannels(g.dispatchables, payload, g.channels),
+      ),
     );
   }
 
@@ -105,7 +121,8 @@ export class NotificationsService {
     userId: string,
     cursor?: string,
     limit = 20,
-  ): Promise<{ items: NotificationRow[]; nextCursor: string | null }> {
+    lang: SupportedLanguage = 'es',
+  ): Promise<{ items: RenderedNotification[]; nextCursor: string | null }> {
     if (cursor !== undefined && isNaN(new Date(cursor).getTime())) {
       throw new BadRequestException('Invalid cursor: must be an ISO 8601 timestamp');
     }
@@ -126,9 +143,21 @@ export class NotificationsService {
       .limit(limit + 1);
 
     const hasMore = rows.length > limit;
-    const items = hasMore ? rows.slice(0, limit) : rows;
-    // hasMore guarantees items is non-empty (length === limit > 0)
-    const nextCursor = hasMore ? items[items.length - 1]!.createdAt.toISOString() : null;
+    const rawItems = hasMore ? rows.slice(0, limit) : rows;
+
+    const enrichedPayloads = await this.enrichPayloads(rawItems);
+
+    const items: RenderedNotification[] = rawItems.map((row) => ({
+      ...row,
+      ...this.renderContent(
+        row.type,
+        enrichedPayloads.get(row.id) ?? ((row.data ?? {}) as Record<string, unknown>),
+        lang,
+      ),
+    }));
+
+    // hasMore guarantees rawItems is non-empty (length === limit > 0)
+    const nextCursor = hasMore ? rawItems[rawItems.length - 1]!.createdAt.toISOString() : null;
 
     return { items, nextCursor };
   }
@@ -187,22 +216,83 @@ export class NotificationsService {
     type: NotificationType,
     payload: Record<string, unknown>,
     lang: SupportedLanguage,
-  ): { title: string; body: string } {
-    const { titleKey, bodyKey, args } = buildNotificationContent(type, payload);
+  ): { title: string; body: string; url: string | null } {
+    const { titleKey, bodyKey, args, url } = buildNotificationContent(type, payload);
     return {
       title: this.i18n.translate(titleKey, { lang, args }),
       body: this.i18n.translate(bodyKey, { lang, args }),
+      url,
     };
   }
 
+  private async enrichPayloads(
+    rows: Array<{ id: string; type: NotificationType; data: unknown }>,
+  ): Promise<Map<string, Record<string, unknown>>> {
+    const result = new Map<string, Record<string, unknown>>();
+
+    const groupIdsNeeded = new Set<string>();
+    const announcementIdsNeeded = new Set<string>();
+
+    for (const row of rows) {
+      const data = (row.data ?? {}) as Record<string, unknown>;
+      result.set(row.id, { ...data });
+
+      if (typeof data.groupId === 'string' && typeof data.groupName !== 'string') {
+        groupIdsNeeded.add(data.groupId);
+      }
+      if (
+        row.type === NotificationType.GROUP_ANNOUNCEMENT &&
+        typeof data.announcementId === 'string' &&
+        typeof data.senderUsername !== 'string'
+      ) {
+        announcementIdsNeeded.add(data.announcementId);
+      }
+    }
+
+    const groupNameMap = new Map<string, string>();
+    const senderUsernameMap = new Map<string, string>();
+
+    await Promise.all([
+      (async () => {
+        if (groupIdsNeeded.size === 0) return;
+        const fetched = await this.db
+          .select({ id: groups.id, name: groups.name })
+          .from(groups)
+          .where(inArray(groups.id, [...groupIdsNeeded]));
+        for (const r of fetched) groupNameMap.set(r.id, r.name);
+      })(),
+      (async () => {
+        if (announcementIdsNeeded.size === 0) return;
+        const fetched = await this.db
+          .select({ id: groupAnnouncements.id, username: users.username })
+          .from(groupAnnouncements)
+          .innerJoin(users, eq(groupAnnouncements.createdBy, users.id))
+          .where(inArray(groupAnnouncements.id, [...announcementIdsNeeded]));
+        for (const r of fetched) senderUsernameMap.set(r.id, r.username);
+      })(),
+    ]);
+
+    for (const row of rows) {
+      const enriched = result.get(row.id)!;
+      if (groupIdsNeeded.has(enriched.groupId as string)) {
+        enriched.groupName = groupNameMap.get(enriched.groupId as string) ?? '';
+      }
+      if (announcementIdsNeeded.has(enriched.announcementId as string)) {
+        enriched.senderUsername = senderUsernameMap.get(enriched.announcementId as string) ?? '';
+      }
+    }
+
+    return result;
+  }
+
   private async dispatchChannels(
-    inserted: NotificationRow[],
+    dispatchables: DispatchableNotification[],
     payload: Record<string, unknown>,
     channels: NotificationChannel[],
   ): Promise<void> {
     if (channels.length === 0) return;
 
-    const deliveryRows = inserted.flatMap((n) =>
+    const deliveryRows = dispatchables.flatMap((n) =>
       channels.map((channel) => ({
         notificationId: n.id,
         channel,
@@ -213,7 +303,7 @@ export class NotificationsService {
     await this.db.insert(notificationDeliveries).values(deliveryRows);
 
     await Promise.allSettled(
-      inserted.flatMap((n) =>
+      dispatchables.flatMap((n) =>
         channels.map((channel) =>
           this.strategies[channel].send(n, payload).catch((err: unknown) => {
             this.logger.error(`Channel ${channel} dispatch failed for notification ${n.id}`, err);

--- a/apps/api/src/modules/notifications/schema/notifications.schema.spec.ts
+++ b/apps/api/src/modules/notifications/schema/notifications.schema.spec.ts
@@ -18,16 +18,7 @@ describe('notifications schema', () => {
     const config = getTableConfig(notifications);
     const columnNames = config.columns.map((c) => c.name);
     expect(columnNames).toEqual(
-      expect.arrayContaining([
-        'id',
-        'user_id',
-        'type',
-        'title',
-        'body',
-        'data',
-        'read_at',
-        'created_at',
-      ]),
+      expect.arrayContaining(['id', 'user_id', 'type', 'data', 'read_at', 'created_at']),
     );
   });
 

--- a/apps/api/src/modules/notifications/schema/notifications.schema.ts
+++ b/apps/api/src/modules/notifications/schema/notifications.schema.ts
@@ -1,5 +1,5 @@
 import { desc, relations } from 'drizzle-orm';
-import { index, jsonb, pgEnum, pgTable, text, timestamp, uuid, varchar } from 'drizzle-orm/pg-core';
+import { index, jsonb, pgEnum, pgTable, timestamp, uuid } from 'drizzle-orm/pg-core';
 
 import { NotificationType } from '@chamuco/shared-types';
 import { users } from '@/modules/users/schema/users.schema';
@@ -25,8 +25,6 @@ export const notifications = pgTable(
       .references(() => users.id, { onDelete: 'cascade' })
       .notNull(),
     type: notificationTypeEnum('type').notNull(),
-    title: varchar('title', { length: 200 }).notNull(),
-    body: text('body').notNull(),
     data: jsonb('data'),
     readAt: timestamp('read_at', { withTimezone: true }),
     createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -83,6 +83,7 @@ ENV NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL
 # Build the Next.js application
 # Next.js collects anonymous telemetry data - disable it
 ENV NEXT_TELEMETRY_DISABLED=1
+ENV NODE_OPTIONS="--max-old-space-size=4096"
 RUN pnpm --filter @chamuco/web build
 
 # ==========================================

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,7 +4,7 @@
   "description": "Chamuco App - Next.js Frontend Application",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "NODE_OPTIONS='--max-old-space-size=8192' next dev --turbopack",
     "prebuild": "node scripts/generate-sw.mjs",
     "build": "next build",
     "start": "next start",

--- a/apps/web/src/components/header/NotificationPanel.test.tsx
+++ b/apps/web/src/components/header/NotificationPanel.test.tsx
@@ -29,8 +29,9 @@ function makeNotification(overrides: Partial<NotificationItem> = {}): Notificati
     type: NotificationType.TRIP_INVITATION,
     title: 'New trip invitation',
     body: 'You have been invited to join Summer Trip 2026.',
+    url: '/trips/trip-1',
     readAt: null,
-    data: { url: '/trips/trip-1' },
+    data: null,
     createdAt: new Date().toISOString(),
     ...overrides,
   };
@@ -130,27 +131,18 @@ describe('NotificationPanel', () => {
       expect(onMarkRead).toHaveBeenCalledWith('notif-abc');
     });
 
-    it('navigates to data.url on row click when url is present', async () => {
+    it('navigates to url on row click when url is present', async () => {
       const user = userEvent.setup();
-      const notif = makeNotification({ data: { url: '/trips/t1' } });
+      const notif = makeNotification({ url: '/groups/g1' });
       renderPanel([notif]);
 
       await user.click(screen.getByText(notif.title));
-      expect(mocks.mockRouterPush).toHaveBeenCalledWith('/trips/t1');
+      expect(mocks.mockRouterPush).toHaveBeenCalledWith('/groups/g1');
     });
 
-    it('does not navigate when data.url is absent', async () => {
+    it('does not navigate when url is null', async () => {
       const user = userEvent.setup();
-      const notif = makeNotification({ data: null });
-      renderPanel([notif]);
-
-      await user.click(screen.getByText(notif.title));
-      expect(mocks.mockRouterPush).not.toHaveBeenCalled();
-    });
-
-    it('does not navigate when data.url is not a string', async () => {
-      const user = userEvent.setup();
-      const notif = makeNotification({ data: { tripId: 'some-id' } });
+      const notif = makeNotification({ url: null });
       renderPanel([notif]);
 
       await user.click(screen.getByText(notif.title));

--- a/apps/web/src/components/header/NotificationPanel.tsx
+++ b/apps/web/src/components/header/NotificationPanel.tsx
@@ -63,9 +63,8 @@ export function NotificationPanel({
 
   function handleItemClick(notif: NotificationItem) {
     onMarkRead(notif.id);
-    const url = typeof notif.data?.url === 'string' ? notif.data.url : null;
-    if (url) {
-      router.push(url);
+    if (notif.url) {
+      router.push(notif.url);
     }
   }
 

--- a/apps/web/src/hooks/useNotifications.test.ts
+++ b/apps/web/src/hooks/useNotifications.test.ts
@@ -16,8 +16,9 @@ function makeNotification(overrides: Partial<NotificationItem> = {}): Notificati
     type: NotificationType.TRIP_INVITATION,
     title: 'New trip invitation',
     body: 'You have been invited to join Summer Trip 2026.',
+    url: '/trips/trip-1',
     readAt: null,
-    data: { url: '/trips/trip-1' },
+    data: null,
     createdAt: new Date().toISOString(),
     ...overrides,
   };
@@ -82,6 +83,20 @@ describe('useNotifications', () => {
 
     unmount();
     vi.useRealTimers();
+  });
+
+  it('re-fetches when chamuco:notification event fires', async () => {
+    const { result } = renderHook(() => useNotifications());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    const callsBefore = mockGet.mock.calls.length;
+
+    await act(async () => {
+      window.dispatchEvent(new window.CustomEvent('chamuco:notification'));
+      await Promise.resolve();
+    });
+
+    expect(mockGet.mock.calls.length).toBeGreaterThan(callsBefore);
   });
 
   it('cancels polling on unmount', async () => {

--- a/apps/web/src/hooks/useNotifications.ts
+++ b/apps/web/src/hooks/useNotifications.ts
@@ -9,6 +9,7 @@ export interface NotificationItem {
   type: NotificationType;
   title: string;
   body: string;
+  url: string | null;
   readAt: string | null;
   data: Record<string, unknown> | null;
   createdAt: string;
@@ -52,9 +53,15 @@ export function useNotifications() {
 
     const intervalId = setInterval(fetchNotifications, POLL_INTERVAL_MS);
 
+    const handleForegroundPush = () => {
+      void fetchNotifications();
+    };
+    window.addEventListener('chamuco:notification', handleForegroundPush);
+
     return () => {
       clearInterval(intervalId);
       abortRef.current?.abort();
+      window.removeEventListener('chamuco:notification', handleForegroundPush);
     };
   }, [fetchNotifications]);
 

--- a/apps/web/src/hooks/usePushNotifications.test.ts
+++ b/apps/web/src/hooks/usePushNotifications.test.ts
@@ -159,6 +159,31 @@ describe('usePushNotifications', () => {
     expect(toast.info).toHaveBeenCalledWith('Hello', 'World');
   });
 
+  it('dispatches chamuco:notification event on foreground message', async () => {
+    vi.mocked(useAuth).mockReturnValue({ currentUser: mockUser } as never);
+    setupBrowserEnv('granted');
+
+    let capturedHandler: ((payload: MessagePayload) => void) | null = null;
+    vi.mocked(onMessage).mockImplementation((_messaging, handler) => {
+      capturedHandler = handler as (payload: MessagePayload) => void;
+      return vi.fn();
+    });
+
+    await act(async () => {
+      renderHook(() => usePushNotifications());
+    });
+
+    const listener = vi.fn();
+    window.addEventListener('chamuco:notification', listener);
+
+    act(() => {
+      capturedHandler?.({ notification: { title: 'Hello' } } as MessagePayload);
+    });
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    window.removeEventListener('chamuco:notification', listener);
+  });
+
   it('uses fallback title when notification has no title', async () => {
     vi.mocked(useAuth).mockReturnValue({ currentUser: mockUser } as never);
     setupBrowserEnv('granted');

--- a/apps/web/src/hooks/usePushNotifications.ts
+++ b/apps/web/src/hooks/usePushNotifications.ts
@@ -46,6 +46,7 @@ export function usePushNotifications(): void {
         const title = payload.notification?.title ?? 'Notification';
         const body = payload.notification?.body;
         toast.info(title, body);
+        window.dispatchEvent(new window.CustomEvent('chamuco:notification'));
       });
     }
 

--- a/package.json
+++ b/package.json
@@ -48,5 +48,5 @@
     "node": ">=22.0.0",
     "pnpm": ">=10.0.0"
   },
-  "packageManager": "pnpm@11.3.0"
+  "packageManager": "pnpm@11.4.0"
 }


### PR DESCRIPTION
## Summary

Three interconnected improvements to the notification system:

**Backend rendering & i18n fix**
- Fixed interpolation syntax: nestjs-i18n uses `string-format` by default, which requires `{key}` (single brace). `{{key}}` is treated as an escape sequence and outputs a literal `{key}` regardless of arguments — all notification and validation templates were using the wrong syntax
- Notifications now render `title`/`body` at dispatch/read time (derived from `type + data`); corresponding DB columns dropped (migration `0024`) — avoids redundant storage and unblocks per-user language support
- Old notifications that were stored without `groupName`/`senderUsername` in the payload are now enriched at read time via batch DB lookups (`enrichPayloads`)

**Deep-link url as a first-class field**
- `buildNotificationContent` now derives `url: string | null` from `type + payload` (same pattern as title/body — single source of truth, no scattered call-site logic)
  - Group events → `/groups/:groupId`
  - Passport events → `/profile/passport`
  - Achievements → `/profile/achievements`
- `url` is threaded through `DispatchableNotification`, `RenderedNotification`, and `NotificationResponseDto` as a top-level field
- FCM push messages now include `webpush.fcmOptions.link` so PWA notification taps navigate automatically
- Call sites (`group-members` ×2, `group-announcements`) no longer inject `url` into the payload — the builder derives it from `groupId` already present

**Frontend**
- `NotificationItem` gains `url: string | null` field
- `handleItemClick` reads `notif.url` directly instead of `notif.data?.url`
- `usePushNotifications` dispatches `chamuco:notification` event on foreground FCM messages so the panel refreshes immediately

**Infrastructure**
- `NODE_OPTIONS=--max-old-space-size=4096` for Next.js CI builds (prevents OOM)
- Cloud Run web deploy: gen2 execution environment, `--no-use-http2`, `--memory=1Gi`
- pnpm bumped to 11.4.0

## Test plan

- [ ] `pnpm --filter api test` — 1027 tests pass
- [ ] `pnpm --filter web test` — 1354 tests pass
- [ ] `GET /v1/notifications` returns `"url": "/groups/<id>"` at top level for group notification types, `null` for types without a target
- [ ] FCM push for a group event includes `webpush.fcmOptions.link` in the multicast message
- [ ] Clicking a notification in the panel navigates to the url and marks it read

🤖 Generated with [Claude Code](https://claude.com/claude-code)