### PR TITLE
fix(web): improve mobile touch responsiveness

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -99,6 +99,12 @@
 }
 
 @layer base {
+  a,
+  button,
+  [role="button"] {
+    touch-action: manipulation;
+  }
+
   :root {
     /* Horizonte-mapped semantic tokens */
     --background: 1 0 0;

--- a/apps/web/src/app/groups/[id]/page.tsx
+++ b/apps/web/src/app/groups/[id]/page.tsx
@@ -71,7 +71,7 @@ export default function GroupDetailPage({ params }: GroupDetailPageProps) {
 
   return (
     <div className="p-8 max-w-2xl">
-      <div className="mb-6">
+      <div className="flex items-center justify-between mb-6">
         <Link
           href="/groups"
           className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors"
@@ -79,26 +79,6 @@ export default function GroupDetailPage({ params }: GroupDetailPageProps) {
           <ArrowLeftIcon className="size-4" />
           {t('title')}
         </Link>
-      </div>
-
-      <div className="flex items-start gap-6 mb-6">
-        <div className="size-16 shrink-0 overflow-hidden rounded-xl bg-muted flex items-center justify-center">
-          <img src={group.coverUrl} alt="" className="size-full object-cover" />
-        </div>
-
-        <div className="flex-1 min-w-0">
-          <div className="flex items-center gap-2">
-            <h1 className="text-2xl font-bold truncate">{group.name}</h1>
-            <span className="shrink-0 rounded-full px-2.5 py-0.5 text-xs font-medium bg-muted text-muted-foreground">
-              {group.visibility === GroupVisibility.PUBLIC
-                ? t('visibility.public')
-                : t('visibility.private')}
-            </span>
-          </div>
-          {group.description && (
-            <p className="mt-1 text-sm text-muted-foreground">{group.description}</p>
-          )}
-        </div>
 
         <div className="flex shrink-0 gap-2">
           <Link
@@ -128,6 +108,26 @@ export default function GroupDetailPage({ params }: GroupDetailPageProps) {
             >
               <GearSixIcon className="size-5" aria-hidden="true" />
             </Link>
+          )}
+        </div>
+      </div>
+
+      <div className="flex items-start gap-6 mb-6">
+        <div className="size-16 shrink-0 overflow-hidden rounded-xl bg-muted flex items-center justify-center">
+          <img src={group.coverUrl} alt="" className="size-full object-cover" />
+        </div>
+
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2">
+            <h1 className="text-2xl font-bold truncate">{group.name}</h1>
+            <span className="shrink-0 rounded-full px-2.5 py-0.5 text-xs font-medium bg-muted text-muted-foreground">
+              {group.visibility === GroupVisibility.PUBLIC
+                ? t('visibility.public')
+                : t('visibility.private')}
+            </span>
+          </div>
+          {group.description && (
+            <p className="mt-1 text-sm text-muted-foreground">{group.description}</p>
           )}
         </div>
       </div>

--- a/apps/web/src/app/groups/page.tsx
+++ b/apps/web/src/app/groups/page.tsx
@@ -31,7 +31,7 @@ export default function GroupsPage() {
   }, [isAuthLoading]);
 
   return (
-    <div className="p-8">
+    <div className="p-8 max-w-2xl">
       <div className="flex items-center justify-between mb-6">
         <h1 className="text-3xl font-bold">{t('title')}</h1>
         <div className="flex items-center gap-2">

--- a/apps/web/src/components/navigation/MobileBottomNav.tsx
+++ b/apps/web/src/components/navigation/MobileBottomNav.tsx
@@ -15,14 +15,14 @@ export function MobileBottomNav() {
     <nav
       className={cn(
         'fixed bottom-0 left-0 right-0 z-40 h-nav-safe pb-nav-inset bg-card border-t border-border flex md:hidden',
-        'transition-transform duration-300',
-        hidden ? 'translate-y-full' : 'translate-y-0',
+        'transition-transform duration-300 will-change-transform',
+        hidden ? 'translate-y-full pointer-events-none' : 'translate-y-0',
       )}
       aria-label="Mobile navigation"
       aria-hidden={hidden}
     >
       {NAV_ITEMS.map((item) => (
-        <div key={item.key} className="flex-1">
+        <div key={item.key} className="flex-1 h-full">
           <NavItem
             item={item}
             layout="bottom-bar"

--- a/apps/web/src/components/navigation/NavItem.test.tsx
+++ b/apps/web/src/components/navigation/NavItem.test.tsx
@@ -127,7 +127,25 @@ describe('NavItem', () => {
     it('applies bottom-bar layout classes', () => {
       render(<NavItem item={mockItem} layout="bottom-bar" />);
       const link = screen.getByRole('link');
-      expect(link).toHaveClass('flex-col', 'px-2', 'py-2', 'text-xs', 'justify-center');
+      expect(link).toHaveClass(
+        'flex-col',
+        'px-2',
+        'py-2',
+        'text-xs',
+        'justify-center',
+        'w-full',
+        'h-full',
+      );
+    });
+
+    it('does not apply rounded-lg in bottom-bar layout', () => {
+      render(<NavItem item={mockItem} layout="bottom-bar" />);
+      expect(screen.getByRole('link')).not.toHaveClass('rounded-lg');
+    });
+
+    it('applies rounded-lg in sidebar layout', () => {
+      render(<NavItem item={mockItem} layout="sidebar" />);
+      expect(screen.getByRole('link')).toHaveClass('rounded-lg');
     });
   });
 

--- a/apps/web/src/components/navigation/NavItem.tsx
+++ b/apps/web/src/components/navigation/NavItem.tsx
@@ -21,7 +21,7 @@ export function NavItem({ item, layout, showLabel = true, badge }: NavItemProps)
   const label = t(`navigation.${item.key}`);
   const Icon = item.icon;
 
-  const baseClasses = 'flex items-center gap-2 rounded-lg transition-colors';
+  const baseClasses = 'flex items-center gap-2 transition-colors';
   const activeClasses = isActive
     ? 'bg-primary text-primary-foreground'
     : 'hover:bg-muted text-foreground';
@@ -29,8 +29,8 @@ export function NavItem({ item, layout, showLabel = true, badge }: NavItemProps)
   const layoutClasses =
     layout === 'sidebar'
       ? showLabel
-        ? 'px-3 py-2 justify-start'
-        : 'px-0 py-2 justify-center'
+        ? 'px-3 py-2 justify-start rounded-lg'
+        : 'px-0 py-2 justify-center rounded-lg'
       : 'flex-col px-2 py-2 text-xs justify-center w-full h-full';
 
   const badgeLabel = badge && badge > 0 ? (badge > 99 ? '99+' : String(badge)) : null;

--- a/apps/web/src/components/navigation/NavItem.tsx
+++ b/apps/web/src/components/navigation/NavItem.tsx
@@ -31,7 +31,7 @@ export function NavItem({ item, layout, showLabel = true, badge }: NavItemProps)
       ? showLabel
         ? 'px-3 py-2 justify-start'
         : 'px-0 py-2 justify-center'
-      : 'flex-col px-2 py-2 text-xs justify-center';
+      : 'flex-col px-2 py-2 text-xs justify-center w-full h-full';
 
   const badgeLabel = badge && badge > 0 ? (badge > 99 ? '99+' : String(badge)) : null;
 

--- a/apps/web/src/components/ui/toast.tsx
+++ b/apps/web/src/components/ui/toast.tsx
@@ -82,7 +82,7 @@ function Toaster() {
     <ToastPrimitive.Viewport
       className={cn(
         'fixed bottom-0 right-0 z-100 flex max-h-screen w-full flex-col gap-2 p-4 md:max-w-sm',
-        'pb-safe-bottom',
+        'pb-safe-bottom pointer-events-none',
       )}
     >
       {toasts.map((toast) => (
@@ -91,6 +91,7 @@ function Toaster() {
           toast={toast}
           className={cn(
             toastVariants({ type: toast.type as keyof typeof typeIconMap }),
+            'pointer-events-auto',
             'data-starting-style:translate-y-2 data-starting-style:opacity-0',
             'data-ending-style:translate-y-2 data-ending-style:opacity-0',
             'transition-all duration-200',


### PR DESCRIPTION
## Summary

Mobile users had to tap navbar items multiple times to navigate. Root cause was the toast notification container (`z-100`, `fixed bottom-0`) sitting invisibly on top of the navbar and intercepting all touch events on Android — even when empty. Secondary issues included the 300ms tap delay common in PWAs and an undersized tap target on navbar cells.

## Changes

**Root fix**
- `toast.tsx`: `pointer-events-none` on the Viewport container so the empty overlay no longer blocks taps; `pointer-events-auto` restored on individual toast roots so close/interaction still works

**Touch delay elimination**
- `globals.css`: `touch-action: manipulation` on `a`, `button`, `[role="button"]` — removes the 300ms tap delay browser-wide without disabling pinch-zoom

**Navbar animation & tap target**
- `MobileBottomNav`: `pointer-events-none` when hidden (prevents ghost taps during slide-out animation); `will-change-transform` for GPU-composited animation
- `MobileBottomNav`: `h-full` on cell wrappers
- `NavItem`: `w-full h-full` on bottom-bar links — tap target now fills the entire cell, not just the icon+text content area

**Groups layout**
- Minor layout adjustments to `groups/page.tsx` and `groups/[id]/page.tsx`

## Testing

- Tap each navbar item on an Android device/emulator — single tap should navigate reliably
- Tap each navbar item on iOS PWA — same expectation
- Trigger a toast notification, verify close button still works
- Scroll down to hide the navbar, scroll back up — animation should be smooth; no ghost taps during transition
- Verify pinch-to-zoom still works (touch-action: manipulation preserves zoom)