### PR TITLE
feat(trips): add trip API client methods

### DIFF
--- a/apps/web/src/services/api-client.test.ts
+++ b/apps/web/src/services/api-client.test.ts
@@ -255,60 +255,35 @@ const groupLinkFixture: TripGroupResponse = {
 
 // ─── Trip methods ─────────────────────────────────────────────────────────────
 
+const minCreateTripPayload = {
+  name: 'Trip',
+  visibility: TripVisibility.PUBLIC,
+  startDate: '2026-12-01',
+  endDate: '2026-12-08',
+  participantCapacity: 1,
+  departureCountry: 'MX',
+  departureCity: 'CDMX',
+  landingCountry: 'MX',
+  landingCity: 'Cancun',
+  isTravelingParticipant: true,
+};
+
 describe('createTrip', () => {
   it('posts to /v1/trips and returns the trip', async () => {
     mockPost.mockResolvedValueOnce({ data: tripFixture });
-    const payload = {
-      name: 'Cancún 2026',
-      visibility: TripVisibility.PUBLIC,
-      startDate: '2026-12-01',
-      endDate: '2026-12-08',
-      participantCapacity: 10,
-      departureCountry: 'MX',
-      departureCity: 'CDMX',
-      landingCountry: 'MX',
-      landingCity: 'Cancun',
-      isTravelingParticipant: true,
-    };
-    const result = await createTrip(payload);
-    expect(mockPost).toHaveBeenCalledWith('/v1/trips', payload);
+    const result = await createTrip(minCreateTripPayload);
+    expect(mockPost).toHaveBeenCalledWith('/v1/trips', minCreateTripPayload);
     expect(result).toEqual(tripFixture);
   });
 
   it('propagates 401 errors', async () => {
     mockPost.mockRejectedValueOnce({ response: { status: 401 } });
-    await expect(
-      createTrip({
-        name: 'x',
-        visibility: TripVisibility.PUBLIC,
-        startDate: '2026-12-01',
-        endDate: '2026-12-08',
-        participantCapacity: 1,
-        departureCountry: 'MX',
-        departureCity: 'CDMX',
-        landingCountry: 'MX',
-        landingCity: 'Cancun',
-        isTravelingParticipant: true,
-      }),
-    ).rejects.toEqual({ response: { status: 401 } });
+    await expect(createTrip(minCreateTripPayload)).rejects.toEqual({ response: { status: 401 } });
   });
 
   it('propagates 404 errors', async () => {
     mockPost.mockRejectedValueOnce({ response: { status: 404 } });
-    await expect(
-      createTrip({
-        name: 'x',
-        visibility: TripVisibility.PUBLIC,
-        startDate: '2026-12-01',
-        endDate: '2026-12-08',
-        participantCapacity: 1,
-        departureCountry: 'MX',
-        departureCity: 'CDMX',
-        landingCountry: 'MX',
-        landingCity: 'Cancun',
-        isTravelingParticipant: true,
-      }),
-    ).rejects.toEqual({ response: { status: 404 } });
+    await expect(createTrip(minCreateTripPayload)).rejects.toEqual({ response: { status: 404 } });
   });
 });
 
@@ -448,14 +423,18 @@ describe('reorderTripDestinations', () => {
 
   it('propagates 401 errors', async () => {
     mockPatch.mockRejectedValueOnce({ response: { status: 401 } });
-    await expect(reorderTripDestinations('trip-uuid-1', { destinationIds: [] })).rejects.toEqual({
+    await expect(
+      reorderTripDestinations('trip-uuid-1', { destinationIds: ['dest-uuid-1'] }),
+    ).rejects.toEqual({
       response: { status: 401 },
     });
   });
 
   it('propagates 404 errors', async () => {
     mockPatch.mockRejectedValueOnce({ response: { status: 404 } });
-    await expect(reorderTripDestinations('trip-uuid-1', { destinationIds: [] })).rejects.toEqual({
+    await expect(
+      reorderTripDestinations('trip-uuid-1', { destinationIds: ['dest-uuid-1'] }),
+    ).rejects.toEqual({
       response: { status: 404 },
     });
   });

--- a/apps/web/src/services/api-client.test.ts
+++ b/apps/web/src/services/api-client.test.ts
@@ -1,17 +1,64 @@
-import { setTokenProvider, apiClient } from './api-client';
+import {
+  addTripDestination,
+  addTripGroup,
+  apiClient,
+  createTrip,
+  deleteTrip,
+  deleteTripDestination,
+  getTrip,
+  getTripDestinations,
+  getTripGroups,
+  removeTripGroup,
+  reorderTripDestinations,
+  setTokenProvider,
+  transitionTripStatus,
+  updateTrip,
+  updateTripDestination,
+} from './api-client';
+import type {
+  DestinationResponse,
+  DestinationWriteResponse,
+  TripGroupResponse,
+  TripResponse,
+} from './trips.types';
+import { TripStatus, TripVisibility } from '@chamuco/shared-types';
 
 // vi.hoisted ensures these exist before the vi.mock factory runs
-const { mockAxiosInstance, mockRequestUse, mockResponseUse } = vi.hoisted(() => {
+const {
+  mockAxiosInstance,
+  mockRequestUse,
+  mockResponseUse,
+  mockGet,
+  mockPost,
+  mockPatch,
+  mockDelete,
+} = vi.hoisted(() => {
   const reqUse = vi.fn();
   const resUse = vi.fn();
+  const get = vi.fn();
+  const post = vi.fn();
+  const patch = vi.fn();
+  const del = vi.fn();
   // The instance is also called by the response interceptor during retry
   const instance = Object.assign(vi.fn().mockResolvedValue({ status: 200 }), {
     interceptors: {
       request: { use: reqUse },
       response: { use: resUse },
     },
+    get,
+    post,
+    patch,
+    delete: del,
   });
-  return { mockAxiosInstance: instance, mockRequestUse: reqUse, mockResponseUse: resUse };
+  return {
+    mockAxiosInstance: instance,
+    mockRequestUse: reqUse,
+    mockResponseUse: resUse,
+    mockGet: get,
+    mockPost: post,
+    mockPatch: patch,
+    mockDelete: del,
+  };
 });
 
 vi.mock('axios', () => ({
@@ -37,6 +84,10 @@ beforeEach(() => {
   // Reset tokenProvider to null between tests
   setTokenProvider(null as unknown as Parameters<typeof setTokenProvider>[0]);
   mockAxiosInstance.mockClear();
+  mockGet.mockClear();
+  mockPost.mockClear();
+  mockPatch.mockClear();
+  mockDelete.mockClear();
 });
 
 describe('setTokenProvider', () => {
@@ -155,5 +206,370 @@ describe('response interceptor', () => {
 describe('apiClient export', () => {
   it('is the axios instance created by axios.create', () => {
     expect(apiClient).toBe(mockAxiosInstance);
+  });
+});
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const tripFixture: TripResponse = {
+  id: 'trip-uuid-1',
+  name: 'Cancún 2026',
+  description: null,
+  status: TripStatus.DRAFT,
+  visibility: TripVisibility.PUBLIC,
+  startDate: '2026-12-01',
+  endDate: '2026-12-08',
+  participantCapacity: 10,
+  departureCountry: 'MX',
+  departureCity: 'Ciudad de Mexico',
+  landingCountry: 'MX',
+  landingCity: 'Cancun',
+  defaultTimezone: 'America/Cancun',
+  defaultCurrency: 'MXN',
+  itineraryNotes: null,
+  agencyId: null,
+  createdBy: 'user-uuid-1',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+  requiresConfirmation: false,
+  feedbackOpenUntil: null,
+};
+
+const destFixture: DestinationResponse = {
+  id: 'dest-uuid-1',
+  tripId: 'trip-uuid-1',
+  position: 1,
+  countryCode: 'MX',
+  city: 'Cancun',
+  label: null,
+  createdAt: '2026-01-01T00:00:00.000Z',
+};
+
+const destWriteFixture: DestinationWriteResponse = { ...destFixture, requiresConfirmation: false };
+
+const groupLinkFixture: TripGroupResponse = {
+  tripId: 'trip-uuid-1',
+  groupId: 'group-uuid-1',
+  addedAt: '2026-01-01T00:00:00.000Z',
+};
+
+// ─── Trip methods ─────────────────────────────────────────────────────────────
+
+describe('createTrip', () => {
+  it('posts to /v1/trips and returns the trip', async () => {
+    mockPost.mockResolvedValueOnce({ data: tripFixture });
+    const payload = {
+      name: 'Cancún 2026',
+      visibility: TripVisibility.PUBLIC,
+      startDate: '2026-12-01',
+      endDate: '2026-12-08',
+      participantCapacity: 10,
+      departureCountry: 'MX',
+      departureCity: 'CDMX',
+      landingCountry: 'MX',
+      landingCity: 'Cancun',
+      isTravelingParticipant: true,
+    };
+    const result = await createTrip(payload);
+    expect(mockPost).toHaveBeenCalledWith('/v1/trips', payload);
+    expect(result).toEqual(tripFixture);
+  });
+
+  it('propagates 401 errors', async () => {
+    mockPost.mockRejectedValueOnce({ response: { status: 401 } });
+    await expect(
+      createTrip({
+        name: 'x',
+        visibility: TripVisibility.PUBLIC,
+        startDate: '2026-12-01',
+        endDate: '2026-12-08',
+        participantCapacity: 1,
+        departureCountry: 'MX',
+        departureCity: 'CDMX',
+        landingCountry: 'MX',
+        landingCity: 'Cancun',
+        isTravelingParticipant: true,
+      }),
+    ).rejects.toEqual({ response: { status: 401 } });
+  });
+
+  it('propagates 404 errors', async () => {
+    mockPost.mockRejectedValueOnce({ response: { status: 404 } });
+    await expect(
+      createTrip({
+        name: 'x',
+        visibility: TripVisibility.PUBLIC,
+        startDate: '2026-12-01',
+        endDate: '2026-12-08',
+        participantCapacity: 1,
+        departureCountry: 'MX',
+        departureCity: 'CDMX',
+        landingCountry: 'MX',
+        landingCity: 'Cancun',
+        isTravelingParticipant: true,
+      }),
+    ).rejects.toEqual({ response: { status: 404 } });
+  });
+});
+
+describe('getTrip', () => {
+  it('gets /v1/trips/:id and returns the trip', async () => {
+    mockGet.mockResolvedValueOnce({ data: tripFixture });
+    const result = await getTrip('trip-uuid-1');
+    expect(mockGet).toHaveBeenCalledWith('/v1/trips/trip-uuid-1');
+    expect(result).toEqual(tripFixture);
+  });
+
+  it('propagates 401 errors', async () => {
+    mockGet.mockRejectedValueOnce({ response: { status: 401 } });
+    await expect(getTrip('trip-uuid-1')).rejects.toEqual({ response: { status: 401 } });
+  });
+
+  it('propagates 404 errors', async () => {
+    mockGet.mockRejectedValueOnce({ response: { status: 404 } });
+    await expect(getTrip('trip-uuid-1')).rejects.toEqual({ response: { status: 404 } });
+  });
+});
+
+describe('updateTrip', () => {
+  it('patches /v1/trips/:id and returns the trip', async () => {
+    mockPatch.mockResolvedValueOnce({ data: tripFixture });
+    const result = await updateTrip('trip-uuid-1', { name: 'Updated' });
+    expect(mockPatch).toHaveBeenCalledWith('/v1/trips/trip-uuid-1', { name: 'Updated' });
+    expect(result).toEqual(tripFixture);
+  });
+
+  it('propagates 401 errors', async () => {
+    mockPatch.mockRejectedValueOnce({ response: { status: 401 } });
+    await expect(updateTrip('trip-uuid-1', {})).rejects.toEqual({ response: { status: 401 } });
+  });
+
+  it('propagates 404 errors', async () => {
+    mockPatch.mockRejectedValueOnce({ response: { status: 404 } });
+    await expect(updateTrip('trip-uuid-1', {})).rejects.toEqual({ response: { status: 404 } });
+  });
+});
+
+describe('deleteTrip', () => {
+  it('deletes /v1/trips/:id', async () => {
+    mockDelete.mockResolvedValueOnce({});
+    await deleteTrip('trip-uuid-1');
+    expect(mockDelete).toHaveBeenCalledWith('/v1/trips/trip-uuid-1');
+  });
+
+  it('propagates 401 errors', async () => {
+    mockDelete.mockRejectedValueOnce({ response: { status: 401 } });
+    await expect(deleteTrip('trip-uuid-1')).rejects.toEqual({ response: { status: 401 } });
+  });
+
+  it('propagates 404 errors', async () => {
+    mockDelete.mockRejectedValueOnce({ response: { status: 404 } });
+    await expect(deleteTrip('trip-uuid-1')).rejects.toEqual({ response: { status: 404 } });
+  });
+});
+
+describe('transitionTripStatus', () => {
+  it('patches /v1/trips/:id/status and returns the trip', async () => {
+    mockPatch.mockResolvedValueOnce({ data: tripFixture });
+    const dto = { status: TripStatus.OPEN };
+    const result = await transitionTripStatus('trip-uuid-1', dto);
+    expect(mockPatch).toHaveBeenCalledWith('/v1/trips/trip-uuid-1/status', dto);
+    expect(result).toEqual(tripFixture);
+  });
+
+  it('propagates 401 errors', async () => {
+    mockPatch.mockRejectedValueOnce({ response: { status: 401 } });
+    await expect(transitionTripStatus('trip-uuid-1', { status: TripStatus.OPEN })).rejects.toEqual({
+      response: { status: 401 },
+    });
+  });
+
+  it('propagates 404 errors', async () => {
+    mockPatch.mockRejectedValueOnce({ response: { status: 404 } });
+    await expect(transitionTripStatus('trip-uuid-1', { status: TripStatus.OPEN })).rejects.toEqual({
+      response: { status: 404 },
+    });
+  });
+});
+
+// ─── Destination methods ──────────────────────────────────────────────────────
+
+describe('getTripDestinations', () => {
+  it('gets /v1/trips/:id/destinations and returns the list', async () => {
+    mockGet.mockResolvedValueOnce({ data: [destFixture] });
+    const result = await getTripDestinations('trip-uuid-1');
+    expect(mockGet).toHaveBeenCalledWith('/v1/trips/trip-uuid-1/destinations');
+    expect(result).toEqual([destFixture]);
+  });
+
+  it('propagates 401 errors', async () => {
+    mockGet.mockRejectedValueOnce({ response: { status: 401 } });
+    await expect(getTripDestinations('trip-uuid-1')).rejects.toEqual({ response: { status: 401 } });
+  });
+
+  it('propagates 404 errors', async () => {
+    mockGet.mockRejectedValueOnce({ response: { status: 404 } });
+    await expect(getTripDestinations('trip-uuid-1')).rejects.toEqual({ response: { status: 404 } });
+  });
+});
+
+describe('addTripDestination', () => {
+  it('posts to /v1/trips/:id/destinations and returns the destination', async () => {
+    mockPost.mockResolvedValueOnce({ data: destWriteFixture });
+    const dto = { countryCode: 'MX', city: 'Cancun' };
+    const result = await addTripDestination('trip-uuid-1', dto);
+    expect(mockPost).toHaveBeenCalledWith('/v1/trips/trip-uuid-1/destinations', dto);
+    expect(result).toEqual(destWriteFixture);
+  });
+
+  it('propagates 401 errors', async () => {
+    mockPost.mockRejectedValueOnce({ response: { status: 401 } });
+    await expect(
+      addTripDestination('trip-uuid-1', { countryCode: 'MX', city: 'Cancun' }),
+    ).rejects.toEqual({ response: { status: 401 } });
+  });
+
+  it('propagates 404 errors', async () => {
+    mockPost.mockRejectedValueOnce({ response: { status: 404 } });
+    await expect(
+      addTripDestination('trip-uuid-1', { countryCode: 'MX', city: 'Cancun' }),
+    ).rejects.toEqual({ response: { status: 404 } });
+  });
+});
+
+describe('reorderTripDestinations', () => {
+  it('patches /v1/trips/:id/destinations/reorder and returns the list', async () => {
+    mockPatch.mockResolvedValueOnce({ data: [destFixture] });
+    const dto = { destinationIds: ['dest-uuid-1'] };
+    const result = await reorderTripDestinations('trip-uuid-1', dto);
+    expect(mockPatch).toHaveBeenCalledWith('/v1/trips/trip-uuid-1/destinations/reorder', dto);
+    expect(result).toEqual([destFixture]);
+  });
+
+  it('propagates 401 errors', async () => {
+    mockPatch.mockRejectedValueOnce({ response: { status: 401 } });
+    await expect(reorderTripDestinations('trip-uuid-1', { destinationIds: [] })).rejects.toEqual({
+      response: { status: 401 },
+    });
+  });
+
+  it('propagates 404 errors', async () => {
+    mockPatch.mockRejectedValueOnce({ response: { status: 404 } });
+    await expect(reorderTripDestinations('trip-uuid-1', { destinationIds: [] })).rejects.toEqual({
+      response: { status: 404 },
+    });
+  });
+});
+
+describe('updateTripDestination', () => {
+  it('patches /v1/trips/:id/destinations/:destId and returns the destination', async () => {
+    mockPatch.mockResolvedValueOnce({ data: destWriteFixture });
+    const dto = { city: 'Tulum' };
+    const result = await updateTripDestination('trip-uuid-1', 'dest-uuid-1', dto);
+    expect(mockPatch).toHaveBeenCalledWith('/v1/trips/trip-uuid-1/destinations/dest-uuid-1', dto);
+    expect(result).toEqual(destWriteFixture);
+  });
+
+  it('propagates 401 errors', async () => {
+    mockPatch.mockRejectedValueOnce({ response: { status: 401 } });
+    await expect(updateTripDestination('trip-uuid-1', 'dest-uuid-1', {})).rejects.toEqual({
+      response: { status: 401 },
+    });
+  });
+
+  it('propagates 404 errors', async () => {
+    mockPatch.mockRejectedValueOnce({ response: { status: 404 } });
+    await expect(updateTripDestination('trip-uuid-1', 'dest-uuid-1', {})).rejects.toEqual({
+      response: { status: 404 },
+    });
+  });
+});
+
+describe('deleteTripDestination', () => {
+  it('deletes /v1/trips/:id/destinations/:destId', async () => {
+    mockDelete.mockResolvedValueOnce({});
+    await deleteTripDestination('trip-uuid-1', 'dest-uuid-1');
+    expect(mockDelete).toHaveBeenCalledWith('/v1/trips/trip-uuid-1/destinations/dest-uuid-1');
+  });
+
+  it('propagates 401 errors', async () => {
+    mockDelete.mockRejectedValueOnce({ response: { status: 401 } });
+    await expect(deleteTripDestination('trip-uuid-1', 'dest-uuid-1')).rejects.toEqual({
+      response: { status: 401 },
+    });
+  });
+
+  it('propagates 404 errors', async () => {
+    mockDelete.mockRejectedValueOnce({ response: { status: 404 } });
+    await expect(deleteTripDestination('trip-uuid-1', 'dest-uuid-1')).rejects.toEqual({
+      response: { status: 404 },
+    });
+  });
+});
+
+// ─── Group methods ────────────────────────────────────────────────────────────
+
+describe('getTripGroups', () => {
+  it('gets /v1/trips/:id/groups and returns the list', async () => {
+    mockGet.mockResolvedValueOnce({ data: [groupLinkFixture] });
+    const result = await getTripGroups('trip-uuid-1');
+    expect(mockGet).toHaveBeenCalledWith('/v1/trips/trip-uuid-1/groups');
+    expect(result).toEqual([groupLinkFixture]);
+  });
+
+  it('propagates 401 errors', async () => {
+    mockGet.mockRejectedValueOnce({ response: { status: 401 } });
+    await expect(getTripGroups('trip-uuid-1')).rejects.toEqual({ response: { status: 401 } });
+  });
+
+  it('propagates 404 errors', async () => {
+    mockGet.mockRejectedValueOnce({ response: { status: 404 } });
+    await expect(getTripGroups('trip-uuid-1')).rejects.toEqual({ response: { status: 404 } });
+  });
+});
+
+describe('addTripGroup', () => {
+  it('posts to /v1/trips/:id/groups and returns the link', async () => {
+    mockPost.mockResolvedValueOnce({ data: groupLinkFixture });
+    const dto = { groupId: 'group-uuid-1' };
+    const result = await addTripGroup('trip-uuid-1', dto);
+    expect(mockPost).toHaveBeenCalledWith('/v1/trips/trip-uuid-1/groups', dto);
+    expect(result).toEqual(groupLinkFixture);
+  });
+
+  it('propagates 401 errors', async () => {
+    mockPost.mockRejectedValueOnce({ response: { status: 401 } });
+    await expect(addTripGroup('trip-uuid-1', { groupId: 'group-uuid-1' })).rejects.toEqual({
+      response: { status: 401 },
+    });
+  });
+
+  it('propagates 404 errors', async () => {
+    mockPost.mockRejectedValueOnce({ response: { status: 404 } });
+    await expect(addTripGroup('trip-uuid-1', { groupId: 'group-uuid-1' })).rejects.toEqual({
+      response: { status: 404 },
+    });
+  });
+});
+
+describe('removeTripGroup', () => {
+  it('deletes /v1/trips/:id/groups/:groupId', async () => {
+    mockDelete.mockResolvedValueOnce({});
+    await removeTripGroup('trip-uuid-1', 'group-uuid-1');
+    expect(mockDelete).toHaveBeenCalledWith('/v1/trips/trip-uuid-1/groups/group-uuid-1');
+  });
+
+  it('propagates 401 errors', async () => {
+    mockDelete.mockRejectedValueOnce({ response: { status: 401 } });
+    await expect(removeTripGroup('trip-uuid-1', 'group-uuid-1')).rejects.toEqual({
+      response: { status: 401 },
+    });
+  });
+
+  it('propagates 404 errors', async () => {
+    mockDelete.mockRejectedValueOnce({ response: { status: 404 } });
+    await expect(removeTripGroup('trip-uuid-1', 'group-uuid-1')).rejects.toEqual({
+      response: { status: 404 },
+    });
   });
 });

--- a/apps/web/src/services/api-client.ts
+++ b/apps/web/src/services/api-client.ts
@@ -1,6 +1,20 @@
 import axios from 'axios';
 import type { AxiosRequestConfig, InternalAxiosRequestConfig } from 'axios';
 
+import type {
+  AddTripGroupPayload,
+  CreateDestinationPayload,
+  CreateTripPayload,
+  DestinationResponse,
+  DestinationWriteResponse,
+  ReorderDestinationsPayload,
+  TransitionTripStatusPayload,
+  TripGroupResponse,
+  TripResponse,
+  UpdateDestinationPayload,
+  UpdateTripPayload,
+} from './trips.types';
+
 type TokenProvider = (forceRefresh?: boolean) => Promise<string | null>;
 
 let tokenProvider: TokenProvider | null = null;
@@ -55,3 +69,96 @@ apiClient.interceptors.response.use(
     return Promise.reject(error);
   },
 );
+
+// ─── Trip methods ─────────────────────────────────────────────────────────────
+
+export async function createTrip(dto: CreateTripPayload): Promise<TripResponse> {
+  const { data } = await apiClient.post<TripResponse>('/v1/trips', dto);
+  return data;
+}
+
+export async function getTrip(id: string): Promise<TripResponse> {
+  const { data } = await apiClient.get<TripResponse>(`/v1/trips/${id}`);
+  return data;
+}
+
+export async function updateTrip(id: string, dto: UpdateTripPayload): Promise<TripResponse> {
+  const { data } = await apiClient.patch<TripResponse>(`/v1/trips/${id}`, dto);
+  return data;
+}
+
+export async function deleteTrip(id: string): Promise<void> {
+  await apiClient.delete(`/v1/trips/${id}`);
+}
+
+export async function transitionTripStatus(
+  id: string,
+  dto: TransitionTripStatusPayload,
+): Promise<TripResponse> {
+  const { data } = await apiClient.patch<TripResponse>(`/v1/trips/${id}/status`, dto);
+  return data;
+}
+
+// ─── Destination methods ──────────────────────────────────────────────────────
+
+export async function getTripDestinations(id: string): Promise<DestinationResponse[]> {
+  const { data } = await apiClient.get<DestinationResponse[]>(`/v1/trips/${id}/destinations`);
+  return data;
+}
+
+export async function addTripDestination(
+  id: string,
+  dto: CreateDestinationPayload,
+): Promise<DestinationWriteResponse> {
+  const { data } = await apiClient.post<DestinationWriteResponse>(
+    `/v1/trips/${id}/destinations`,
+    dto,
+  );
+  return data;
+}
+
+export async function reorderTripDestinations(
+  id: string,
+  dto: ReorderDestinationsPayload,
+): Promise<DestinationResponse[]> {
+  const { data } = await apiClient.patch<DestinationResponse[]>(
+    `/v1/trips/${id}/destinations/reorder`,
+    dto,
+  );
+  return data;
+}
+
+export async function updateTripDestination(
+  id: string,
+  destId: string,
+  dto: UpdateDestinationPayload,
+): Promise<DestinationWriteResponse> {
+  const { data } = await apiClient.patch<DestinationWriteResponse>(
+    `/v1/trips/${id}/destinations/${destId}`,
+    dto,
+  );
+  return data;
+}
+
+export async function deleteTripDestination(id: string, destId: string): Promise<void> {
+  await apiClient.delete(`/v1/trips/${id}/destinations/${destId}`);
+}
+
+// ─── Group methods ────────────────────────────────────────────────────────────
+
+export async function getTripGroups(id: string): Promise<TripGroupResponse[]> {
+  const { data } = await apiClient.get<TripGroupResponse[]>(`/v1/trips/${id}/groups`);
+  return data;
+}
+
+export async function addTripGroup(
+  id: string,
+  dto: AddTripGroupPayload,
+): Promise<TripGroupResponse> {
+  const { data } = await apiClient.post<TripGroupResponse>(`/v1/trips/${id}/groups`, dto);
+  return data;
+}
+
+export async function removeTripGroup(id: string, groupId: string): Promise<void> {
+  await apiClient.delete(`/v1/trips/${id}/groups/${groupId}`);
+}

--- a/apps/web/src/services/trips.types.ts
+++ b/apps/web/src/services/trips.types.ts
@@ -1,5 +1,8 @@
 import type { TripStatus, TripVisibility } from '@chamuco/shared-types';
 
+// Mirrors the NestJS DTOs in apps/api/src/modules/trips/dto/.
+// When the backend adds or removes fields, update this file to match.
+
 // ─── Request payloads ────────────────────────────────────────────────────────
 
 export interface CreateTripPayload {

--- a/apps/web/src/services/trips.types.ts
+++ b/apps/web/src/services/trips.types.ts
@@ -1,0 +1,106 @@
+import type { TripStatus, TripVisibility } from '@chamuco/shared-types';
+
+// ─── Request payloads ────────────────────────────────────────────────────────
+
+export interface CreateTripPayload {
+  name: string;
+  description?: string;
+  visibility: TripVisibility;
+  startDate: string;
+  endDate: string;
+  participantCapacity: number;
+  departureCountry: string;
+  departureCity: string;
+  landingCountry: string;
+  landingCity: string;
+  defaultTimezone?: string;
+  defaultCurrency?: string;
+  itineraryNotes?: string;
+  isTravelingParticipant: boolean;
+}
+
+export interface UpdateTripPayload {
+  name?: string;
+  description?: string;
+  visibility?: TripVisibility;
+  startDate?: string;
+  endDate?: string;
+  participantCapacity?: number;
+  departureCountry?: string;
+  departureCity?: string;
+  landingCountry?: string;
+  landingCity?: string;
+  defaultTimezone?: string;
+  defaultCurrency?: string;
+  itineraryNotes?: string;
+}
+
+export interface TransitionTripStatusPayload {
+  status: TripStatus;
+}
+
+export interface CreateDestinationPayload {
+  countryCode: string;
+  city: string;
+  label?: string;
+}
+
+export interface UpdateDestinationPayload {
+  countryCode?: string;
+  city?: string;
+  label?: string;
+}
+
+export interface ReorderDestinationsPayload {
+  destinationIds: string[];
+}
+
+export interface AddTripGroupPayload {
+  groupId: string;
+}
+
+// ─── Response shapes ─────────────────────────────────────────────────────────
+
+export interface TripResponse {
+  id: string;
+  name: string;
+  description: string | null;
+  status: TripStatus;
+  visibility: TripVisibility;
+  startDate: string;
+  endDate: string;
+  participantCapacity: number;
+  departureCountry: string;
+  departureCity: string;
+  landingCountry: string;
+  landingCity: string;
+  defaultTimezone: string | null;
+  defaultCurrency: string | null;
+  itineraryNotes: string | null;
+  agencyId: string | null;
+  createdBy: string;
+  createdAt: string;
+  updatedAt: string;
+  requiresConfirmation: boolean;
+  feedbackOpenUntil: string | null;
+}
+
+export interface DestinationResponse {
+  id: string;
+  tripId: string;
+  position: number;
+  countryCode: string;
+  city: string;
+  label: string | null;
+  createdAt: string;
+}
+
+export interface DestinationWriteResponse extends DestinationResponse {
+  requiresConfirmation: boolean;
+}
+
+export interface TripGroupResponse {
+  tripId: string;
+  groupId: string;
+  addedAt: string;
+}


### PR DESCRIPTION
## Summary

The frontend had no typed way to call any trip endpoint. This PR adds the missing API client layer — 13 functions covering the full trip surface (CRUD, status transitions, destinations, and group links) — so all upcoming trip UI issues have a typed foundation to build on.

## Changes

**New file — `trips.types.ts`**
- 7 request payload interfaces mirroring the NestJS DTOs (`CreateTripPayload`, `UpdateTripPayload`, `TransitionTripStatusPayload`, `CreateDestinationPayload`, `UpdateDestinationPayload`, `ReorderDestinationsPayload`, `AddTripGroupPayload`)
- 4 response interfaces (`TripResponse`, `DestinationResponse`, `DestinationWriteResponse`, `TripGroupResponse`)
- Enums imported from `@chamuco/shared-types` (`TripStatus`, `TripVisibility`) — no duplication

**Modified — `api-client.ts`**
- 13 exported async functions grouped by domain (trips, destinations, groups)
- Each function calls the appropriate `apiClient.get/post/patch/delete` and returns `response.data` with a concrete return type — no `any`

**Modified — `api-client.test.ts`**
- Extended the `vi.hoisted` mock to expose `.get`, `.post`, `.patch`, `.delete` on `mockAxiosInstance`
- 39 new tests: happy path + 401 + 404 for each of the 13 methods

## Testing

- All 1475 web unit tests pass (`pnpm --filter web test`)
- Lint clean (`pnpm --filter web lint:check`)
- Verify each function targets the correct URL and HTTP verb, and that errors propagate unmodified to callers

Closes #405