### PR TITLE
refactor(ui): standardize action buttons to iconic pattern

### DIFF
--- a/apps/api/src/database/seeds/seed-dev.ts
+++ b/apps/api/src/database/seeds/seed-dev.ts
@@ -133,7 +133,7 @@ async function seedDev(): Promise<void> {
       .values(
         AVATAR_ASSET_IDS.map((id) => ({
           id,
-          type: 'text' as const,
+          type: 'image' as const,
           source: 'emoji' as const,
           target: '🤖',
           isPublic: true,
@@ -148,7 +148,7 @@ async function seedDev(): Promise<void> {
       .values(
         COVER_ASSET_IDS.map((id) => ({
           id,
-          type: 'text' as const,
+          type: 'image' as const,
           source: 'emoji' as const,
           target: '🤖',
           isPublic: true,

--- a/apps/api/src/modules/feedback/feedback.controller.ts
+++ b/apps/api/src/modules/feedback/feedback.controller.ts
@@ -15,11 +15,12 @@ export class FeedbackController {
 
   @Post()
   @HttpCode(201)
-  @Throttle({ default: { ttl: 86_400_000, limit: 3 } })
+  // TODO: revert limit to 3 after testing phase
+  @Throttle({ default: { ttl: 86_400_000, limit: 50 } })
   @ApiOperation({
     summary: 'Submit user feedback',
     description:
-      'Creates a GitHub issue with the user comment. Limited to 3 submissions per user per 24 hours.',
+      'Creates a GitHub issue with the user comment. Limited to 50 submissions per user per 24 hours.',
   })
   @ApiResponse({
     status: 201,
@@ -29,7 +30,7 @@ export class FeedbackController {
   @ApiResponse({ status: 400, description: 'Validation error — comment too short or too long.' })
   @ApiResponse({
     status: 429,
-    description: 'Rate limit exceeded — max 3 submissions per 24 hours.',
+    description: 'Rate limit exceeded — max 50 submissions per 24 hours.',
   })
   @ApiResponse({ status: 503, description: 'GitHub API unavailable.' })
   async create(

--- a/apps/web/src/app/groups/[id]/announcements/page.test.tsx
+++ b/apps/web/src/app/groups/[id]/announcements/page.test.tsx
@@ -59,6 +59,7 @@ vi.mock('@/hooks/useUser', () => ({
 vi.mock('@phosphor-icons/react', () => ({
   ArrowLeftIcon: () => <span data-testid="arrow-left-icon" />,
   MegaphoneIcon: () => <span data-testid="megaphone-icon" />,
+  PlusIcon: () => <span data-testid="plus-icon" />,
 }));
 
 vi.mock('@/components/ui/announcement-card', () => ({
@@ -196,7 +197,7 @@ describe('GroupAnnouncementsPage', () => {
     render(<GroupAnnouncementsPage params={Promise.resolve({ id: 'group-id' })} />);
 
     await waitFor(() => {
-      const link = screen.getByRole('link', { name: 'announcementsNewButton' });
+      const link = screen.getByRole('link', { name: 'announcementsSubmit' });
       expect(link).toBeInTheDocument();
       expect(link).toHaveAttribute('href', '/groups/group-id/announcements/new');
     });
@@ -207,9 +208,7 @@ describe('GroupAnnouncementsPage', () => {
     render(<GroupAnnouncementsPage params={Promise.resolve({ id: 'group-id' })} />);
 
     await waitFor(() => {
-      expect(
-        screen.queryByRole('link', { name: 'announcementsNewButton' }),
-      ).not.toBeInTheDocument();
+      expect(screen.queryByRole('link', { name: 'announcementsSubmit' })).not.toBeInTheDocument();
     });
   });
 

--- a/apps/web/src/app/groups/[id]/announcements/page.tsx
+++ b/apps/web/src/app/groups/[id]/announcements/page.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useTranslation } from 'react-i18next';
 import { GroupRole } from '@chamuco/shared-types';
-import { ArrowLeftIcon, MegaphoneIcon } from '@phosphor-icons/react';
+import { ArrowLeftIcon, MegaphoneIcon, PlusIcon } from '@phosphor-icons/react';
 
 import { apiClient } from '@/services/api-client';
 import { useAuth } from '@/hooks/useAuth';
@@ -103,9 +103,11 @@ export default function GroupAnnouncementsPage({ params }: AnnouncementsPageProp
         {isAdmin && (
           <Link
             href={`/groups/${id}/announcements/new`}
-            className="inline-flex items-center justify-center rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+            className="inline-flex items-center justify-center rounded-lg bg-primary p-2 text-primary-foreground transition-colors hover:bg-primary/90"
+            title={t('announcementsSubmit')}
+            aria-label={t('announcementsSubmit')}
           >
-            {t('announcementsNewButton')}
+            <PlusIcon className="size-5" aria-hidden="true" />
           </Link>
         )}
       </div>

--- a/apps/web/src/app/groups/page.tsx
+++ b/apps/web/src/app/groups/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { useTranslation } from 'react-i18next';
+import { MagnifyingGlassIcon, PlusIcon } from '@phosphor-icons/react';
 
 import { apiClient } from '@/services/api-client';
 import { useAuth } from '@/hooks/useAuth';
@@ -11,7 +12,7 @@ import { InvitationsSection } from '@/components/groups/InvitationsSection';
 import type { Group } from '@/types/group';
 
 export default function GroupsPage() {
-  const { t } = useTranslation('groups');
+  const { t } = useTranslation(['groups', 'common']);
   const { isLoading: isAuthLoading } = useAuth();
   const [groups, setGroups] = useState<Group[]>([]);
   const [isLoading, setIsLoading] = useState(true);
@@ -36,15 +37,19 @@ export default function GroupsPage() {
         <div className="flex items-center gap-2">
           <Link
             href="/explore/groups"
-            className="inline-flex items-center justify-center rounded-lg border border-border px-4 py-2 text-sm font-medium transition-colors hover:bg-muted"
+            className="inline-flex items-center justify-center rounded-lg border border-border bg-background p-2 transition-colors hover:bg-muted"
+            title={t('common:actions.search')}
+            aria-label={t('common:actions.search')}
           >
-            {t('search.searchGroups')}
+            <MagnifyingGlassIcon className="size-5" aria-hidden="true" />
           </Link>
           <Link
             href="/groups/new"
-            className="inline-flex items-center justify-center rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+            className="inline-flex items-center justify-center rounded-lg bg-primary p-2 text-primary-foreground transition-colors hover:bg-primary/90"
+            title={t('common:actions.create')}
+            aria-label={t('common:actions.create')}
           >
-            {t('createGroup')}
+            <PlusIcon className="size-5" aria-hidden="true" />
           </Link>
         </div>
       </div>
@@ -59,7 +64,7 @@ export default function GroupsPage() {
             href="/groups/new"
             className="mt-4 inline-flex items-center justify-center rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
           >
-            {t('createGroup')}
+            {t('common:actions.create')}
           </Link>
         </div>
       ) : (

--- a/apps/web/src/components/groups/members/InvitationResponseButtons.test.tsx
+++ b/apps/web/src/components/groups/members/InvitationResponseButtons.test.tsx
@@ -26,15 +26,15 @@ describe('InvitationResponseButtons', () => {
     render(<InvitationResponseButtons groupId="g1" onSuccess={mocks.mockOnSuccess} />);
 
     expect(screen.getByText('members.invitation.received')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'members.invitation.accept' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'members.invitation.decline' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'common:actions.accept' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'common:actions.decline' })).toBeInTheDocument();
   });
 
   describe('accept', () => {
     it('calls PATCH invitations/accept when accept is clicked', async () => {
       const user = userEvent.setup();
       render(<InvitationResponseButtons groupId="g1" onSuccess={mocks.mockOnSuccess} />);
-      await user.click(screen.getByRole('button', { name: 'members.invitation.accept' }));
+      await user.click(screen.getByRole('button', { name: 'common:actions.accept' }));
 
       await waitFor(() => {
         expect(mocks.mockPatch).toHaveBeenCalledWith('/v1/groups/g1/invitations/accept');
@@ -44,23 +44,23 @@ describe('InvitationResponseButtons', () => {
     it('calls onSuccess after accepting', async () => {
       const user = userEvent.setup();
       render(<InvitationResponseButtons groupId="g1" onSuccess={mocks.mockOnSuccess} />);
-      await user.click(screen.getByRole('button', { name: 'members.invitation.accept' }));
+      await user.click(screen.getByRole('button', { name: 'common:actions.accept' }));
 
       await waitFor(() => {
         expect(mocks.mockOnSuccess).toHaveBeenCalled();
       });
     });
 
-    it('shows accepting label while in flight', async () => {
+    it('disables both buttons while accept is in flight', async () => {
       let resolve!: () => void;
       mocks.mockPatch.mockReturnValue(new Promise<void>((r) => (resolve = r)));
 
       const user = userEvent.setup();
       render(<InvitationResponseButtons groupId="g1" onSuccess={mocks.mockOnSuccess} />);
-      await user.click(screen.getByRole('button', { name: 'members.invitation.accept' }));
+      await user.click(screen.getByRole('button', { name: 'common:actions.accept' }));
 
-      expect(screen.getByRole('button', { name: 'members.invitation.accepting' })).toBeDisabled();
-      expect(screen.getByRole('button', { name: 'members.invitation.decline' })).toBeDisabled();
+      expect(screen.getByRole('button', { name: 'common:actions.accept' })).toBeDisabled();
+      expect(screen.getByRole('button', { name: 'common:actions.decline' })).toBeDisabled();
       resolve();
     });
 
@@ -68,12 +68,12 @@ describe('InvitationResponseButtons', () => {
       mocks.mockPatch.mockRejectedValue(new Error('fail'));
       const user = userEvent.setup();
       render(<InvitationResponseButtons groupId="g1" onSuccess={mocks.mockOnSuccess} />);
-      await user.click(screen.getByRole('button', { name: 'members.invitation.accept' }));
+      await user.click(screen.getByRole('button', { name: 'common:actions.accept' }));
 
       await waitFor(() => {
         expect(screen.getByText('members.invitation.acceptError')).toBeInTheDocument();
       });
-      expect(screen.getByRole('button', { name: 'members.invitation.accept' })).not.toBeDisabled();
+      expect(screen.getByRole('button', { name: 'common:actions.accept' })).not.toBeDisabled();
     });
   });
 
@@ -81,7 +81,7 @@ describe('InvitationResponseButtons', () => {
     it('calls PATCH invitations/decline when decline is clicked', async () => {
       const user = userEvent.setup();
       render(<InvitationResponseButtons groupId="g1" onSuccess={mocks.mockOnSuccess} />);
-      await user.click(screen.getByRole('button', { name: 'members.invitation.decline' }));
+      await user.click(screen.getByRole('button', { name: 'common:actions.decline' }));
 
       await waitFor(() => {
         expect(mocks.mockPatch).toHaveBeenCalledWith('/v1/groups/g1/invitations/decline');
@@ -91,23 +91,23 @@ describe('InvitationResponseButtons', () => {
     it('calls onSuccess after declining', async () => {
       const user = userEvent.setup();
       render(<InvitationResponseButtons groupId="g1" onSuccess={mocks.mockOnSuccess} />);
-      await user.click(screen.getByRole('button', { name: 'members.invitation.decline' }));
+      await user.click(screen.getByRole('button', { name: 'common:actions.decline' }));
 
       await waitFor(() => {
         expect(mocks.mockOnSuccess).toHaveBeenCalled();
       });
     });
 
-    it('shows declining label while in flight', async () => {
+    it('disables both buttons while decline is in flight', async () => {
       let resolve!: () => void;
       mocks.mockPatch.mockReturnValue(new Promise<void>((r) => (resolve = r)));
 
       const user = userEvent.setup();
       render(<InvitationResponseButtons groupId="g1" onSuccess={mocks.mockOnSuccess} />);
-      await user.click(screen.getByRole('button', { name: 'members.invitation.decline' }));
+      await user.click(screen.getByRole('button', { name: 'common:actions.decline' }));
 
-      expect(screen.getByRole('button', { name: 'members.invitation.declining' })).toBeDisabled();
-      expect(screen.getByRole('button', { name: 'members.invitation.accept' })).toBeDisabled();
+      expect(screen.getByRole('button', { name: 'common:actions.decline' })).toBeDisabled();
+      expect(screen.getByRole('button', { name: 'common:actions.accept' })).toBeDisabled();
       resolve();
     });
 
@@ -115,12 +115,12 @@ describe('InvitationResponseButtons', () => {
       mocks.mockPatch.mockRejectedValue(new Error('fail'));
       const user = userEvent.setup();
       render(<InvitationResponseButtons groupId="g1" onSuccess={mocks.mockOnSuccess} />);
-      await user.click(screen.getByRole('button', { name: 'members.invitation.decline' }));
+      await user.click(screen.getByRole('button', { name: 'common:actions.decline' }));
 
       await waitFor(() => {
         expect(screen.getByText('members.invitation.declineError')).toBeInTheDocument();
       });
-      expect(screen.getByRole('button', { name: 'members.invitation.decline' })).not.toBeDisabled();
+      expect(screen.getByRole('button', { name: 'common:actions.decline' })).not.toBeDisabled();
     });
   });
 });

--- a/apps/web/src/components/groups/members/InvitationResponseButtons.tsx
+++ b/apps/web/src/components/groups/members/InvitationResponseButtons.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { CheckIcon, XIcon } from '@phosphor-icons/react';
 import { apiClient } from '@/services/api-client';
 import { Button } from '@/components/ui/button';
 
@@ -16,7 +17,7 @@ export function InvitationResponseButtons({
   onSuccess,
   showMessage = true,
 }: InvitationResponseButtonsProps) {
-  const { t } = useTranslation('groups');
+  const { t } = useTranslation(['groups', 'common']);
   const [isAccepting, setIsAccepting] = useState(false);
   const [isDeclining, setIsDeclining] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -53,11 +54,24 @@ export function InvitationResponseButtons({
         <p className="text-sm text-muted-foreground">{t('members.invitation.received')}</p>
       )}
       <div className="flex gap-2">
-        <Button variant="outline" size="sm" onClick={handleDecline} disabled={isBusy}>
-          {isDeclining ? t('members.invitation.declining') : t('members.invitation.decline')}
+        <Button
+          size="icon"
+          onClick={handleAccept}
+          disabled={isBusy}
+          title={t('common:actions.accept')}
+          aria-label={t('common:actions.accept')}
+        >
+          <CheckIcon aria-hidden="true" />
         </Button>
-        <Button size="sm" onClick={handleAccept} disabled={isBusy}>
-          {isAccepting ? t('members.invitation.accepting') : t('members.invitation.accept')}
+        <Button
+          variant="outline"
+          size="icon"
+          onClick={handleDecline}
+          disabled={isBusy}
+          title={t('common:actions.decline')}
+          aria-label={t('common:actions.decline')}
+        >
+          <XIcon aria-hidden="true" />
         </Button>
       </div>
       {error && <p className="text-xs text-destructive">{error}</p>}

--- a/apps/web/src/components/profile/EmergencyContactsSection.test.tsx
+++ b/apps/web/src/components/profile/EmergencyContactsSection.test.tsx
@@ -144,29 +144,29 @@ describe('EmergencyContactsSection', () => {
 
     it('renders Add contact button', () => {
       setup();
-      expect(screen.getByRole('button', { name: 'emergencyContacts.add' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'common:actions.create' })).toBeInTheDocument();
     });
   });
 
   describe('adding a contact', () => {
     it('shows add form when Add button is clicked', async () => {
       const { user } = setup();
-      await user.click(screen.getByRole('button', { name: 'emergencyContacts.add' }));
+      await user.click(screen.getByRole('button', { name: 'common:actions.create' }));
       expect(screen.getByLabelText('emergencyContacts.fullName')).toBeInTheDocument();
       expect(screen.getByLabelText('emergencyContacts.relationship')).toBeInTheDocument();
     });
 
     it('hides Add button while add form is open', async () => {
       const { user } = setup();
-      await user.click(screen.getByRole('button', { name: 'emergencyContacts.add' }));
+      await user.click(screen.getByRole('button', { name: 'common:actions.create' }));
       expect(
-        screen.queryByRole('button', { name: 'emergencyContacts.add' }),
+        screen.queryByRole('button', { name: 'common:actions.create' }),
       ).not.toBeInTheDocument();
     });
 
     it('calls POST /users/me/emergency-contacts with form values on submit', async () => {
       const { user } = setup([]);
-      await user.click(screen.getByRole('button', { name: 'emergencyContacts.add' }));
+      await user.click(screen.getByRole('button', { name: 'common:actions.create' }));
       await user.type(screen.getByLabelText('emergencyContacts.fullName'), 'Ana López');
       await user.type(screen.getByLabelText('emergencyContacts.phoneNumber'), '3009876543');
       await user.type(screen.getByLabelText('emergencyContacts.relationship'), 'Sister');
@@ -185,7 +185,7 @@ describe('EmergencyContactsSection', () => {
 
     it('strips internal spaces from phone number before POST', async () => {
       const { user } = setup([]);
-      await user.click(screen.getByRole('button', { name: 'emergencyContacts.add' }));
+      await user.click(screen.getByRole('button', { name: 'common:actions.create' }));
       await user.type(screen.getByLabelText('emergencyContacts.fullName'), 'Ana López');
       await user.type(screen.getByLabelText('emergencyContacts.phoneNumber'), '300 987 6543');
       await user.type(screen.getByLabelText('emergencyContacts.relationship'), 'Sister');
@@ -204,13 +204,13 @@ describe('EmergencyContactsSection', () => {
 
     it('defaults isPrimary to true when list is empty', async () => {
       const { user } = setup([]);
-      await user.click(screen.getByRole('button', { name: 'emergencyContacts.add' }));
+      await user.click(screen.getByRole('button', { name: 'common:actions.create' }));
       expect(screen.getByRole('checkbox', { name: 'emergencyContacts.isPrimary' })).toBeChecked();
     });
 
     it('defaults isPrimary to false when list is non-empty', async () => {
       const { user } = setup();
-      await user.click(screen.getByRole('button', { name: 'emergencyContacts.add' }));
+      await user.click(screen.getByRole('button', { name: 'common:actions.create' }));
       expect(
         screen.getByRole('checkbox', { name: 'emergencyContacts.isPrimary' }),
       ).not.toBeChecked();
@@ -218,7 +218,7 @@ describe('EmergencyContactsSection', () => {
 
     it('calls onRefresh after adding', async () => {
       const { user, onRefresh } = setup([]);
-      await user.click(screen.getByRole('button', { name: 'emergencyContacts.add' }));
+      await user.click(screen.getByRole('button', { name: 'common:actions.create' }));
       await user.type(screen.getByLabelText('emergencyContacts.fullName'), 'Ana López');
       await user.type(screen.getByLabelText('emergencyContacts.phoneNumber'), '3009876543');
       await user.type(screen.getByLabelText('emergencyContacts.relationship'), 'Sister');
@@ -228,7 +228,7 @@ describe('EmergencyContactsSection', () => {
 
     it('shows success toast on add', async () => {
       const { user } = setup([]);
-      await user.click(screen.getByRole('button', { name: 'emergencyContacts.add' }));
+      await user.click(screen.getByRole('button', { name: 'common:actions.create' }));
       await user.type(screen.getByLabelText('emergencyContacts.fullName'), 'Ana López');
       await user.type(screen.getByLabelText('emergencyContacts.phoneNumber'), '3009876543');
       await user.type(screen.getByLabelText('emergencyContacts.relationship'), 'Sister');
@@ -240,7 +240,7 @@ describe('EmergencyContactsSection', () => {
 
     it('hides add form after successful add', async () => {
       const { user } = setup([]);
-      await user.click(screen.getByRole('button', { name: 'emergencyContacts.add' }));
+      await user.click(screen.getByRole('button', { name: 'common:actions.create' }));
       await user.type(screen.getByLabelText('emergencyContacts.fullName'), 'Ana López');
       await user.type(screen.getByLabelText('emergencyContacts.phoneNumber'), '3009876543');
       await user.type(screen.getByLabelText('emergencyContacts.relationship'), 'Sister');
@@ -252,7 +252,7 @@ describe('EmergencyContactsSection', () => {
 
     it('cancels add form when Cancel is clicked', async () => {
       const { user } = setup();
-      await user.click(screen.getByRole('button', { name: 'emergencyContacts.add' }));
+      await user.click(screen.getByRole('button', { name: 'common:actions.create' }));
       await user.click(screen.getByRole('button', { name: 'emergencyContacts.cancel' }));
       expect(screen.queryByLabelText('emergencyContacts.fullName')).not.toBeInTheDocument();
     });
@@ -260,7 +260,7 @@ describe('EmergencyContactsSection', () => {
     it('shows error toast when add fails', async () => {
       mocks.mockPost.mockRejectedValue(new Error('network error'));
       const { user } = setup([]);
-      await user.click(screen.getByRole('button', { name: 'emergencyContacts.add' }));
+      await user.click(screen.getByRole('button', { name: 'common:actions.create' }));
       await user.type(screen.getByLabelText('emergencyContacts.fullName'), 'Ana López');
       await user.type(screen.getByLabelText('emergencyContacts.phoneNumber'), '3009876543');
       await user.type(screen.getByLabelText('emergencyContacts.relationship'), 'Sister');
@@ -274,7 +274,7 @@ describe('EmergencyContactsSection', () => {
   describe('form validation', () => {
     it('shows fullName error when name is empty', async () => {
       const { user } = setup([]);
-      await user.click(screen.getByRole('button', { name: 'emergencyContacts.add' }));
+      await user.click(screen.getByRole('button', { name: 'common:actions.create' }));
       await user.type(screen.getByLabelText('emergencyContacts.phoneNumber'), '3009876543');
       await user.type(screen.getByLabelText('emergencyContacts.relationship'), 'Sister');
       await user.click(screen.getByRole('button', { name: 'emergencyContacts.save' }));
@@ -284,7 +284,7 @@ describe('EmergencyContactsSection', () => {
 
     it('shows relationship error when relationship is empty', async () => {
       const { user } = setup([]);
-      await user.click(screen.getByRole('button', { name: 'emergencyContacts.add' }));
+      await user.click(screen.getByRole('button', { name: 'common:actions.create' }));
       await user.type(screen.getByLabelText('emergencyContacts.fullName'), 'Ana López');
       await user.type(screen.getByLabelText('emergencyContacts.phoneNumber'), '3009876543');
       await user.click(screen.getByRole('button', { name: 'emergencyContacts.save' }));
@@ -294,7 +294,7 @@ describe('EmergencyContactsSection', () => {
 
     it('shows phone required error when phone is empty', async () => {
       const { user } = setup([]);
-      await user.click(screen.getByRole('button', { name: 'emergencyContacts.add' }));
+      await user.click(screen.getByRole('button', { name: 'common:actions.create' }));
       await user.type(screen.getByLabelText('emergencyContacts.fullName'), 'Ana López');
       await user.type(screen.getByLabelText('emergencyContacts.relationship'), 'Sister');
       await user.click(screen.getByRole('button', { name: 'emergencyContacts.save' }));
@@ -305,7 +305,7 @@ describe('EmergencyContactsSection', () => {
     it('shows invalid phone error when phone fails validation', async () => {
       mocks.mockIsValidPhoneNumber.mockReturnValue(false);
       const { user } = setup([]);
-      await user.click(screen.getByRole('button', { name: 'emergencyContacts.add' }));
+      await user.click(screen.getByRole('button', { name: 'common:actions.create' }));
       await user.type(screen.getByLabelText('emergencyContacts.fullName'), 'Ana López');
       await user.type(screen.getByLabelText('emergencyContacts.phoneNumber'), '123');
       await user.type(screen.getByLabelText('emergencyContacts.relationship'), 'Sister');
@@ -316,7 +316,7 @@ describe('EmergencyContactsSection', () => {
 
     it('shows fullNameInvalid error when name contains special characters', async () => {
       const { user } = setup([]);
-      await user.click(screen.getByRole('button', { name: 'emergencyContacts.add' }));
+      await user.click(screen.getByRole('button', { name: 'common:actions.create' }));
       await user.type(screen.getByLabelText('emergencyContacts.fullName'), 'Ana123!');
       await user.type(screen.getByLabelText('emergencyContacts.phoneNumber'), '3009876543');
       await user.type(screen.getByLabelText('emergencyContacts.relationship'), 'Sister');
@@ -327,7 +327,7 @@ describe('EmergencyContactsSection', () => {
 
     it('shows relationshipInvalid error when relationship contains special characters', async () => {
       const { user } = setup([]);
-      await user.click(screen.getByRole('button', { name: 'emergencyContacts.add' }));
+      await user.click(screen.getByRole('button', { name: 'common:actions.create' }));
       await user.type(screen.getByLabelText('emergencyContacts.fullName'), 'Ana López');
       await user.type(screen.getByLabelText('emergencyContacts.phoneNumber'), '3009876543');
       await user.type(screen.getByLabelText('emergencyContacts.relationship'), 'Sis@ter!');
@@ -338,7 +338,7 @@ describe('EmergencyContactsSection', () => {
 
     it('shows relationshipRequired error when relationship is one character', async () => {
       const { user } = setup([]);
-      await user.click(screen.getByRole('button', { name: 'emergencyContacts.add' }));
+      await user.click(screen.getByRole('button', { name: 'common:actions.create' }));
       await user.type(screen.getByLabelText('emergencyContacts.fullName'), 'Ana López');
       await user.type(screen.getByLabelText('emergencyContacts.phoneNumber'), '3009876543');
       await user.type(screen.getByLabelText('emergencyContacts.relationship'), 'A');
@@ -349,7 +349,7 @@ describe('EmergencyContactsSection', () => {
 
     it('accepts accented characters in fullName and relationship', async () => {
       const { user } = setup([]);
-      await user.click(screen.getByRole('button', { name: 'emergencyContacts.add' }));
+      await user.click(screen.getByRole('button', { name: 'common:actions.create' }));
       await user.type(screen.getByLabelText('emergencyContacts.fullName'), 'María José');
       await user.type(screen.getByLabelText('emergencyContacts.phoneNumber'), '3009876543');
       await user.type(screen.getByLabelText('emergencyContacts.relationship'), 'Hermana');
@@ -535,7 +535,7 @@ describe('EmergencyContactsSection', () => {
   describe('input constraints', () => {
     it('sets maxLength 100 on fullName input in add form', async () => {
       const { user } = setup();
-      await user.click(screen.getByRole('button', { name: 'emergencyContacts.add' }));
+      await user.click(screen.getByRole('button', { name: 'common:actions.create' }));
       expect(screen.getByLabelText('emergencyContacts.fullName')).toHaveAttribute(
         'maxLength',
         '100',
@@ -544,7 +544,7 @@ describe('EmergencyContactsSection', () => {
 
     it('sets maxLength 50 on relationship input in add form', async () => {
       const { user } = setup();
-      await user.click(screen.getByRole('button', { name: 'emergencyContacts.add' }));
+      await user.click(screen.getByRole('button', { name: 'common:actions.create' }));
       expect(screen.getByLabelText('emergencyContacts.relationship')).toHaveAttribute(
         'maxLength',
         '50',
@@ -575,7 +575,7 @@ describe('EmergencyContactsSection', () => {
   describe('isPrimary toggle', () => {
     it('sends isPrimary: true when checkbox is checked on add', async () => {
       const { user } = setup();
-      await user.click(screen.getByRole('button', { name: 'emergencyContacts.add' }));
+      await user.click(screen.getByRole('button', { name: 'common:actions.create' }));
       await user.type(screen.getByLabelText('emergencyContacts.fullName'), 'Carlos Pérez');
       await user.type(screen.getByLabelText('emergencyContacts.phoneNumber'), '3009876543');
       await user.type(screen.getByLabelText('emergencyContacts.relationship'), 'Father');

--- a/apps/web/src/components/profile/EmergencyContactsSection.tsx
+++ b/apps/web/src/components/profile/EmergencyContactsSection.tsx
@@ -3,6 +3,7 @@
 import { useState, type SubmitEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 import { getCountryDataList } from 'countries-list';
+import { PlusIcon } from '@phosphor-icons/react';
 
 import { Button } from '@/components/ui/button';
 import { EditDeleteActions } from '@/components/ui/edit-delete-actions';
@@ -189,7 +190,7 @@ interface EmergencyContactsSectionProps {
 }
 
 export function EmergencyContactsSection({ contacts, onRefresh }: EmergencyContactsSectionProps) {
-  const { t } = useTranslation('profile');
+  const { t } = useTranslation(['profile', 'common']);
 
   const [editingId, setEditingId] = useState<string | null>(null);
   const [isAdding, setIsAdding] = useState(false);
@@ -358,7 +359,21 @@ export function EmergencyContactsSection({ contacts, onRefresh }: EmergencyConta
 
   return (
     <div className="max-w-lg space-y-6">
-      <h2 className="text-xl font-semibold">{t('emergencyContacts.heading')}</h2>
+      <div className="flex items-center justify-between">
+        <h2 className="text-xl font-semibold">{t('emergencyContacts.heading')}</h2>
+        {!isAdding && (
+          <Button
+            type="button"
+            size="icon"
+            onClick={startAdd}
+            disabled={isSaving}
+            title={t('common:actions.create')}
+            aria-label={t('common:actions.create')}
+          >
+            <PlusIcon aria-hidden="true" />
+          </Button>
+        )}
+      </div>
 
       {contacts.length === 0 && !isAdding && (
         <p className="text-sm text-muted-foreground">{t('emergencyContacts.empty')}</p>
@@ -422,12 +437,6 @@ export function EmergencyContactsSection({ contacts, onRefresh }: EmergencyConta
           onCancel={cancelAdd}
           saveLabel={t('emergencyContacts.save')}
         />
-      )}
-
-      {!isAdding && (
-        <Button type="button" variant="outline" onClick={startAdd} disabled={isSaving}>
-          {t('emergencyContacts.add')}
-        </Button>
       )}
     </div>
   );

--- a/apps/web/src/components/profile/LoyaltyProgramsSection.test.tsx
+++ b/apps/web/src/components/profile/LoyaltyProgramsSection.test.tsx
@@ -110,27 +110,29 @@ describe('LoyaltyProgramsSection', () => {
 
     it('renders Add program button', () => {
       setup();
-      expect(screen.getByRole('button', { name: 'loyaltyPrograms.add' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'common:actions.create' })).toBeInTheDocument();
     });
   });
 
   describe('adding a program', () => {
     it('shows add form when Add button is clicked', async () => {
       const { user } = setup();
-      await user.click(screen.getByRole('button', { name: 'loyaltyPrograms.add' }));
+      await user.click(screen.getByRole('button', { name: 'common:actions.create' }));
       expect(screen.getByLabelText('loyaltyPrograms.programName')).toBeInTheDocument();
       expect(screen.getByLabelText('loyaltyPrograms.memberId')).toBeInTheDocument();
     });
 
     it('hides Add button while add form is open', async () => {
       const { user } = setup();
-      await user.click(screen.getByRole('button', { name: 'loyaltyPrograms.add' }));
-      expect(screen.queryByRole('button', { name: 'loyaltyPrograms.add' })).not.toBeInTheDocument();
+      await user.click(screen.getByRole('button', { name: 'common:actions.create' }));
+      expect(
+        screen.queryByRole('button', { name: 'common:actions.create' }),
+      ).not.toBeInTheDocument();
     });
 
     it('calls POST /users/me/loyalty-programs with form values on submit', async () => {
       const { user } = setup([]);
-      await user.click(screen.getByRole('button', { name: 'loyaltyPrograms.add' }));
+      await user.click(screen.getByRole('button', { name: 'common:actions.create' }));
       await user.type(screen.getByLabelText('loyaltyPrograms.programName'), 'Avianca');
       await user.type(screen.getByLabelText('loyaltyPrograms.memberId'), 'AV999');
       await user.click(screen.getByRole('button', { name: 'loyaltyPrograms.save' }));
@@ -146,7 +148,7 @@ describe('LoyaltyProgramsSection', () => {
 
     it('calls onRefresh after adding', async () => {
       const { user, onRefresh } = setup([]);
-      await user.click(screen.getByRole('button', { name: 'loyaltyPrograms.add' }));
+      await user.click(screen.getByRole('button', { name: 'common:actions.create' }));
       await user.type(screen.getByLabelText('loyaltyPrograms.programName'), 'Avianca');
       await user.type(screen.getByLabelText('loyaltyPrograms.memberId'), 'AV999');
       await user.click(screen.getByRole('button', { name: 'loyaltyPrograms.save' }));
@@ -155,7 +157,7 @@ describe('LoyaltyProgramsSection', () => {
 
     it('shows success toast on add', async () => {
       const { user } = setup([]);
-      await user.click(screen.getByRole('button', { name: 'loyaltyPrograms.add' }));
+      await user.click(screen.getByRole('button', { name: 'common:actions.create' }));
       await user.type(screen.getByLabelText('loyaltyPrograms.programName'), 'Avianca');
       await user.type(screen.getByLabelText('loyaltyPrograms.memberId'), 'AV999');
       await user.click(screen.getByRole('button', { name: 'loyaltyPrograms.save' }));
@@ -166,7 +168,7 @@ describe('LoyaltyProgramsSection', () => {
 
     it('hides add form after successful add', async () => {
       const { user } = setup([]);
-      await user.click(screen.getByRole('button', { name: 'loyaltyPrograms.add' }));
+      await user.click(screen.getByRole('button', { name: 'common:actions.create' }));
       await user.type(screen.getByLabelText('loyaltyPrograms.programName'), 'Avianca');
       await user.type(screen.getByLabelText('loyaltyPrograms.memberId'), 'AV999');
       await user.click(screen.getByRole('button', { name: 'loyaltyPrograms.save' }));
@@ -177,7 +179,7 @@ describe('LoyaltyProgramsSection', () => {
 
     it('cancels add form when Cancel is clicked', async () => {
       const { user } = setup();
-      await user.click(screen.getByRole('button', { name: 'loyaltyPrograms.add' }));
+      await user.click(screen.getByRole('button', { name: 'common:actions.create' }));
       await user.click(screen.getByRole('button', { name: 'loyaltyPrograms.cancel' }));
       expect(screen.queryByLabelText('loyaltyPrograms.programName')).not.toBeInTheDocument();
     });
@@ -185,7 +187,7 @@ describe('LoyaltyProgramsSection', () => {
     it('shows error toast when add fails', async () => {
       mocks.mockPost.mockRejectedValue(new Error('network error'));
       const { user } = setup([]);
-      await user.click(screen.getByRole('button', { name: 'loyaltyPrograms.add' }));
+      await user.click(screen.getByRole('button', { name: 'common:actions.create' }));
       await user.type(screen.getByLabelText('loyaltyPrograms.programName'), 'Avianca');
       await user.type(screen.getByLabelText('loyaltyPrograms.memberId'), 'AV999');
       await user.click(screen.getByRole('button', { name: 'loyaltyPrograms.save' }));
@@ -196,7 +198,7 @@ describe('LoyaltyProgramsSection', () => {
 
     it('includes notes in POST payload when notes are entered', async () => {
       const { user } = setup([]);
-      await user.click(screen.getByRole('button', { name: 'loyaltyPrograms.add' }));
+      await user.click(screen.getByRole('button', { name: 'common:actions.create' }));
       await user.type(screen.getByLabelText('loyaltyPrograms.programName'), 'Avianca');
       await user.type(screen.getByLabelText('loyaltyPrograms.memberId'), 'AV999');
       await user.type(screen.getByLabelText('loyaltyPrograms.notes'), 'Silver tier');
@@ -338,7 +340,7 @@ describe('LoyaltyProgramsSection', () => {
   describe('input constraints', () => {
     it('sets maxLength 100 on programName input in add form', async () => {
       const { user } = setup();
-      await user.click(screen.getByRole('button', { name: 'loyaltyPrograms.add' }));
+      await user.click(screen.getByRole('button', { name: 'common:actions.create' }));
       expect(screen.getByLabelText('loyaltyPrograms.programName')).toHaveAttribute(
         'maxLength',
         '100',
@@ -347,7 +349,7 @@ describe('LoyaltyProgramsSection', () => {
 
     it('sets maxLength 100 on memberId input in add form', async () => {
       const { user } = setup();
-      await user.click(screen.getByRole('button', { name: 'loyaltyPrograms.add' }));
+      await user.click(screen.getByRole('button', { name: 'common:actions.create' }));
       expect(screen.getByLabelText('loyaltyPrograms.memberId')).toHaveAttribute('maxLength', '100');
     });
 

--- a/apps/web/src/components/profile/LoyaltyProgramsSection.tsx
+++ b/apps/web/src/components/profile/LoyaltyProgramsSection.tsx
@@ -2,6 +2,7 @@
 
 import { useState, type SubmitEvent } from 'react';
 import { useTranslation } from 'react-i18next';
+import { PlusIcon } from '@phosphor-icons/react';
 
 import { Button } from '@/components/ui/button';
 import { EditDeleteActions } from '@/components/ui/edit-delete-actions';
@@ -105,7 +106,7 @@ function ProgramForm({
 }
 
 export function LoyaltyProgramsSection({ programs, onRefresh }: LoyaltyProgramsSectionProps) {
-  const { t } = useTranslation('profile');
+  const { t } = useTranslation(['profile', 'common']);
 
   const [editingId, setEditingId] = useState<string | null>(null);
   const [isAdding, setIsAdding] = useState(false);
@@ -214,7 +215,21 @@ export function LoyaltyProgramsSection({ programs, onRefresh }: LoyaltyProgramsS
 
   return (
     <div className="space-y-6 max-w-lg">
-      <h2 className="text-xl font-semibold">{t('loyaltyPrograms.heading')}</h2>
+      <div className="flex items-center justify-between">
+        <h2 className="text-xl font-semibold">{t('loyaltyPrograms.heading')}</h2>
+        {!isAdding && (
+          <Button
+            type="button"
+            size="icon"
+            onClick={startAdd}
+            disabled={isSaving}
+            title={t('common:actions.create')}
+            aria-label={t('common:actions.create')}
+          >
+            <PlusIcon aria-hidden="true" />
+          </Button>
+        )}
+      </div>
 
       {programs.length === 0 && !isAdding && (
         <p className="text-sm text-muted-foreground">{t('loyaltyPrograms.empty')}</p>
@@ -273,12 +288,6 @@ export function LoyaltyProgramsSection({ programs, onRefresh }: LoyaltyProgramsS
           onCancel={cancelAdd}
           saveLabel={t('loyaltyPrograms.save')}
         />
-      )}
-
-      {!isAdding && (
-        <Button type="button" variant="outline" onClick={startAdd} disabled={isSaving}>
-          {t('loyaltyPrograms.add')}
-        </Button>
       )}
     </div>
   );

--- a/apps/web/src/components/profile/NationalitiesSection.test.tsx
+++ b/apps/web/src/components/profile/NationalitiesSection.test.tsx
@@ -189,26 +189,28 @@ describe('NationalitiesSection', () => {
 
     it('renders Add button', () => {
       setup();
-      expect(screen.getByRole('button', { name: 'nationalities.add' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'common:actions.create' })).toBeInTheDocument();
     });
   });
 
   describe('adding a nationality', () => {
     it('shows add form when Add button is clicked', async () => {
       const { user } = setup();
-      await user.click(screen.getByRole('button', { name: 'nationalities.add' }));
+      await user.click(screen.getByRole('button', { name: 'common:actions.create' }));
       expect(screen.getByLabelText('nationalities.nationalIdNumber')).toBeInTheDocument();
     });
 
     it('hides Add button while add form is open', async () => {
       const { user } = setup();
-      await user.click(screen.getByRole('button', { name: 'nationalities.add' }));
-      expect(screen.queryByRole('button', { name: 'nationalities.add' })).not.toBeInTheDocument();
+      await user.click(screen.getByRole('button', { name: 'common:actions.create' }));
+      expect(
+        screen.queryByRole('button', { name: 'common:actions.create' }),
+      ).not.toBeInTheDocument();
     });
 
     it('calls POST with correct payload on submit', async () => {
       const { user } = setup([]);
-      await user.click(screen.getByRole('button', { name: 'nationalities.add' }));
+      await user.click(screen.getByRole('button', { name: 'common:actions.create' }));
       await user.selectOptions(screen.getByTestId('add-country'), 'CO');
       await user.type(screen.getByLabelText('nationalities.nationalIdNumber'), '9876543210');
       await user.click(screen.getByRole('button', { name: 'nationalities.save' }));
@@ -226,7 +228,7 @@ describe('NationalitiesSection', () => {
 
     it('calls POST with passport fields when all three provided', async () => {
       const { user } = setup([]);
-      await user.click(screen.getByRole('button', { name: 'nationalities.add' }));
+      await user.click(screen.getByRole('button', { name: 'common:actions.create' }));
       await user.selectOptions(screen.getByTestId('add-country'), 'CO');
       await user.type(screen.getByLabelText('nationalities.passportNumber'), 'AB123456');
       await user.type(screen.getByLabelText('nationalities.passportExpiryDate'), '2030-01-15');
@@ -246,14 +248,14 @@ describe('NationalitiesSection', () => {
 
     it('auto-fills expiry date to issue date + 10 years when expiry is empty', async () => {
       const { user } = setup([]);
-      await user.click(screen.getByRole('button', { name: 'nationalities.add' }));
+      await user.click(screen.getByRole('button', { name: 'common:actions.create' }));
       await user.type(screen.getByLabelText('nationalities.passportIssueDate'), '2020-01-15');
       expect(screen.getByLabelText('nationalities.passportExpiryDate')).toHaveValue('2030-01-15');
     });
 
     it('does not overwrite expiry date when already set', async () => {
       const { user } = setup([]);
-      await user.click(screen.getByRole('button', { name: 'nationalities.add' }));
+      await user.click(screen.getByRole('button', { name: 'common:actions.create' }));
       await user.type(screen.getByLabelText('nationalities.passportExpiryDate'), '2025-06-01');
       await user.type(screen.getByLabelText('nationalities.passportIssueDate'), '2020-01-15');
       expect(screen.getByLabelText('nationalities.passportExpiryDate')).toHaveValue('2025-06-01');
@@ -261,13 +263,13 @@ describe('NationalitiesSection', () => {
 
     it('defaults isPrimary to true when list is empty', async () => {
       const { user } = setup([]);
-      await user.click(screen.getByRole('button', { name: 'nationalities.add' }));
+      await user.click(screen.getByRole('button', { name: 'common:actions.create' }));
       expect(screen.getByRole('checkbox', { name: 'nationalities.primaryBadge' })).toBeChecked();
     });
 
     it('defaults isPrimary to false when list is non-empty', async () => {
       const { user } = setup();
-      await user.click(screen.getByRole('button', { name: 'nationalities.add' }));
+      await user.click(screen.getByRole('button', { name: 'common:actions.create' }));
       expect(
         screen.getByRole('checkbox', { name: 'nationalities.primaryBadge' }),
       ).not.toBeChecked();
@@ -275,7 +277,7 @@ describe('NationalitiesSection', () => {
 
     it('calls onRefresh after adding', async () => {
       const { user, onRefresh } = setup([]);
-      await user.click(screen.getByRole('button', { name: 'nationalities.add' }));
+      await user.click(screen.getByRole('button', { name: 'common:actions.create' }));
       await user.selectOptions(screen.getByTestId('add-country'), 'CO');
       await user.click(screen.getByRole('button', { name: 'nationalities.save' }));
       await waitFor(() => expect(onRefresh).toHaveBeenCalledOnce());
@@ -283,7 +285,7 @@ describe('NationalitiesSection', () => {
 
     it('shows success toast on add', async () => {
       const { user } = setup([]);
-      await user.click(screen.getByRole('button', { name: 'nationalities.add' }));
+      await user.click(screen.getByRole('button', { name: 'common:actions.create' }));
       await user.selectOptions(screen.getByTestId('add-country'), 'CO');
       await user.click(screen.getByRole('button', { name: 'nationalities.save' }));
       await waitFor(() =>
@@ -293,7 +295,7 @@ describe('NationalitiesSection', () => {
 
     it('hides add form after successful add', async () => {
       const { user } = setup([]);
-      await user.click(screen.getByRole('button', { name: 'nationalities.add' }));
+      await user.click(screen.getByRole('button', { name: 'common:actions.create' }));
       await user.selectOptions(screen.getByTestId('add-country'), 'CO');
       await user.click(screen.getByRole('button', { name: 'nationalities.save' }));
       await waitFor(() =>
@@ -303,7 +305,7 @@ describe('NationalitiesSection', () => {
 
     it('cancels add form when Cancel is clicked', async () => {
       const { user } = setup();
-      await user.click(screen.getByRole('button', { name: 'nationalities.add' }));
+      await user.click(screen.getByRole('button', { name: 'common:actions.create' }));
       await user.click(screen.getByRole('button', { name: 'nationalities.cancel' }));
       expect(screen.queryByLabelText('nationalities.nationalIdNumber')).not.toBeInTheDocument();
     });
@@ -311,7 +313,7 @@ describe('NationalitiesSection', () => {
     it('shows error toast when add fails', async () => {
       mocks.mockPost.mockRejectedValue(new Error('network error'));
       const { user } = setup([]);
-      await user.click(screen.getByRole('button', { name: 'nationalities.add' }));
+      await user.click(screen.getByRole('button', { name: 'common:actions.create' }));
       await user.selectOptions(screen.getByTestId('add-country'), 'CO');
       await user.click(screen.getByRole('button', { name: 'nationalities.save' }));
       await waitFor(() =>
@@ -323,7 +325,7 @@ describe('NationalitiesSection', () => {
   describe('form validation', () => {
     it('shows nationalIdFormat error when national ID has spaces', async () => {
       const { user } = setup([]);
-      await user.click(screen.getByRole('button', { name: 'nationalities.add' }));
+      await user.click(screen.getByRole('button', { name: 'common:actions.create' }));
       await user.selectOptions(screen.getByTestId('add-country'), 'CO');
       await user.type(screen.getByLabelText('nationalities.nationalIdNumber'), 'AB 123');
       await user.click(screen.getByRole('button', { name: 'nationalities.save' }));
@@ -333,14 +335,14 @@ describe('NationalitiesSection', () => {
 
     it('auto-uppercases national ID input', async () => {
       const { user } = setup([]);
-      await user.click(screen.getByRole('button', { name: 'nationalities.add' }));
+      await user.click(screen.getByRole('button', { name: 'common:actions.create' }));
       await user.type(screen.getByLabelText('nationalities.nationalIdNumber'), 'ab-123');
       expect(screen.getByLabelText('nationalities.nationalIdNumber')).toHaveValue('AB-123');
     });
 
     it('accepts national ID with hyphens', async () => {
       const { user } = setup([]);
-      await user.click(screen.getByRole('button', { name: 'nationalities.add' }));
+      await user.click(screen.getByRole('button', { name: 'common:actions.create' }));
       await user.selectOptions(screen.getByTestId('add-country'), 'CO');
       await user.type(screen.getByLabelText('nationalities.nationalIdNumber'), 'AB-123');
       await user.click(screen.getByRole('button', { name: 'nationalities.save' }));
@@ -349,7 +351,7 @@ describe('NationalitiesSection', () => {
 
     it('shows nationalIdFormat error when national ID starts with a hyphen', async () => {
       const { user } = setup([]);
-      await user.click(screen.getByRole('button', { name: 'nationalities.add' }));
+      await user.click(screen.getByRole('button', { name: 'common:actions.create' }));
       await user.selectOptions(screen.getByTestId('add-country'), 'CO');
       await user.type(screen.getByLabelText('nationalities.nationalIdNumber'), '-AB123');
       await user.click(screen.getByRole('button', { name: 'nationalities.save' }));
@@ -359,7 +361,7 @@ describe('NationalitiesSection', () => {
 
     it('shows nationalIdFormat error when national ID ends with a hyphen', async () => {
       const { user } = setup([]);
-      await user.click(screen.getByRole('button', { name: 'nationalities.add' }));
+      await user.click(screen.getByRole('button', { name: 'common:actions.create' }));
       await user.selectOptions(screen.getByTestId('add-country'), 'CO');
       await user.type(screen.getByLabelText('nationalities.nationalIdNumber'), 'AB123-');
       await user.click(screen.getByRole('button', { name: 'nationalities.save' }));
@@ -369,13 +371,13 @@ describe('NationalitiesSection', () => {
 
     it('disables save button when no country selected in add form', async () => {
       const { user } = setup([]);
-      await user.click(screen.getByRole('button', { name: 'nationalities.add' }));
+      await user.click(screen.getByRole('button', { name: 'common:actions.create' }));
       expect(screen.getByRole('button', { name: 'nationalities.save' })).toBeDisabled();
     });
 
     it('shows passportIncomplete error when only passport number provided', async () => {
       const { user } = setup([]);
-      await user.click(screen.getByRole('button', { name: 'nationalities.add' }));
+      await user.click(screen.getByRole('button', { name: 'common:actions.create' }));
       await user.selectOptions(screen.getByTestId('add-country'), 'CO');
       await user.type(screen.getByLabelText('nationalities.passportNumber'), 'AB123456');
       await user.click(screen.getByRole('button', { name: 'nationalities.save' }));
@@ -385,7 +387,7 @@ describe('NationalitiesSection', () => {
 
     it('shows passportIncomplete error when only issue date provided', async () => {
       const { user } = setup([]);
-      await user.click(screen.getByRole('button', { name: 'nationalities.add' }));
+      await user.click(screen.getByRole('button', { name: 'common:actions.create' }));
       await user.selectOptions(screen.getByTestId('add-country'), 'CO');
       await user.type(screen.getByLabelText('nationalities.passportIssueDate'), '2020-01-15');
       await user.click(screen.getByRole('button', { name: 'nationalities.save' }));
@@ -395,7 +397,7 @@ describe('NationalitiesSection', () => {
 
     it('shows expiryBeforeIssue error when expiry <= issue date', async () => {
       const { user } = setup([]);
-      await user.click(screen.getByRole('button', { name: 'nationalities.add' }));
+      await user.click(screen.getByRole('button', { name: 'common:actions.create' }));
       await user.selectOptions(screen.getByTestId('add-country'), 'CO');
       await user.type(screen.getByLabelText('nationalities.passportNumber'), 'AB123456');
       await user.type(screen.getByLabelText('nationalities.passportExpiryDate'), '2020-01-01');
@@ -407,7 +409,7 @@ describe('NationalitiesSection', () => {
 
     it('auto-uppercases passport number input', async () => {
       const { user } = setup([]);
-      await user.click(screen.getByRole('button', { name: 'nationalities.add' }));
+      await user.click(screen.getByRole('button', { name: 'common:actions.create' }));
       await user.selectOptions(screen.getByTestId('add-country'), 'CO');
       await user.type(screen.getByLabelText('nationalities.passportNumber'), 'ab-123456');
       expect(screen.getByLabelText('nationalities.passportNumber')).toHaveValue('AB-123456');
@@ -415,7 +417,7 @@ describe('NationalitiesSection', () => {
 
     it('shows passportFormat error when passport number has spaces', async () => {
       const { user } = setup([]);
-      await user.click(screen.getByRole('button', { name: 'nationalities.add' }));
+      await user.click(screen.getByRole('button', { name: 'common:actions.create' }));
       await user.selectOptions(screen.getByTestId('add-country'), 'CO');
       await user.type(screen.getByLabelText('nationalities.passportNumber'), 'AB 123456');
       await user.type(screen.getByLabelText('nationalities.passportExpiryDate'), '2030-01-15');
@@ -427,7 +429,7 @@ describe('NationalitiesSection', () => {
 
     it('shows passportFormat error when passport number starts with a hyphen', async () => {
       const { user } = setup([]);
-      await user.click(screen.getByRole('button', { name: 'nationalities.add' }));
+      await user.click(screen.getByRole('button', { name: 'common:actions.create' }));
       await user.selectOptions(screen.getByTestId('add-country'), 'CO');
       await user.type(screen.getByLabelText('nationalities.passportNumber'), '-AB123456');
       await user.type(screen.getByLabelText('nationalities.passportExpiryDate'), '2030-01-15');
@@ -439,7 +441,7 @@ describe('NationalitiesSection', () => {
 
     it('shows passportFormat error when passport number ends with a hyphen', async () => {
       const { user } = setup([]);
-      await user.click(screen.getByRole('button', { name: 'nationalities.add' }));
+      await user.click(screen.getByRole('button', { name: 'common:actions.create' }));
       await user.selectOptions(screen.getByTestId('add-country'), 'CO');
       await user.type(screen.getByLabelText('nationalities.passportNumber'), 'AB123456-');
       await user.type(screen.getByLabelText('nationalities.passportExpiryDate'), '2030-01-15');
@@ -451,7 +453,7 @@ describe('NationalitiesSection', () => {
 
     it('accepts passport number with hyphens', async () => {
       const { user } = setup([]);
-      await user.click(screen.getByRole('button', { name: 'nationalities.add' }));
+      await user.click(screen.getByRole('button', { name: 'common:actions.create' }));
       await user.selectOptions(screen.getByTestId('add-country'), 'CO');
       await user.type(screen.getByLabelText('nationalities.passportNumber'), 'AB-123456');
       await user.type(screen.getByLabelText('nationalities.passportExpiryDate'), '2030-01-15');
@@ -467,7 +469,7 @@ describe('NationalitiesSection', () => {
 
     it('accepts nationality with no passport fields', async () => {
       const { user } = setup([]);
-      await user.click(screen.getByRole('button', { name: 'nationalities.add' }));
+      await user.click(screen.getByRole('button', { name: 'common:actions.create' }));
       await user.selectOptions(screen.getByTestId('add-country'), 'CO');
       await user.click(screen.getByRole('button', { name: 'nationalities.save' }));
       await waitFor(() => expect(mocks.mockPost).toHaveBeenCalledOnce());

--- a/apps/web/src/components/profile/NationalitiesSection.tsx
+++ b/apps/web/src/components/profile/NationalitiesSection.tsx
@@ -4,7 +4,7 @@ import { useState, type SubmitEvent } from 'react';
 import axios from 'axios';
 import { useTranslation } from 'react-i18next';
 import { getCountryDataList, getEmojiFlag, type TCountryCode } from 'countries-list';
-import { CaretDownIcon, GlobeIcon, IdentificationCardIcon } from '@phosphor-icons/react';
+import { CaretDownIcon, GlobeIcon, IdentificationCardIcon, PlusIcon } from '@phosphor-icons/react';
 import { PassportStatus } from '@chamuco/shared-types';
 import { DOCUMENT_ID_FORMAT_REGEX } from '@chamuco/shared-utils';
 
@@ -251,7 +251,7 @@ interface NationalitiesSectionProps {
 }
 
 export function NationalitiesSection({ data, onRefresh }: NationalitiesSectionProps) {
-  const { t } = useTranslation('profile');
+  const { t } = useTranslation(['profile', 'common']);
 
   const [editingId, setEditingId] = useState<string | null>(null);
   const [expandedNatId, setExpandedNatId] = useState<string | null>(null);
@@ -441,7 +441,21 @@ export function NationalitiesSection({ data, onRefresh }: NationalitiesSectionPr
 
   return (
     <div className="max-w-lg space-y-6">
-      <h2 className="text-xl font-semibold">{t('nationalities.heading')}</h2>
+      <div className="flex items-center justify-between">
+        <h2 className="text-xl font-semibold">{t('nationalities.heading')}</h2>
+        {!isAdding && (
+          <Button
+            type="button"
+            size="icon"
+            onClick={startAdd}
+            disabled={isSaving}
+            title={t('common:actions.create')}
+            aria-label={t('common:actions.create')}
+          >
+            <PlusIcon aria-hidden="true" />
+          </Button>
+        )}
+      </div>
 
       {data.length === 0 && !isAdding && (
         <p className="text-sm text-muted-foreground">{t('nationalities.empty')}</p>
@@ -554,12 +568,6 @@ export function NationalitiesSection({ data, onRefresh }: NationalitiesSectionPr
           onCancel={cancelAdd}
           saveLabel={t('nationalities.save')}
         />
-      )}
-
-      {!isAdding && (
-        <Button type="button" variant="outline" onClick={startAdd} disabled={isSaving}>
-          {t('nationalities.add')}
-        </Button>
       )}
     </div>
   );

--- a/apps/web/src/components/ui/delete-confirm-button.tsx
+++ b/apps/web/src/components/ui/delete-confirm-button.tsx
@@ -2,20 +2,16 @@
 
 import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { TrashIcon } from '@phosphor-icons/react';
 
 import { Button } from '@/components/ui/button';
-import type { buttonVariants } from '@/components/ui/button';
-import type { VariantProps } from 'class-variance-authority';
-
-type ButtonSize = NonNullable<VariantProps<typeof buttonVariants>['size']>;
 
 interface DeleteConfirmButtonProps {
   onDelete: () => void | Promise<void>;
   disabled?: boolean;
-  size?: ButtonSize;
 }
 
-export function DeleteConfirmButton({ onDelete, disabled, size = 'sm' }: DeleteConfirmButtonProps) {
+export function DeleteConfirmButton({ onDelete, disabled }: DeleteConfirmButtonProps) {
   const { t } = useTranslation();
   const [confirming, setConfirming] = useState(false);
   const confirmBtnRef = useRef<HTMLButtonElement | null>(null);
@@ -43,12 +39,17 @@ export function DeleteConfirmButton({ onDelete, disabled, size = 'sm' }: DeleteC
     <Button
       ref={confirming ? confirmBtnRef : undefined}
       type="button"
-      size={size}
+      size="icon"
       variant={confirming ? 'destructive' : 'outline'}
       onClick={handleClick}
       disabled={disabled}
+      className={confirming ? 'w-auto px-2.5' : undefined}
+      {...(!confirming && {
+        title: t('actions.delete'),
+        'aria-label': t('actions.delete'),
+      })}
     >
-      {confirming ? t('actions.deleteConfirm') : t('actions.delete')}
+      {confirming ? t('actions.deleteConfirm') : <TrashIcon aria-hidden="true" />}
     </Button>
   );
 }

--- a/apps/web/src/components/ui/edit-delete-actions.tsx
+++ b/apps/web/src/components/ui/edit-delete-actions.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useTranslation } from 'react-i18next';
+import { PencilSimpleIcon } from '@phosphor-icons/react';
 
 import { Button } from '@/components/ui/button';
 import { DeleteConfirmButton } from '@/components/ui/delete-confirm-button';
@@ -24,8 +25,16 @@ export function EditDeleteActions({
   return (
     <div className={cn('flex shrink-0 flex-col gap-1.5 sm:flex-row', className)}>
       {onEdit && (
-        <Button type="button" size="sm" variant="outline" onClick={onEdit} disabled={disabled}>
-          {t('actions.edit')}
+        <Button
+          type="button"
+          size="icon"
+          variant="outline"
+          onClick={onEdit}
+          disabled={disabled}
+          title={t('actions.edit')}
+          aria-label={t('actions.edit')}
+        >
+          <PencilSimpleIcon aria-hidden="true" />
         </Button>
       )}
       {onDelete && <DeleteConfirmButton onDelete={onDelete} disabled={disabled} />}

--- a/apps/web/src/locales/en/groups.json
+++ b/apps/web/src/locales/en/groups.json
@@ -102,7 +102,6 @@
   "announcements": "Announcements",
   "announcementsEmpty": "No announcements yet.",
   "announcementsNew": "New Announcement",
-  "announcementsNewButton": "New announcement",
   "announcementsPublish": "Announce",
   "announcementsPlaceholder": "Write an announcement to all members...",
   "announcementsSubmit": "Publish",

--- a/apps/web/src/locales/es/common.json
+++ b/apps/web/src/locales/es/common.json
@@ -18,7 +18,11 @@
     "loading": "Cargando...",
     "viewMore": "Ver Más",
     "viewLess": "Ver Menos",
-    "backToSignIn": "Volver al inicio de sesión"
+    "backToSignIn": "Volver al inicio de sesión",
+    "accept": "Aceptar",
+    "decline": "Rechazar",
+    "accepting": "Aceptando...",
+    "declining": "Rechazando..."
   },
   "navigation": {
     "home": "Inicio",

--- a/apps/web/src/locales/es/groups.json
+++ b/apps/web/src/locales/es/groups.json
@@ -63,10 +63,6 @@
     },
     "invitation": {
       "received": "Has sido invitado a unirte a este grupo",
-      "accept": "Aceptar invitación",
-      "decline": "Rechazar",
-      "accepting": "Aceptando...",
-      "declining": "Rechazando...",
       "acceptError": "Error al aceptar la invitación",
       "declineError": "Error al rechazar la invitación"
     },
@@ -102,7 +98,6 @@
   "announcements": "Anuncios",
   "announcementsEmpty": "Aún no hay anuncios.",
   "announcementsNew": "Nuevo Anuncio",
-  "announcementsNewButton": "Nuevo anuncio",
   "announcementsPublish": "Anunciar",
   "announcementsPlaceholder": "Escribe un anuncio para todos los miembros...",
   "announcementsSubmit": "Publicar",


### PR DESCRIPTION
## Summary

Replaces text-only action buttons across the app with icon-only buttons following the established iconic UI convention (icon + `title`/`aria-label` tooltip). Keeps text labels only for primary CTAs and ambiguous empty-state actions. Also bumps the feedback rate limit for the testing phase.

## Changes

**Groups**
- `groups/page.tsx` — Search (🔍) and Create (➕) header buttons are now icon-only
- `announcements/page.tsx` — "New announcement" button replaced with ➕ icon using existing `announcementsSubmit` key; removed stale `announcementsNewButton` i18n key

**Group invitations**
- `InvitationResponseButtons` — Accept (✓) and Decline (✗) are now icon-only; accept appears first; fixed pre-existing `actions.received` key bug (was resolving to wrong namespace)

**Announcement cards**
- `EditDeleteActions` — Edit button gains `PencilSimpleIcon` alongside text
- `DeleteConfirmButton` — Normal state is icon-only (`TrashIcon`); confirmation state keeps text; height discrepancy fixed by always using `size="icon"` with `w-auto px-2.5` override when confirming

**Profile sections** (Nationalities, Loyalty Programs, Emergency Contacts)
- Create button moved from bottom of list to inline right of section heading, now icon-only (➕)

**Feedback rate limit**
- Bumped from 3 → 50 per 24h for testing phase; TODO left to revert after go-live

## Testing

- All 1420 web tests pass; all API tests pass
- Updated test queries in `InvitationResponseButtons`, `NationalitiesSection`, `LoyaltyProgramsSection`, `EmergencyContactsSection`, and `announcements/page` tests to match new `aria-label` values
- Verify icon buttons show tooltips on hover
- Verify delete confirmation state doesn't jump in height
- Verify profile section create button appears inline with heading and hides while form is open