### PR TITLE
fix(notifications): correct group invite URL and FCM delivery bugs

### DIFF
--- a/apps/api/src/modules/group-announcements/group-announcements.service.spec.ts
+++ b/apps/api/src/modules/group-announcements/group-announcements.service.spec.ts
@@ -177,13 +177,13 @@ describe('GroupAnnouncementsService', () => {
       expect(result.createdByUsername).toBe(ADMIN_USERNAME);
     });
 
-    it('calls notifyMany with all active member IDs', async () => {
+    it('excludes the caller from notifyMany', async () => {
       mockSelect.mockReturnValue(makeChain([{ userId: MEMBER_ID }, { userId: ADMIN_ID }]));
 
       await service.create(GROUP_ID, ADMIN_ID, ADMIN_USERNAME, dto);
 
       expect(mockNotificationsNotifyMany).toHaveBeenCalledWith(
-        [MEMBER_ID, ADMIN_ID],
+        [MEMBER_ID],
         NotificationType.GROUP_ANNOUNCEMENT,
         expect.objectContaining({ groupId: GROUP_ID }),
         [NotificationChannel.PUSH],

--- a/apps/api/src/modules/group-announcements/group-announcements.service.ts
+++ b/apps/api/src/modules/group-announcements/group-announcements.service.ts
@@ -57,7 +57,7 @@ export class GroupAnnouncementsService {
       }),
     ]);
 
-    const userIds = memberRows.map((r) => r.userId);
+    const userIds = memberRows.map((r) => r.userId).filter((id) => id !== callerId);
 
     this.notifications
       .notifyMany(

--- a/apps/api/src/modules/notifications/channel-strategies/channel-strategies.spec.ts
+++ b/apps/api/src/modules/notifications/channel-strategies/channel-strategies.spec.ts
@@ -89,10 +89,15 @@ describe('PushChannelStrategy', () => {
       expect(sendEachForMulticast).toHaveBeenCalledWith(
         expect.objectContaining({
           tokens: ['tok-a', 'tok-b'],
-          notification: { title: FAKE_NOTIFICATION.title, body: FAKE_NOTIFICATION.body },
-          data: { key: 'val' },
+          data: expect.objectContaining({
+            key: 'val',
+            title: FAKE_NOTIFICATION.title,
+            body: FAKE_NOTIFICATION.body,
+          }),
         }),
       );
+      const call = sendEachForMulticast.mock.calls[0]![0] as Record<string, unknown>;
+      expect(call).not.toHaveProperty('notification');
       expect(db.delete).not.toHaveBeenCalled();
       expect(getSetArgs()?.status).toBe(DeliveryStatus.SENT);
       expect(getSetArgs()?.sentAt).toBeInstanceOf(Date);
@@ -200,14 +205,14 @@ describe('PushChannelStrategy', () => {
 
       expect(sendEachForMulticast).toHaveBeenCalledWith(
         expect.objectContaining({
-          data: { count: '3', flag: 'true', nested: '{"x":1}' },
+          data: expect.objectContaining({ count: '3', flag: 'true', nested: '{"x":1}' }),
         }),
       );
     });
   });
 
-  describe('webpush click-action URL', () => {
-    it('sets webpush.fcmOptions.link when notification has a url', async () => {
+  describe('url in data', () => {
+    it('sets data.url when notification has a url', async () => {
       const sendEachForMulticast = jest
         .fn()
         .mockResolvedValue(makeBatchResponse([{ success: true }]));
@@ -218,12 +223,12 @@ describe('PushChannelStrategy', () => {
 
       expect(sendEachForMulticast).toHaveBeenCalledWith(
         expect.objectContaining({
-          webpush: { fcmOptions: { link: '/groups/abc' } },
+          data: expect.objectContaining({ url: '/groups/abc' }),
         }),
       );
     });
 
-    it('omits webpush when notification url is null', async () => {
+    it('omits data.url when notification url is null', async () => {
       const sendEachForMulticast = jest
         .fn()
         .mockResolvedValue(makeBatchResponse([{ success: true }]));
@@ -231,8 +236,8 @@ describe('PushChannelStrategy', () => {
 
       await strategy.send(FAKE_NOTIFICATION, {});
 
-      const call = sendEachForMulticast.mock.calls[0]![0] as Record<string, unknown>;
-      expect(call).not.toHaveProperty('webpush');
+      const call = sendEachForMulticast.mock.calls[0]![0] as { data: Record<string, string> };
+      expect(call.data).not.toHaveProperty('url');
     });
   });
 });

--- a/apps/api/src/modules/notifications/channel-strategies/push-channel.strategy.ts
+++ b/apps/api/src/modules/notifications/channel-strategies/push-channel.strategy.ts
@@ -43,9 +43,12 @@ export class PushChannelStrategy implements NotificationChannelStrategy {
     try {
       batchResponse = await this.firebaseAdmin.messaging().sendEachForMulticast({
         tokens,
-        notification: { title: notification.title, body: notification.body },
-        data,
-        ...(notification.url ? { webpush: { fcmOptions: { link: notification.url } } } : {}),
+        data: {
+          ...data,
+          title: notification.title,
+          body: notification.body,
+          ...(notification.url ? { url: notification.url } : {}),
+        },
       });
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err);

--- a/apps/api/src/modules/notifications/notification-content.builder.spec.ts
+++ b/apps/api/src/modules/notifications/notification-content.builder.spec.ts
@@ -63,11 +63,11 @@ describe('buildNotificationContent()', () => {
   });
 
   describe('url derivation', () => {
-    it('derives /groups/:id url for GROUP_INVITATION when groupId is present', () => {
+    it('derives /groups url for GROUP_INVITATION regardless of groupId', () => {
       const result = buildNotificationContent(NotificationType.GROUP_INVITATION, {
         groupId: 'g-123',
       });
-      expect(result.url).toBe('/groups/g-123');
+      expect(result.url).toBe('/groups');
     });
 
     it('derives /groups/:id url for GROUP_JOIN_ACCEPTED', () => {
@@ -84,9 +84,9 @@ describe('buildNotificationContent()', () => {
       expect(result.url).toBe('/groups/g-789');
     });
 
-    it('returns null for group types when groupId is missing', () => {
+    it('derives /groups url for GROUP_INVITATION when groupId is missing', () => {
       const result = buildNotificationContent(NotificationType.GROUP_INVITATION, {});
-      expect(result.url).toBeNull();
+      expect(result.url).toBe('/groups');
     });
 
     it('derives /profile/passport for PASSPORT_EXPIRING_SOON', () => {

--- a/apps/api/src/modules/notifications/notification-content.builder.ts
+++ b/apps/api/src/modules/notifications/notification-content.builder.ts
@@ -27,6 +27,7 @@ function buildNotificationUrl(
 ): string | null {
   switch (type) {
     case NotificationType.GROUP_INVITATION:
+      return '/groups';
     case NotificationType.GROUP_JOIN_ACCEPTED:
     case NotificationType.GROUP_ANNOUNCEMENT:
       return typeof payload.groupId === 'string' ? `/groups/${payload.groupId}` : null;

--- a/apps/web/public/sw.template.js
+++ b/apps/web/public/sw.template.js
@@ -130,9 +130,9 @@ const messaging = firebase.messaging();
 messaging.onBackgroundMessage((payload) => {
   console.log('[FCM] Background message received:', payload);
 
-  const notificationTitle = payload.notification?.title || 'Chamuco Travel';
+  const notificationTitle = payload.data?.title || 'Chamuco Travel';
   const notificationOptions = {
-    body: payload.notification?.body || '',
+    body: payload.data?.body || '',
     icon: '/icons/icon-192x192.png',
     badge: '/icons/icon-192x192.png',
     data: payload.data,

--- a/apps/web/src/hooks/usePushNotifications.test.ts
+++ b/apps/web/src/hooks/usePushNotifications.test.ts
@@ -151,9 +151,7 @@ describe('usePushNotifications', () => {
     expect(onMessage).toHaveBeenCalledWith(mockMessaging, expect.any(Function));
 
     act(() => {
-      capturedHandler?.({
-        notification: { title: 'Hello', body: 'World' },
-      } as MessagePayload);
+      capturedHandler?.({ data: { title: 'Hello', body: 'World' } } as unknown as MessagePayload);
     });
 
     expect(toast.info).toHaveBeenCalledWith('Hello', 'World');
@@ -177,7 +175,7 @@ describe('usePushNotifications', () => {
     window.addEventListener('chamuco:notification', listener);
 
     act(() => {
-      capturedHandler?.({ notification: { title: 'Hello' } } as MessagePayload);
+      capturedHandler?.({ data: { title: 'Hello' } } as unknown as MessagePayload);
     });
 
     expect(listener).toHaveBeenCalledTimes(1);
@@ -199,7 +197,7 @@ describe('usePushNotifications', () => {
     });
 
     act(() => {
-      capturedHandler?.({ notification: {} } as MessagePayload);
+      capturedHandler?.({ data: {} } as unknown as MessagePayload);
     });
 
     expect(toast.info).toHaveBeenCalledWith('Notification', undefined);

--- a/apps/web/src/hooks/usePushNotifications.ts
+++ b/apps/web/src/hooks/usePushNotifications.ts
@@ -43,8 +43,8 @@ export function usePushNotifications(): void {
 
       if (cancelled) return;
       unsubscribeForeground = onMessage(messaging, (payload) => {
-        const title = payload.notification?.title ?? 'Notification';
-        const body = payload.notification?.body;
+        const title = payload.data?.['title'] ?? 'Notification';
+        const body = payload.data?.['body'];
         toast.info(title, body);
         window.dispatchEvent(new window.CustomEvent('chamuco:notification'));
       });


### PR DESCRIPTION
## Summary

Three notification bugs reported via user feedback: group invite notifications deep-linked directly into the group before the user accepted (resulting in a "not found" error), push notifications appeared duplicated (one from the app's service worker, one from Chrome's native FCM handler), and the deep-link URL always opened the home page instead of the intended destination.

## Changes

**Routing fix**
- `GROUP_INVITATION` notifications now point to `/groups` instead of `/groups/:id` — the groups page already renders the `InvitationsSection` where the user can accept. `GROUP_JOIN_ACCEPTED` and `GROUP_ANNOUNCEMENT` retain the `/groups/:id` deep-link since the user is already a member at that point.

**Self-notification exclusion**
- `GroupAnnouncementsService.create` now filters the announcement creator out of the `notifyMany` recipient list so admins don't receive their own announcements.

**Data-only FCM payload**
- Removed the `notification: { title, body }` field from the FCM multicast message. Chrome shows a native notification automatically when this field is present, while the service worker also calls `showNotification` — causing duplicates. With a data-only payload the service worker is the sole display path.
- `title`, `body`, and `url` are now embedded in the `data` field. The `notificationclick` handler already read `event.notification.data?.url` — this was always correct, but the value was never populated until now.
- `sw.template.js` updated to read `payload.data.title` / `payload.data.body` instead of `payload.notification.*`.

## Testing

- Trigger a group invite → tap the push notification → should land on `/groups` (invitations visible), not produce a "not found" error.
- Create a group announcement as admin → only other members should receive the push; admin should not.
- Receive a push notification while app is backgrounded → only one notification should appear in the OS tray (not two).
- Tap any push notification with a URL → should navigate to the correct deep-link, not `/`.
- Unit tests updated and passing (15/15 channel strategies, 17/17 content builder, 20/20 announcements service).

Closes #371