### PR TITLE
refactor(api): normalize error responses for non-successful service operations

### DIFF
--- a/apps/api/src/modules/group-members/group-members.controller.spec.ts
+++ b/apps/api/src/modules/group-members/group-members.controller.spec.ts
@@ -68,6 +68,7 @@ let mockRemoveMember: jest.Mock;
 let mockUpdateMemberRole: jest.Mock;
 let mockListActiveMembers: jest.Mock;
 let mockListPendingMembers: jest.Mock;
+let mockGetMyMembership: jest.Mock;
 
 describe('GroupMembersController', () => {
   let controller: GroupMembersController;
@@ -84,6 +85,10 @@ describe('GroupMembersController', () => {
     mockUpdateMemberRole = jest.fn().mockResolvedValue(undefined);
     mockListActiveMembers = jest.fn().mockResolvedValue([mockMemberResponse]);
     mockListPendingMembers = jest.fn().mockResolvedValue([mockPendingResponse]);
+    mockGetMyMembership = jest.fn().mockResolvedValue({
+      status: GroupMemberStatus.ACTIVE,
+      role: GroupRole.MEMBER,
+    });
 
     const module: TestingModule = await Test.createTestingModule({
       controllers: [GroupMembersController],
@@ -102,6 +107,7 @@ describe('GroupMembersController', () => {
             updateMemberRole: mockUpdateMemberRole,
             listActiveMembers: mockListActiveMembers,
             listPendingMembers: mockListPendingMembers,
+            getMyMembership: mockGetMyMembership,
           },
         },
       ],
@@ -219,6 +225,24 @@ describe('GroupMembersController', () => {
 
       expect(mockListPendingMembers).toHaveBeenCalledWith('group-uuid', mockAuthUser.id);
       expect(result).toEqual([mockPendingResponse]);
+    });
+  });
+
+  describe('GET /v1/groups/:id/me/membership', () => {
+    it('delegates to GroupMembersService.getMyMembership and returns the result', async () => {
+      const result = await controller.getMyMembership(mockAuthUser, 'group-uuid');
+
+      expect(mockGetMyMembership).toHaveBeenCalledWith('group-uuid', mockAuthUser.id);
+      expect(result).toEqual({ status: GroupMemberStatus.ACTIVE, role: GroupRole.MEMBER });
+    });
+
+    it('propagates NotFoundException when service throws', async () => {
+      const { NotFoundException } = await import('@nestjs/common');
+      mockGetMyMembership.mockRejectedValue(new NotFoundException('Membership not found'));
+
+      await expect(controller.getMyMembership(mockAuthUser, 'group-uuid')).rejects.toThrow(
+        NotFoundException,
+      );
     });
   });
 });

--- a/apps/api/src/modules/group-members/group-members.controller.ts
+++ b/apps/api/src/modules/group-members/group-members.controller.ts
@@ -245,7 +245,8 @@ export class GroupMembersController {
   @ApiOperation({
     summary: 'Get my membership',
     description:
-      "Returns the authenticated user's current membership status and role for the group, or null if no membership record exists.",
+      "Returns the authenticated user's current membership status and role for the group. " +
+      'Throws 404 if the group does not exist or the caller is not a member.',
   })
   @ApiParam({ name: 'id', type: String, description: 'Group UUID' })
   @ApiResponse({ status: 200, type: MyMembershipResponseDto })

--- a/apps/api/src/modules/group-members/group-members.controller.ts
+++ b/apps/api/src/modules/group-members/group-members.controller.ts
@@ -248,17 +248,13 @@ export class GroupMembersController {
       "Returns the authenticated user's current membership status and role for the group, or null if no membership record exists.",
   })
   @ApiParam({ name: 'id', type: String, description: 'Group UUID' })
-  @ApiResponse({
-    status: 200,
-    type: MyMembershipResponseDto,
-    description: 'Membership record, or null if none.',
-  })
+  @ApiResponse({ status: 200, type: MyMembershipResponseDto })
   @ApiUnauthorizedResponse({ description: 'Unauthenticated.' })
-  @ApiNotFoundResponse({ description: 'Group not found.' })
+  @ApiNotFoundResponse({ description: 'Group not found, or caller is not a member.' })
   async getMyMembership(
     @CurrentUser() user: AuthenticatedUser,
     @Param('id', ParseUUIDPipe) id: string,
-  ): Promise<MyMembershipResponseDto | null> {
+  ): Promise<MyMembershipResponseDto> {
     return this.groupMembersService.getMyMembership(id, user.id);
   }
 

--- a/apps/api/src/modules/group-members/group-members.service.spec.ts
+++ b/apps/api/src/modules/group-members/group-members.service.spec.ts
@@ -1102,4 +1102,33 @@ describe('GroupMembersService', () => {
       expect(result).toEqual([]);
     });
   });
+
+  // ─── getMyMembership ─────────────────────────────────────────────────────────
+
+  describe('getMyMembership', () => {
+    it('returns membership dto when user is an active member', async () => {
+      mockGroupsFindFirst.mockResolvedValue(mockPublicGroup);
+      mockGroupMembersFindFirst.mockResolvedValue(activeMembership);
+
+      const result = await service.getMyMembership(GROUP_ID, USER_ID);
+
+      expect(result).toEqual({
+        status: GroupMemberStatus.ACTIVE,
+        role: GroupRole.MEMBER,
+      });
+    });
+
+    it('throws NotFoundException when group does not exist', async () => {
+      mockGroupsFindFirst.mockResolvedValue(undefined);
+
+      await expect(service.getMyMembership(GROUP_ID, USER_ID)).rejects.toThrow(NotFoundException);
+    });
+
+    it('throws NotFoundException when user is not a member of the group', async () => {
+      mockGroupsFindFirst.mockResolvedValue(mockPublicGroup);
+      mockGroupMembersFindFirst.mockResolvedValue(undefined);
+
+      await expect(service.getMyMembership(GROUP_ID, USER_ID)).rejects.toThrow(NotFoundException);
+    });
+  });
 });

--- a/apps/api/src/modules/group-members/group-members.service.ts
+++ b/apps/api/src/modules/group-members/group-members.service.ts
@@ -528,14 +528,14 @@ export class GroupMembersService {
 
   // ─── My membership ───────────────────────────────────────────────────────────
 
-  async getMyMembership(groupId: string, userId: string): Promise<MyMembershipResponseDto | null> {
+  async getMyMembership(groupId: string, userId: string): Promise<MyMembershipResponseDto> {
     await this.assertGroupExists(groupId);
 
     const membership = await this.db.query.groupMembers.findFirst({
       where: and(eq(groupMembers.groupId, groupId), eq(groupMembers.userId, userId)),
     });
 
-    if (!membership) return null;
+    if (!membership) throw new NotFoundException('Membership not found');
 
     return {
       status: membership.status as GroupMemberStatus,

--- a/apps/api/src/modules/groups/groups.controller.ts
+++ b/apps/api/src/modules/groups/groups.controller.ts
@@ -12,15 +12,16 @@ import {
   Query,
 } from '@nestjs/common';
 import {
+  ApiBadRequestResponse,
   ApiBearerAuth,
+  ApiForbiddenResponse,
+  ApiNotFoundResponse,
   ApiOperation,
   ApiParam,
   ApiQuery,
   ApiResponse,
   ApiTags,
-  ApiBadRequestResponse,
-  ApiForbiddenResponse,
-  ApiNotFoundResponse,
+  ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
 
 import { CurrentUser } from '@/common/decorators/current-user.decorator';
@@ -48,6 +49,7 @@ export class GroupsController {
   })
   @ApiResponse({ status: 201, type: GroupResponseDto })
   @ApiBadRequestResponse({ description: 'Validation error in request body.' })
+  @ApiUnauthorizedResponse({ description: 'Unauthenticated.' })
   async createGroup(
     @CurrentUser() user: AuthenticatedUser,
     @Body() dto: CreateGroupDto,
@@ -63,6 +65,7 @@ export class GroupsController {
       'Currently returns an empty list until group membership is implemented.',
   })
   @ApiResponse({ status: 200, type: [GroupResponseDto] })
+  @ApiUnauthorizedResponse({ description: 'Unauthenticated.' })
   async listMyGroups(@CurrentUser() user: AuthenticatedUser): Promise<GroupResponseDto[]> {
     return this.groupsService.listMyGroups(user.id);
   }
@@ -94,6 +97,7 @@ export class GroupsController {
   })
   @ApiResponse({ status: 200, type: GroupSearchResponseDto })
   @ApiBadRequestResponse({ description: 'Validation error in query params.' })
+  @ApiUnauthorizedResponse({ description: 'Unauthenticated.' })
   async searchGroups(
     @CurrentUser() user: AuthenticatedUser,
     @Query() query: SearchGroupsQueryDto,
@@ -105,6 +109,7 @@ export class GroupsController {
   @ApiOperation({ summary: 'Get a group by ID' })
   @ApiParam({ name: 'id', type: String, description: 'Group UUID' })
   @ApiResponse({ status: 200, type: GroupResponseDto })
+  @ApiUnauthorizedResponse({ description: 'Unauthenticated.' })
   @ApiNotFoundResponse({ description: 'Group not found.' })
   async getGroup(
     @CurrentUser() user: AuthenticatedUser,
@@ -124,6 +129,7 @@ export class GroupsController {
     description:
       'Validation error in request body, or GROUP_CANNOT_BE_MADE_PUBLIC: group has non-owner members and cannot be switched to PUBLIC.',
   })
+  @ApiUnauthorizedResponse({ description: 'Unauthenticated.' })
   @ApiForbiddenResponse({ description: 'Only the group owner can update this group.' })
   @ApiNotFoundResponse({ description: 'Group not found.' })
   async updateGroup(
@@ -142,6 +148,7 @@ export class GroupsController {
   })
   @ApiParam({ name: 'id', type: String, description: 'Group UUID' })
   @ApiResponse({ status: 204, description: 'Group deleted.' })
+  @ApiUnauthorizedResponse({ description: 'Unauthenticated.' })
   @ApiForbiddenResponse({ description: 'Only the group owner can delete this group.' })
   @ApiNotFoundResponse({ description: 'Group not found.' })
   async deleteGroup(

--- a/apps/api/src/modules/notifications/notifications.controller.ts
+++ b/apps/api/src/modules/notifications/notifications.controller.ts
@@ -11,13 +11,16 @@ import {
   Query,
 } from '@nestjs/common';
 import {
+  ApiBadRequestResponse,
   ApiBearerAuth,
   ApiBody,
+  ApiNotFoundResponse,
   ApiOperation,
   ApiParam,
   ApiQuery,
   ApiResponse,
   ApiTags,
+  ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
 import { CurrentUser } from '@/common/decorators/current-user.decorator';
 import type { AuthenticatedUser } from '@/types/express';
@@ -56,8 +59,8 @@ export class NotificationsController {
       'Pass the returned `nextCursor` as `cursor` to fetch the next page.',
   })
   @ApiResponse({ status: 200, type: NotificationsPageDto })
-  @ApiResponse({ status: 400, description: 'Invalid cursor — must be an ISO 8601 timestamp' })
-  @ApiResponse({ status: 401, description: 'Missing or invalid Firebase ID token' })
+  @ApiBadRequestResponse({ description: 'Invalid cursor — must be an ISO 8601 timestamp.' })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid Firebase ID token.' })
   async getNotifications(
     @CurrentUser() user: AuthenticatedUser,
     @Query() query: GetNotificationsQueryDto,
@@ -79,8 +82,8 @@ export class NotificationsController {
     summary: 'Mark all notifications as read',
     description: 'Sets readAt on every unread notification belonging to the authenticated user.',
   })
-  @ApiResponse({ status: 204, description: 'All unread notifications marked as read' })
-  @ApiResponse({ status: 401, description: 'Missing or invalid Firebase ID token' })
+  @ApiResponse({ status: 204, description: 'All unread notifications marked as read.' })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid Firebase ID token.' })
   async markAllRead(@CurrentUser() user: AuthenticatedUser): Promise<void> {
     return this.notificationsService.markAllRead(user.id);
   }
@@ -91,11 +94,12 @@ export class NotificationsController {
     summary: 'Mark a single notification as read',
     description:
       'Sets readAt on the specified notification. ' +
-      'Silently succeeds if the notification is already read or belongs to a different user.',
+      'Idempotent — marking an already-read notification succeeds.',
   })
   @ApiParam({ name: 'id', description: 'UUID of the notification to mark as read', format: 'uuid' })
-  @ApiResponse({ status: 204, description: 'Notification marked as read' })
-  @ApiResponse({ status: 401, description: 'Missing or invalid Firebase ID token' })
+  @ApiResponse({ status: 204, description: 'Notification marked as read.' })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid Firebase ID token.' })
+  @ApiNotFoundResponse({ description: 'Notification not found.' })
   async markRead(
     @CurrentUser() user: AuthenticatedUser,
     @Param('id', ParseUUIDPipe) id: string,
@@ -112,9 +116,9 @@ export class NotificationsController {
       'Idempotent — registering the same token again updates last_used_at.',
   })
   @ApiBody({ type: RegisterFcmTokenDto })
-  @ApiResponse({ status: 204, description: 'Token registered' })
-  @ApiResponse({ status: 400, description: 'Validation error' })
-  @ApiResponse({ status: 401, description: 'Missing or invalid Firebase ID token' })
+  @ApiResponse({ status: 204, description: 'Token registered.' })
+  @ApiBadRequestResponse({ description: 'Validation error.' })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid Firebase ID token.' })
   async registerFcmToken(
     @CurrentUser() user: AuthenticatedUser,
     @Body() dto: RegisterFcmTokenDto,
@@ -130,9 +134,9 @@ export class NotificationsController {
       'Deletes the given FCM token on logout. ' + 'Returns 204 even if the token does not exist.',
   })
   @ApiBody({ type: DeleteFcmTokenDto })
-  @ApiResponse({ status: 204, description: 'Token removed (or was not present)' })
-  @ApiResponse({ status: 400, description: 'Validation error' })
-  @ApiResponse({ status: 401, description: 'Missing or invalid Firebase ID token' })
+  @ApiResponse({ status: 204, description: 'Token removed (or was not present).' })
+  @ApiBadRequestResponse({ description: 'Validation error.' })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid Firebase ID token.' })
   async deleteFcmToken(
     @CurrentUser() user: AuthenticatedUser,
     @Body() dto: DeleteFcmTokenDto,

--- a/apps/api/src/modules/notifications/notifications.service.spec.ts
+++ b/apps/api/src/modules/notifications/notifications.service.spec.ts
@@ -1,4 +1,4 @@
-import { BadRequestException } from '@nestjs/common';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { DeliveryStatus, NotificationChannel, NotificationType } from '@chamuco/shared-types';
 import { DRIZZLE_CLIENT } from '@/database/drizzle.provider';
@@ -621,7 +621,6 @@ describe('NotificationsService', () => {
     });
 
     it('throws NotFoundException when notification not found for this user', async () => {
-      const { NotFoundException } = await import('@nestjs/common');
       db.update.mockReturnValue(makeUpdateReturning([]));
 
       await expect(service.markRead('user-1', 'notif-99')).rejects.toThrow(NotFoundException);

--- a/apps/api/src/modules/notifications/notifications.service.spec.ts
+++ b/apps/api/src/modules/notifications/notifications.service.spec.ts
@@ -32,6 +32,14 @@ const makeUpdate = () => ({
   }),
 });
 
+const makeUpdateReturning = (rows: object[]) => ({
+  set: jest.fn().mockReturnValue({
+    where: jest.fn().mockReturnValue({
+      returning: jest.fn().mockResolvedValue(rows),
+    }),
+  }),
+});
+
 const makeSelect = (rows: object[]) => ({
   from: jest.fn().mockReturnValue({
     where: jest.fn().mockReturnValue({
@@ -602,7 +610,7 @@ describe('NotificationsService', () => {
 
   describe('markRead()', () => {
     it('updates readAt for the given user and notification', async () => {
-      db.update.mockReturnValue(makeUpdate());
+      db.update.mockReturnValue(makeUpdateReturning([{ id: 'notif-1' }]));
 
       await service.markRead('user-1', 'notif-1');
 
@@ -610,6 +618,13 @@ describe('NotificationsService', () => {
       const setFn = db.update.mock.results[0]!.value.set as jest.Mock;
       const setArg = setFn.mock.calls[0]![0] as { readAt: unknown };
       expect(setArg.readAt).toBeInstanceOf(Date);
+    });
+
+    it('throws NotFoundException when notification not found for this user', async () => {
+      const { NotFoundException } = await import('@nestjs/common');
+      db.update.mockReturnValue(makeUpdateReturning([]));
+
+      await expect(service.markRead('user-1', 'notif-99')).rejects.toThrow(NotFoundException);
     });
   });
 

--- a/apps/api/src/modules/notifications/notifications.service.ts
+++ b/apps/api/src/modules/notifications/notifications.service.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Inject, Injectable, Logger } from '@nestjs/common';
+import { BadRequestException, Inject, Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { and, count, desc, eq, inArray, isNull, lt, sql } from 'drizzle-orm';
 import {
   DeliveryStatus,
@@ -168,10 +168,13 @@ export class NotificationsService {
   }
 
   async markRead(userId: string, notificationId: string): Promise<void> {
-    await this.db
+    const [updated] = await this.db
       .update(notifications)
       .set({ readAt: new Date() })
-      .where(and(eq(notifications.id, notificationId), eq(notifications.userId, userId)));
+      .where(and(eq(notifications.id, notificationId), eq(notifications.userId, userId)))
+      .returning({ id: notifications.id });
+
+    if (!updated) throw new NotFoundException('Notification not found');
   }
 
   async markAllRead(userId: string): Promise<void> {

--- a/apps/api/src/modules/users/users.controller.ts
+++ b/apps/api/src/modules/users/users.controller.ts
@@ -12,13 +12,17 @@ import {
   Query,
 } from '@nestjs/common';
 import {
+  ApiBadRequestResponse,
   ApiBody,
   ApiBearerAuth,
+  ApiConflictResponse,
+  ApiNotFoundResponse,
   ApiOperation,
   ApiParam,
   ApiQuery,
   ApiResponse,
   ApiTags,
+  ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
 import { Throttle } from '@nestjs/throttler';
 import { CurrentUser } from '@/common/decorators/current-user.decorator';
@@ -66,8 +70,8 @@ export class UsersController {
       'phone number, and bio.',
   })
   @ApiResponse({ status: 200, type: UserProfileResponseDto })
-  @ApiResponse({ status: 401, description: 'Missing or invalid Firebase ID token' })
-  @ApiResponse({ status: 404, description: 'User profile not found' })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid Firebase ID token.' })
+  @ApiNotFoundResponse({ description: 'User profile not found.' })
   getProfile(@CurrentUser() user: AuthenticatedUser): Promise<UserProfileResponseDto> {
     return this.usersService.getProfile(user.id);
   }
@@ -84,9 +88,9 @@ export class UsersController {
       'Email must be a valid address when provided; updating it resets emailVerified to false.',
   })
   @ApiResponse({ status: 200, type: UserProfileResponseDto })
-  @ApiResponse({ status: 400, description: 'Validation failed — invalid field value' })
-  @ApiResponse({ status: 401, description: 'Missing or invalid Firebase ID token' })
-  @ApiResponse({ status: 404, description: 'User profile not found' })
+  @ApiBadRequestResponse({ description: 'Validation failed — invalid field value.' })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid Firebase ID token.' })
+  @ApiNotFoundResponse({ description: 'User profile not found.' })
   updateProfile(
     @CurrentUser() user: AuthenticatedUser,
     @Body() dto: UpdateUserProfileDto,
@@ -103,8 +107,8 @@ export class UsersController {
       'Chamuco registration (i.e. has not chosen a username).',
   })
   @ApiResponse({ status: 200, type: UserResponseDto })
-  @ApiResponse({ status: 401, description: 'Missing or invalid Firebase ID token' })
-  @ApiResponse({ status: 404, description: 'User record not found — registration not completed' })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid Firebase ID token.' })
+  @ApiNotFoundResponse({ description: 'User record not found — registration not completed.' })
   getMe(@CurrentUser() user: AuthenticatedUser): Promise<UserResponseDto> {
     return this.usersService.getMe(user);
   }
@@ -118,9 +122,9 @@ export class UsersController {
       'Updates any subset of editable user fields: displayName, timezone, profileVisibility.',
   })
   @ApiResponse({ status: 200, type: UserResponseDto })
-  @ApiResponse({ status: 400, description: 'Validation failed — invalid field value' })
-  @ApiResponse({ status: 401, description: 'Missing or invalid Firebase ID token' })
-  @ApiResponse({ status: 404, description: 'User not found' })
+  @ApiBadRequestResponse({ description: 'Validation failed — invalid field value.' })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid Firebase ID token.' })
+  @ApiNotFoundResponse({ description: 'User not found.' })
   async updateMe(
     @CurrentUser() user: AuthenticatedUser,
     @Body() dto: UpdateUserDto,
@@ -140,8 +144,8 @@ export class UsersController {
       'The previous avatar asset is deleted after the new one is stored.',
   })
   @ApiResponse({ status: 200, type: UserResponseDto })
-  @ApiResponse({ status: 400, description: 'Invalid source or target' })
-  @ApiResponse({ status: 401, description: 'Missing or invalid Firebase ID token' })
+  @ApiBadRequestResponse({ description: 'Invalid source or target.' })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid Firebase ID token.' })
   updateAvatar(
     @CurrentUser() user: AuthenticatedUser,
     @Body() dto: UpdateAvatarDto,
@@ -158,8 +162,8 @@ export class UsersController {
       'phobias, physical limitations, and medical conditions.',
   })
   @ApiResponse({ status: 200, type: UserHealthResponseDto })
-  @ApiResponse({ status: 401, description: 'Missing or invalid Firebase ID token' })
-  @ApiResponse({ status: 404, description: 'User profile not found' })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid Firebase ID token.' })
+  @ApiNotFoundResponse({ description: 'User profile not found.' })
   getHealthProfile(@CurrentUser() user: AuthenticatedUser): Promise<UserHealthResponseDto> {
     return this.usersService.getHealth(user.id);
   }
@@ -175,12 +179,11 @@ export class UsersController {
       'description is required when the enum value is OTHER.',
   })
   @ApiResponse({ status: 200, type: UserHealthResponseDto })
-  @ApiResponse({
-    status: 400,
-    description: 'Validation failed — invalid enum value or missing description for OTHER',
+  @ApiBadRequestResponse({
+    description: 'Validation failed — invalid enum value or missing description for OTHER.',
   })
-  @ApiResponse({ status: 401, description: 'Missing or invalid Firebase ID token' })
-  @ApiResponse({ status: 404, description: 'User profile not found' })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid Firebase ID token.' })
+  @ApiNotFoundResponse({ description: 'User profile not found.' })
   updateHealthProfile(
     @CurrentUser() user: AuthenticatedUser,
     @Body() dto: UpdateUserHealthDto,
@@ -194,8 +197,8 @@ export class UsersController {
     description: "Returns all emergency contacts stored on the authenticated user's profile.",
   })
   @ApiResponse({ status: 200, type: EmergencyContactDto, isArray: true })
-  @ApiResponse({ status: 401, description: 'Missing or invalid Firebase ID token' })
-  @ApiResponse({ status: 404, description: 'User profile not found' })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid Firebase ID token.' })
+  @ApiNotFoundResponse({ description: 'User profile not found.' })
   getEmergencyContacts(@CurrentUser() user: AuthenticatedUser): Promise<EmergencyContactDto[]> {
     return this.usersService.getEmergencyContacts(user.id);
   }
@@ -210,9 +213,9 @@ export class UsersController {
       'If isPrimary is true, the current primary contact is automatically demoted.',
   })
   @ApiResponse({ status: 201, type: EmergencyContactDto })
-  @ApiResponse({ status: 400, description: 'Validation failed — invalid field value' })
-  @ApiResponse({ status: 401, description: 'Missing or invalid Firebase ID token' })
-  @ApiResponse({ status: 404, description: 'User profile not found' })
+  @ApiBadRequestResponse({ description: 'Validation failed — invalid field value.' })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid Firebase ID token.' })
+  @ApiNotFoundResponse({ description: 'User profile not found.' })
   addEmergencyContact(
     @CurrentUser() user: AuthenticatedUser,
     @Body() dto: EmergencyContactDto,
@@ -231,13 +234,12 @@ export class UsersController {
       'If isPrimary is set to true, all other contacts are automatically demoted.',
   })
   @ApiResponse({ status: 200, type: EmergencyContactDto })
-  @ApiResponse({
-    status: 400,
+  @ApiBadRequestResponse({
     description:
-      'Validation failed — invalid field value, or isPrimary: false (assign a new primary instead)',
+      'Validation failed — invalid field value, or isPrimary: false (assign a new primary instead).',
   })
-  @ApiResponse({ status: 401, description: 'Missing or invalid Firebase ID token' })
-  @ApiResponse({ status: 404, description: 'User profile or emergency contact not found' })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid Firebase ID token.' })
+  @ApiNotFoundResponse({ description: 'User profile or emergency contact not found.' })
   updateEmergencyContact(
     @CurrentUser() user: AuthenticatedUser,
     @Param('id', ParseUUIDPipe) contactId: string,
@@ -255,13 +257,10 @@ export class UsersController {
       'Removes a single emergency contact. ' +
       'Returns 409 if the contact is the primary and other contacts exist — re-assign primary first.',
   })
-  @ApiResponse({ status: 204, description: 'Contact deleted' })
-  @ApiResponse({ status: 401, description: 'Missing or invalid Firebase ID token' })
-  @ApiResponse({ status: 404, description: 'User profile or emergency contact not found' })
-  @ApiResponse({
-    status: 409,
-    description: 'Cannot delete primary contact while other contacts exist',
-  })
+  @ApiResponse({ status: 204, description: 'Contact deleted.' })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid Firebase ID token.' })
+  @ApiNotFoundResponse({ description: 'User profile or emergency contact not found.' })
+  @ApiConflictResponse({ description: 'Cannot delete primary contact while other contacts exist.' })
   deleteEmergencyContact(
     @CurrentUser() user: AuthenticatedUser,
     @Param('id', ParseUUIDPipe) contactId: string,
@@ -276,7 +275,7 @@ export class UsersController {
       'Returns all nationality records for the authenticated user, ordered by primary first.',
   })
   @ApiResponse({ status: 200, type: NationalityResponseDto, isArray: true })
-  @ApiResponse({ status: 401, description: 'Missing or invalid Firebase ID token' })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid Firebase ID token.' })
   getNationalities(@CurrentUser() user: AuthenticatedUser): Promise<NationalityResponseDto[]> {
     return this.usersService.getNationalities(user.id);
   }
@@ -292,12 +291,11 @@ export class UsersController {
       'If any passport field is provided, all three must be present.',
   })
   @ApiResponse({ status: 201, type: NationalityResponseDto })
-  @ApiResponse({
-    status: 400,
-    description: 'Validation failed — invalid field value or incomplete passport data',
+  @ApiBadRequestResponse({
+    description: 'Validation failed — invalid field value or incomplete passport data.',
   })
-  @ApiResponse({ status: 401, description: 'Missing or invalid Firebase ID token' })
-  @ApiResponse({ status: 409, description: 'Nationality for this country already exists' })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid Firebase ID token.' })
+  @ApiConflictResponse({ description: 'Nationality for this country already exists.' })
   addNationality(
     @CurrentUser() user: AuthenticatedUser,
     @Body() dto: CreateNationalityDto,
@@ -318,13 +316,12 @@ export class UsersController {
       'If any passport field is provided, all three must be present.',
   })
   @ApiResponse({ status: 200, type: NationalityResponseDto })
-  @ApiResponse({
-    status: 400,
+  @ApiBadRequestResponse({
     description:
-      'Validation failed — invalid field value, incomplete passport data, or isPrimary: false',
+      'Validation failed — invalid field value, incomplete passport data, or isPrimary: false.',
   })
-  @ApiResponse({ status: 401, description: 'Missing or invalid Firebase ID token' })
-  @ApiResponse({ status: 404, description: 'Nationality not found' })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid Firebase ID token.' })
+  @ApiNotFoundResponse({ description: 'Nationality not found.' })
   updateNationality(
     @CurrentUser() user: AuthenticatedUser,
     @Param('id', ParseUUIDPipe) nationalityId: string,
@@ -342,12 +339,11 @@ export class UsersController {
       'Removes a single nationality record. ' +
       'Returns 409 if the record is the primary and other nationalities exist — re-assign primary first.',
   })
-  @ApiResponse({ status: 204, description: 'Nationality deleted' })
-  @ApiResponse({ status: 401, description: 'Missing or invalid Firebase ID token' })
-  @ApiResponse({ status: 404, description: 'Nationality not found' })
-  @ApiResponse({
-    status: 409,
-    description: 'Cannot delete primary nationality while other nationalities exist',
+  @ApiResponse({ status: 204, description: 'Nationality deleted.' })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid Firebase ID token.' })
+  @ApiNotFoundResponse({ description: 'Nationality not found.' })
+  @ApiConflictResponse({
+    description: 'Cannot delete primary nationality while other nationalities exist.',
   })
   deleteNationality(
     @CurrentUser() user: AuthenticatedUser,
@@ -364,8 +360,8 @@ export class UsersController {
       'Visible only to the user themselves.',
   })
   @ApiResponse({ status: 200, type: LoyaltyProgramDto, isArray: true })
-  @ApiResponse({ status: 401, description: 'Missing or invalid Firebase ID token' })
-  @ApiResponse({ status: 404, description: 'User profile not found' })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid Firebase ID token.' })
+  @ApiNotFoundResponse({ description: 'User profile not found.' })
   getLoyaltyPrograms(@CurrentUser() user: AuthenticatedUser): Promise<LoyaltyProgramDto[]> {
     return this.usersService.getLoyaltyPrograms(user.id);
   }
@@ -380,9 +376,9 @@ export class UsersController {
       'No uniqueness check — a user may hold multiple memberships in the same program.',
   })
   @ApiResponse({ status: 201, type: LoyaltyProgramDto })
-  @ApiResponse({ status: 400, description: 'Validation failed — invalid field value' })
-  @ApiResponse({ status: 401, description: 'Missing or invalid Firebase ID token' })
-  @ApiResponse({ status: 404, description: 'User profile not found' })
+  @ApiBadRequestResponse({ description: 'Validation failed — invalid field value.' })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid Firebase ID token.' })
+  @ApiNotFoundResponse({ description: 'User profile not found.' })
   addLoyaltyProgram(
     @CurrentUser() user: AuthenticatedUser,
     @Body() dto: LoyaltyProgramDto,
@@ -399,9 +395,9 @@ export class UsersController {
     description: 'Updates any subset of fields on a single loyalty program identified by its UUID.',
   })
   @ApiResponse({ status: 200, type: LoyaltyProgramDto })
-  @ApiResponse({ status: 400, description: 'Validation failed — invalid field value' })
-  @ApiResponse({ status: 401, description: 'Missing or invalid Firebase ID token' })
-  @ApiResponse({ status: 404, description: 'User profile or loyalty program not found' })
+  @ApiBadRequestResponse({ description: 'Validation failed — invalid field value.' })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid Firebase ID token.' })
+  @ApiNotFoundResponse({ description: 'User profile or loyalty program not found.' })
   updateLoyaltyProgram(
     @CurrentUser() user: AuthenticatedUser,
     @Param('id', ParseUUIDPipe) programId: string,
@@ -417,9 +413,9 @@ export class UsersController {
     summary: 'Delete a loyalty program',
     description: 'Removes a single loyalty program identified by its UUID.',
   })
-  @ApiResponse({ status: 204, description: 'Loyalty program deleted' })
-  @ApiResponse({ status: 401, description: 'Missing or invalid Firebase ID token' })
-  @ApiResponse({ status: 404, description: 'User profile or loyalty program not found' })
+  @ApiResponse({ status: 204, description: 'Loyalty program deleted.' })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid Firebase ID token.' })
+  @ApiNotFoundResponse({ description: 'User profile or loyalty program not found.' })
   deleteLoyaltyProgram(
     @CurrentUser() user: AuthenticatedUser,
     @Param('id', ParseUUIDPipe) programId: string,
@@ -433,8 +429,8 @@ export class UsersController {
     description: "Returns the authenticated user's preferences: language, currency, theme.",
   })
   @ApiResponse({ status: 200, type: UserPreferencesResponseDto })
-  @ApiResponse({ status: 401, description: 'Missing or invalid Firebase ID token' })
-  @ApiResponse({ status: 404, description: 'User preferences not found' })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid Firebase ID token.' })
+  @ApiNotFoundResponse({ description: 'User preferences not found.' })
   getPreferences(@CurrentUser() user: AuthenticatedUser): Promise<UserPreferencesResponseDto> {
     return this.usersService.getPreferences(user.id);
   }
@@ -447,9 +443,9 @@ export class UsersController {
     description: 'Updates any subset of preference fields: language, currency, theme.',
   })
   @ApiResponse({ status: 200, type: UserPreferencesResponseDto })
-  @ApiResponse({ status: 400, description: 'Validation failed — invalid enum value' })
-  @ApiResponse({ status: 401, description: 'Missing or invalid Firebase ID token' })
-  @ApiResponse({ status: 404, description: 'User preferences not found' })
+  @ApiBadRequestResponse({ description: 'Validation failed — invalid enum value.' })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid Firebase ID token.' })
+  @ApiNotFoundResponse({ description: 'User preferences not found.' })
   updatePreferences(
     @CurrentUser() user: AuthenticatedUser,
     @Body() dto: UpdateUserPreferencesDto,
@@ -467,8 +463,8 @@ export class UsersController {
       'IN_APP delivery (the notifications row) is always created regardless of preferences.',
   })
   @ApiResponse({ status: 200, type: NotificationPreferencesResponseDto })
-  @ApiResponse({ status: 401, description: 'Missing or invalid Firebase ID token' })
-  @ApiResponse({ status: 404, description: 'User preferences not found' })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid Firebase ID token.' })
+  @ApiNotFoundResponse({ description: 'User preferences not found.' })
   getNotificationPreferences(
     @CurrentUser() user: AuthenticatedUser,
   ): Promise<NotificationPreferencesResponseDto> {
@@ -488,9 +484,9 @@ export class UsersController {
       'To re-enable all channels for a type, omit the key.',
   })
   @ApiResponse({ status: 200, type: NotificationPreferencesResponseDto })
-  @ApiResponse({ status: 400, description: 'Validation failed — body must be an object' })
-  @ApiResponse({ status: 401, description: 'Missing or invalid Firebase ID token' })
-  @ApiResponse({ status: 404, description: 'User preferences not found' })
+  @ApiBadRequestResponse({ description: 'Validation failed — body must be an object.' })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid Firebase ID token.' })
+  @ApiNotFoundResponse({ description: 'User preferences not found.' })
   updateNotificationPreferences(
     @CurrentUser() user: AuthenticatedUser,
     @Body() dto: UpdateNotificationPreferencesDto,
@@ -511,9 +507,9 @@ export class UsersController {
   })
   @ApiQuery({ name: 'username', description: 'Username to check (3–30 chars, a-z 0-9 _ -)' })
   @ApiResponse({ status: 200, type: UsernameAvailabilityDto })
-  @ApiResponse({ status: 400, description: 'Invalid username format' })
-  @ApiResponse({ status: 401, description: 'Missing or invalid Firebase token' })
-  @ApiResponse({ status: 429, description: 'Too many requests' })
+  @ApiBadRequestResponse({ description: 'Invalid username format.' })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid Firebase token.' })
+  @ApiResponse({ status: 429, description: 'Too many requests.' })
   checkUsernameAvailability(@Query('username') username: string): Promise<UsernameAvailabilityDto> {
     const normalized = (username ?? '').toLowerCase();
     if (!/^[a-z0-9_-]{3,30}$/.test(normalized)) {
@@ -536,8 +532,8 @@ export class UsersController {
     format: 'uuid',
   })
   @ApiResponse({ status: 200, type: VisaResponseDto, isArray: true })
-  @ApiResponse({ status: 401, description: 'Missing or invalid Firebase ID token' })
-  @ApiResponse({ status: 404, description: 'Nationality not found' })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid Firebase ID token.' })
+  @ApiNotFoundResponse({ description: 'Nationality not found.' })
   getVisas(
     @CurrentUser() user: AuthenticatedUser,
     @Param('nationalityId', ParseUUIDPipe) nationalityId: string,
@@ -554,9 +550,9 @@ export class UsersController {
   })
   @ApiBody({ type: CreateVisaDto })
   @ApiResponse({ status: 201, type: VisaResponseDto })
-  @ApiResponse({ status: 400, description: 'Validation failed' })
-  @ApiResponse({ status: 401, description: 'Missing or invalid Firebase ID token' })
-  @ApiResponse({ status: 404, description: 'Nationality not found' })
+  @ApiBadRequestResponse({ description: 'Validation failed.' })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid Firebase ID token.' })
+  @ApiNotFoundResponse({ description: 'Nationality not found.' })
   addVisa(
     @CurrentUser() user: AuthenticatedUser,
     @Param('nationalityId', ParseUUIDPipe) nationalityId: string,
@@ -576,9 +572,9 @@ export class UsersController {
   @ApiParam({ name: 'id', description: 'UUID of the visa record', format: 'uuid' })
   @ApiBody({ type: UpdateVisaDto })
   @ApiResponse({ status: 200, type: VisaResponseDto })
-  @ApiResponse({ status: 400, description: 'Validation failed' })
-  @ApiResponse({ status: 401, description: 'Missing or invalid Firebase ID token' })
-  @ApiResponse({ status: 404, description: 'Nationality or visa not found' })
+  @ApiBadRequestResponse({ description: 'Validation failed.' })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid Firebase ID token.' })
+  @ApiNotFoundResponse({ description: 'Nationality or visa not found.' })
   updateVisa(
     @CurrentUser() user: AuthenticatedUser,
     @Param('nationalityId', ParseUUIDPipe) nationalityId: string,
@@ -597,9 +593,9 @@ export class UsersController {
     format: 'uuid',
   })
   @ApiParam({ name: 'id', description: 'UUID of the visa record', format: 'uuid' })
-  @ApiResponse({ status: 204, description: 'Visa deleted' })
-  @ApiResponse({ status: 401, description: 'Missing or invalid Firebase ID token' })
-  @ApiResponse({ status: 404, description: 'Nationality or visa not found' })
+  @ApiResponse({ status: 204, description: 'Visa deleted.' })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid Firebase ID token.' })
+  @ApiNotFoundResponse({ description: 'Nationality or visa not found.' })
   deleteVisa(
     @CurrentUser() user: AuthenticatedUser,
     @Param('nationalityId', ParseUUIDPipe) nationalityId: string,
@@ -620,8 +616,8 @@ export class UsersController {
     format: 'uuid',
   })
   @ApiResponse({ status: 200, type: EtaResponseDto, isArray: true })
-  @ApiResponse({ status: 401, description: 'Missing or invalid Firebase ID token' })
-  @ApiResponse({ status: 404, description: 'Nationality not found' })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid Firebase ID token.' })
+  @ApiNotFoundResponse({ description: 'Nationality not found.' })
   getEtas(
     @CurrentUser() user: AuthenticatedUser,
     @Param('nationalityId', ParseUUIDPipe) nationalityId: string,
@@ -638,9 +634,9 @@ export class UsersController {
   })
   @ApiBody({ type: CreateEtaDto })
   @ApiResponse({ status: 201, type: EtaResponseDto })
-  @ApiResponse({ status: 400, description: 'Validation failed' })
-  @ApiResponse({ status: 401, description: 'Missing or invalid Firebase ID token' })
-  @ApiResponse({ status: 404, description: 'Nationality not found' })
+  @ApiBadRequestResponse({ description: 'Validation failed.' })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid Firebase ID token.' })
+  @ApiNotFoundResponse({ description: 'Nationality not found.' })
   addEta(
     @CurrentUser() user: AuthenticatedUser,
     @Param('nationalityId', ParseUUIDPipe) nationalityId: string,
@@ -660,9 +656,9 @@ export class UsersController {
   @ApiParam({ name: 'id', description: 'UUID of the ETA record', format: 'uuid' })
   @ApiBody({ type: UpdateEtaDto })
   @ApiResponse({ status: 200, type: EtaResponseDto })
-  @ApiResponse({ status: 400, description: 'Validation failed' })
-  @ApiResponse({ status: 401, description: 'Missing or invalid Firebase ID token' })
-  @ApiResponse({ status: 404, description: 'Nationality or ETA not found' })
+  @ApiBadRequestResponse({ description: 'Validation failed.' })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid Firebase ID token.' })
+  @ApiNotFoundResponse({ description: 'Nationality or ETA not found.' })
   updateEta(
     @CurrentUser() user: AuthenticatedUser,
     @Param('nationalityId', ParseUUIDPipe) nationalityId: string,
@@ -681,9 +677,9 @@ export class UsersController {
     format: 'uuid',
   })
   @ApiParam({ name: 'id', description: 'UUID of the ETA record', format: 'uuid' })
-  @ApiResponse({ status: 204, description: 'ETA deleted' })
-  @ApiResponse({ status: 401, description: 'Missing or invalid Firebase ID token' })
-  @ApiResponse({ status: 404, description: 'Nationality or ETA not found' })
+  @ApiResponse({ status: 204, description: 'ETA deleted.' })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid Firebase ID token.' })
+  @ApiNotFoundResponse({ description: 'Nationality or ETA not found.' })
   deleteEta(
     @CurrentUser() user: AuthenticatedUser,
     @Param('nationalityId', ParseUUIDPipe) nationalityId: string,
@@ -715,8 +711,8 @@ export class UsersController {
     example: 10,
   })
   @ApiResponse({ status: 200, type: UserSearchResponseDto })
-  @ApiResponse({ status: 400, description: 'Validation error in query params' })
-  @ApiResponse({ status: 401, description: 'Missing or invalid Firebase ID token' })
+  @ApiBadRequestResponse({ description: 'Validation error in query params.' })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid Firebase ID token.' })
   searchUsers(
     @CurrentUser() user: AuthenticatedUser,
     @Query() query: SearchUsersQueryDto,
@@ -737,8 +733,8 @@ export class UsersController {
   })
   @ApiParam({ name: 'username', description: 'Username without @ prefix' })
   @ApiResponse({ status: 200, type: PublicProfileResponseDto })
-  @ApiResponse({ status: 404, description: 'User not found' })
-  @ApiResponse({ status: 429, description: 'Too many requests' })
+  @ApiNotFoundResponse({ description: 'User not found.' })
+  @ApiResponse({ status: 429, description: 'Too many requests.' })
   getPublicProfile(@Param('username') username: string): Promise<PublicProfileResponseDto> {
     return this.usersService.getPublicProfile(username);
   }

--- a/apps/web/src/app/groups/[id]/announcements/[announcementId]/edit/page.tsx
+++ b/apps/web/src/app/groups/[id]/announcements/[announcementId]/edit/page.tsx
@@ -37,7 +37,7 @@ export default function EditAnnouncementPage({ params }: EditAnnouncementPagePro
       try {
         const [membershipRes, announcementRes] = await Promise.all([
           apiClient
-            .get<{ status: string; role: GroupRole } | null>(`/v1/groups/${id}/members/me`)
+            .get<{ status: string; role: GroupRole }>(`/v1/groups/${id}/members/me`)
             .catch(() => null),
           apiClient.get<GroupAnnouncement>(`/v1/groups/${id}/announcements/${announcementId}`),
         ]);

--- a/apps/web/src/app/groups/[id]/announcements/new/page.tsx
+++ b/apps/web/src/app/groups/[id]/announcements/new/page.tsx
@@ -39,7 +39,7 @@ export default function NewAnnouncementPage({ params }: NewAnnouncementPageProps
         const [groupRes, membershipRes] = await Promise.all([
           apiClient.get<Group>(`/v1/groups/${id}`),
           apiClient
-            .get<{ status: string; role: GroupRole } | null>(`/v1/groups/${id}/members/me`)
+            .get<{ status: string; role: GroupRole }>(`/v1/groups/${id}/members/me`)
             .catch(() => null),
         ]);
 

--- a/apps/web/src/app/groups/[id]/page.tsx
+++ b/apps/web/src/app/groups/[id]/page.tsx
@@ -41,7 +41,7 @@ export default function GroupDetailPage({ params }: GroupDetailPageProps) {
     Promise.all([
       apiClient.get<Group>(`/v1/groups/${id}`),
       apiClient
-        .get<{ status: string; role: GroupRole } | null>(`/v1/groups/${id}/members/me`)
+        .get<{ status: string; role: GroupRole }>(`/v1/groups/${id}/members/me`)
         .catch(() => null),
       apiClient
         .get<GroupAnnouncementsResponse>(`/v1/groups/${id}/announcements?limit=3&offset=0`)


### PR DESCRIPTION
## Summary

Services across the API had inconsistent behavior for missing resources: some threw `NotFoundException`, some silently returned `null`, and one did a blind update that succeeded even when the target row didn't exist for the caller. This PR enforces a consistent contract — if a resource is not found, the service throws `NotFoundException`.

Separately, three controllers were still using the generic `@ApiResponse({ status: N })` form instead of the typed OpenAPI shorthand decorators (`@ApiNotFoundResponse`, `@ApiUnauthorizedResponse`, etc.) used everywhere else in the codebase.

## Changes

**Service-level error normalization**
- `group-members.service.ts` — `getMyMembership` now throws `NotFoundException` instead of returning `null` when the caller is not a member
- `notifications.service.ts` — `markRead` uses `.returning()` to detect zero-affected-row updates and throws `NotFoundException`; already-read notifications still succeed (idempotent overwrite of `readAt`)

**OpenAPI decorator normalization**
- `users.controller.ts` — replaced all `@ApiResponse({ status: 400/401/404/409 })` with `@ApiBadRequestResponse`, `@ApiUnauthorizedResponse`, `@ApiNotFoundResponse`, `@ApiConflictResponse`
- `groups.controller.ts` — added missing `@ApiUnauthorizedResponse` to all 6 endpoints
- `notifications.controller.ts` — replaced generic status decorators with typed shorthands; updated `markRead` description to reflect the new 404 behavior

**Frontend type accuracy**
- Removed `| null` from the `get<>` generic on three pages that call `GET /v1/groups/:id/members/me` — the API body is never `null` (it's either the DTO or a 404 error); `.catch(() => null)` at the Axios level still handles the not-a-member path correctly

**Tests**
- Added `getMyMembership` describe blocks in `group-members.service.spec.ts` and `group-members.controller.spec.ts` covering the happy path and both `NotFoundException` paths
- Updated `notifications.service.spec.ts`: new `makeUpdateReturning` helper + NotFoundException test for `markRead`

## Testing

- [x] `group-members` service: returns DTO for active member, throws for missing group, throws for non-member
- [x] `group-members` controller: delegates correctly, propagates `NotFoundException`
- [x] `notifications` service: marks read idempotently, throws for non-existent/unauthorized notification ID
- [x] Full test suite: 1246 tests passing, 0 failures
- [x] API lint: 0 errors (4 pre-existing warnings in unrelated IIFEs)

## Notes

Intentionally **not** changed: `markAllRead` (bulk op — 0 rows updated is valid) and `deleteToken` (idempotent logout — documented "returns 204 even if token does not exist"). These are correct by design.

Closes #403