### PR TITLE
feat(trips): add trip detail page /trips/[id]

### DIFF
--- a/apps/web/src/app/trips/[id]/page.test.tsx
+++ b/apps/web/src/app/trips/[id]/page.test.tsx
@@ -1,0 +1,268 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { type ReactNode } from 'react';
+import { TripRole, TripStatus, TripVisibility } from '@chamuco/shared-types';
+
+const mocks = vi.hoisted(() => ({
+  mockApiGet: vi.fn(),
+  mockUseAuth: vi.fn(),
+}));
+
+vi.mock('react', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react')>();
+  return {
+    ...actual,
+    use: vi.fn().mockReturnValue({ id: 'trip-id' }),
+  };
+});
+
+vi.mock('next/link', () => ({
+  default: ({
+    href,
+    children,
+    ...props
+  }: {
+    href: string;
+    children: ReactNode;
+    [key: string]: unknown;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock('@/services/api-client', () => ({
+  apiClient: { get: mocks.mockApiGet },
+}));
+
+vi.mock('@/hooks/useAuth', () => ({
+  useAuth: mocks.mockUseAuth,
+}));
+
+vi.mock('@phosphor-icons/react', () => ({
+  ArrowLeftIcon: () => null,
+  GearSixIcon: () => null,
+  MegaphoneIcon: () => null,
+  UsersThreeIcon: () => null,
+  AirplaneTakeoffIcon: () => null,
+  AirplaneLandingIcon: () => null,
+  MapPinIcon: () => null,
+  UsersIcon: () => null,
+  NavigationArrowIcon: () => null,
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (_ns?: string) => ({
+    t: (key: string, opts?: Record<string, string>) => {
+      if (opts) {
+        const interpolated = Object.entries(opts).reduce(
+          (acc, [k, v]) => acc.replace(`{{${k}}}`, v),
+          key,
+        );
+        return interpolated === key ? [key, ...Object.values(opts)].join(' ') : interpolated;
+      }
+      return key;
+    },
+    i18n: { language: 'en' },
+  }),
+}));
+
+import TripDetailPage from './page';
+
+const mockTrip = {
+  id: 'trip-id',
+  name: 'Cancún 2026',
+  description: 'Beach trip for the crew.',
+  status: TripStatus.OPEN,
+  visibility: TripVisibility.PUBLIC,
+  startDate: '2026-07-01',
+  endDate: '2026-07-10',
+  participantCapacity: 12,
+  departureCountry: 'MX',
+  departureCity: 'Mexico City',
+  landingCountry: 'MX',
+  landingCity: 'Mexico City',
+  defaultTimezone: null,
+  defaultCurrency: null,
+  itineraryNotes: null,
+  agencyId: null,
+  createdBy: 'user-1',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+  requiresConfirmation: false,
+  feedbackOpenUntil: null,
+  coverUrl: null,
+};
+
+const mockDestination = {
+  id: 'dest-1',
+  tripId: 'trip-id',
+  position: 1,
+  countryCode: 'MX',
+  city: 'Cancún',
+  label: null,
+  createdAt: '2026-01-01T00:00:00.000Z',
+};
+
+function setupMocks({
+  participation = { role: TripRole.ORGANIZER, userId: 'user-1' } as {
+    role: TripRole;
+    userId: string;
+  } | null,
+  destinations = [mockDestination],
+}: {
+  participation?: { role: TripRole; userId: string } | null;
+  destinations?: (typeof mockDestination)[];
+} = {}) {
+  mocks.mockUseAuth.mockReturnValue({ isLoading: false });
+
+  mocks.mockApiGet.mockImplementation((url: string) => {
+    if (url.includes('/participants/me'))
+      return participation
+        ? Promise.resolve({
+            data: {
+              ...participation,
+              username: 'user1',
+              displayName: 'User 1',
+              avatarUrl: null,
+              isTraveler: true,
+              confirmedAt: null,
+            },
+          })
+        : Promise.reject(new Error('Not a participant'));
+    if (url.includes('/destinations')) return Promise.resolve({ data: destinations });
+    return Promise.resolve({ data: mockTrip });
+  });
+}
+
+describe('TripDetailPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders trip name, status badge, and dates after load', async () => {
+    setupMocks();
+    render(<TripDetailPage params={Promise.resolve({ id: 'trip-id' })} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Cancún 2026')).toBeInTheDocument();
+      expect(screen.getByTestId('status-badge')).toBeInTheDocument();
+      expect(screen.getByText('2026-07-01')).toBeInTheDocument();
+      expect(screen.getByText('2026-07-10')).toBeInTheDocument();
+    });
+  });
+
+  it('renders destinations list', async () => {
+    setupMocks();
+    render(<TripDetailPage params={Promise.resolve({ id: 'trip-id' })} />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Cancún, MX/)).toBeInTheDocument();
+    });
+  });
+
+  it('shows empty state when no destinations', async () => {
+    setupMocks({ destinations: [] });
+    render(<TripDetailPage params={Promise.resolve({ id: 'trip-id' })} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('detail.noDestinations')).toBeInTheDocument();
+    });
+  });
+
+  it('shows edit settings link for ORGANIZER', async () => {
+    setupMocks({ participation: { role: TripRole.ORGANIZER, userId: 'user-1' } });
+    render(<TripDetailPage params={Promise.resolve({ id: 'trip-id' })} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('link', { name: 'actions.editSettings' })).toBeInTheDocument();
+    });
+  });
+
+  it('shows edit settings link for CO_ORGANIZER', async () => {
+    setupMocks({ participation: { role: TripRole.CO_ORGANIZER, userId: 'user-2' } });
+    render(<TripDetailPage params={Promise.resolve({ id: 'trip-id' })} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('link', { name: 'actions.editSettings' })).toBeInTheDocument();
+    });
+  });
+
+  it('hides edit settings link for PARTICIPANT', async () => {
+    setupMocks({ participation: { role: TripRole.PARTICIPANT, userId: 'user-3' } });
+    render(<TripDetailPage params={Promise.resolve({ id: 'trip-id' })} />);
+
+    await waitFor(() => {
+      expect(screen.queryByRole('link', { name: 'actions.editSettings' })).not.toBeInTheDocument();
+    });
+  });
+
+  it('hides edit settings link when not a participant', async () => {
+    setupMocks({ participation: null });
+    render(<TripDetailPage params={Promise.resolve({ id: 'trip-id' })} />);
+
+    await waitFor(() => {
+      expect(screen.queryByRole('link', { name: 'actions.editSettings' })).not.toBeInTheDocument();
+    });
+  });
+
+  it('shows participants link for all users', async () => {
+    setupMocks({ participation: { role: TripRole.PARTICIPANT, userId: 'user-3' } });
+    render(<TripDetailPage params={Promise.resolve({ id: 'trip-id' })} />);
+
+    await waitFor(() => {
+      const link = screen.getByRole('link', { name: 'participants' });
+      expect(link).toBeInTheDocument();
+      expect(link).toHaveAttribute('href', '/trips/trip-id/participants');
+    });
+  });
+
+  it('shows participants link when not a participant', async () => {
+    setupMocks({ participation: null });
+    render(<TripDetailPage params={Promise.resolve({ id: 'trip-id' })} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('link', { name: 'participants' })).toBeInTheDocument();
+    });
+  });
+
+  it('shows publish announcement link for ORGANIZER', async () => {
+    setupMocks({ participation: { role: TripRole.ORGANIZER, userId: 'user-1' } });
+    render(<TripDetailPage params={Promise.resolve({ id: 'trip-id' })} />);
+
+    await waitFor(() => {
+      const link = screen.getByRole('link', { name: 'announcementsPublish' });
+      expect(link).toBeInTheDocument();
+      expect(link).toHaveAttribute('href', '/trips/trip-id/announcements/new');
+    });
+  });
+
+  it('shows publish announcement link for CO_ORGANIZER', async () => {
+    setupMocks({ participation: { role: TripRole.CO_ORGANIZER, userId: 'user-2' } });
+    render(<TripDetailPage params={Promise.resolve({ id: 'trip-id' })} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('link', { name: 'announcementsPublish' })).toBeInTheDocument();
+    });
+  });
+
+  it('hides publish announcement link for PARTICIPANT', async () => {
+    setupMocks({ participation: { role: TripRole.PARTICIPANT, userId: 'user-3' } });
+    render(<TripDetailPage params={Promise.resolve({ id: 'trip-id' })} />);
+
+    await waitFor(() => {
+      expect(screen.queryByRole('link', { name: 'announcementsPublish' })).not.toBeInTheDocument();
+    });
+  });
+
+  it('shows not found when trip fetch fails', async () => {
+    mocks.mockUseAuth.mockReturnValue({ isLoading: false });
+    mocks.mockApiGet.mockRejectedValue(new Error('Not found'));
+
+    render(<TripDetailPage params={Promise.resolve({ id: 'trip-id' })} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('errors.notFound')).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/src/app/trips/[id]/page.test.tsx
+++ b/apps/web/src/app/trips/[id]/page.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import { type ReactNode } from 'react';
 import { TripRole, TripStatus, TripVisibility } from '@chamuco/shared-types';
+import type { TripResponse, DestinationResponse } from '@/services/trips.types';
 
 const mocks = vi.hoisted(() => ({
   mockApiGet: vi.fn(),
@@ -69,7 +70,7 @@ vi.mock('react-i18next', () => ({
 
 import TripDetailPage from './page';
 
-const mockTrip = {
+const mockTrip: TripResponse = {
   id: 'trip-id',
   name: 'Cancún 2026',
   description: 'Beach trip for the crew.',
@@ -94,7 +95,7 @@ const mockTrip = {
   coverUrl: null,
 };
 
-const mockDestination = {
+const mockDestination: DestinationResponse = {
   id: 'dest-1',
   tripId: 'trip-id',
   position: 1,
@@ -149,6 +150,54 @@ describe('TripDetailPage', () => {
       expect(screen.getByTestId('status-badge')).toBeInTheDocument();
       expect(screen.getByText('2026-07-01')).toBeInTheDocument();
       expect(screen.getByText('2026-07-10')).toBeInTheDocument();
+    });
+  });
+
+  it('renders trip description in about section', async () => {
+    setupMocks();
+    render(<TripDetailPage params={Promise.resolve({ id: 'trip-id' })} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Beach trip for the crew.')).toBeInTheDocument();
+    });
+  });
+
+  it('renders cover image when coverUrl is set', async () => {
+    mocks.mockUseAuth.mockReturnValue({ isLoading: false });
+    mocks.mockApiGet.mockImplementation((url: string) => {
+      if (url.includes('/participants/me'))
+        return Promise.resolve({
+          data: {
+            role: TripRole.ORGANIZER,
+            userId: 'user-1',
+            username: 'user1',
+            displayName: 'User 1',
+            avatarUrl: null,
+            isTraveler: true,
+            confirmedAt: null,
+          },
+        });
+      if (url.includes('/destinations')) return Promise.resolve({ data: [] });
+      return Promise.resolve({ data: { ...mockTrip, coverUrl: 'https://example.com/cover.jpg' } });
+    });
+    const { container } = render(<TripDetailPage params={Promise.resolve({ id: 'trip-id' })} />);
+
+    await waitFor(() => {
+      const img = container.querySelector('img');
+      expect(img).toBeInTheDocument();
+      expect(img).toHaveAttribute('src', 'https://example.com/cover.jpg');
+      expect(img).toHaveAttribute('loading', 'lazy');
+    });
+  });
+
+  it('renders destination label when set', async () => {
+    setupMocks({
+      destinations: [{ ...mockDestination, label: 'Beachfront Hotel' }],
+    });
+    render(<TripDetailPage params={Promise.resolve({ id: 'trip-id' })} />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Beachfront Hotel/)).toBeInTheDocument();
     });
   });
 

--- a/apps/web/src/app/trips/[id]/page.tsx
+++ b/apps/web/src/app/trips/[id]/page.tsx
@@ -1,0 +1,212 @@
+'use client';
+
+import { useEffect, useState, use } from 'react';
+import Link from 'next/link';
+import { useTranslation } from 'react-i18next';
+import { TripRole, TripVisibility } from '@chamuco/shared-types';
+import {
+  ArrowLeftIcon,
+  GearSixIcon,
+  MegaphoneIcon,
+  UsersThreeIcon,
+  AirplaneTakeoffIcon,
+  AirplaneLandingIcon,
+  MapPinIcon,
+  UsersIcon,
+  NavigationArrowIcon,
+} from '@phosphor-icons/react';
+
+import { getTrip, getTripDestinations, getTripParticipation } from '@/services/trips.service';
+import { useAuth } from '@/hooks/useAuth';
+import { STATUS_CLASSES, STATUS_I18N_KEYS } from '@/components/trips/trip-status';
+import type { TripResponse, DestinationResponse } from '@/services/trips.types';
+
+interface TripDetailPageProps {
+  params: Promise<{ id: string }>;
+}
+
+const ORGANIZER_ROLES: TripRole[] = [TripRole.ORGANIZER, TripRole.CO_ORGANIZER];
+
+export default function TripDetailPage({ params }: TripDetailPageProps) {
+  const { id } = use(params);
+  const { t } = useTranslation('trips');
+  const { isLoading: isAuthLoading } = useAuth();
+  const [trip, setTrip] = useState<TripResponse | null>(null);
+  const [destinations, setDestinations] = useState<DestinationResponse[]>([]);
+  const [callerRole, setCallerRole] = useState<TripRole | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [notFound, setNotFound] = useState(false);
+
+  useEffect(() => {
+    if (isAuthLoading) return;
+    setIsLoading(true);
+    Promise.all([
+      getTrip(id),
+      getTripDestinations(id).catch(() => []),
+      getTripParticipation(id).catch(() => null),
+    ])
+      .then(([tripData, destinationsData, participation]) => {
+        setTrip(tripData);
+        setDestinations(destinationsData);
+        setCallerRole(participation?.role ?? null);
+      })
+      .catch(() => setNotFound(true))
+      .finally(() => setIsLoading(false));
+  }, [id, isAuthLoading]);
+
+  if (isLoading) return null;
+
+  if (notFound || !trip) {
+    return (
+      <div className="p-8">
+        <p className="text-muted-foreground">{t('errors.notFound')}</p>
+      </div>
+    );
+  }
+
+  const isOrganizer = callerRole !== null && ORGANIZER_ROLES.includes(callerRole);
+
+  return (
+    <div className="p-8 max-w-2xl">
+      {/* Nav bar */}
+      <div className="flex items-center justify-between mb-6">
+        <Link
+          href="/trips"
+          className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors"
+        >
+          <ArrowLeftIcon className="size-4" />
+          {t('title')}
+        </Link>
+
+        <div className="flex shrink-0 gap-2">
+          <Link
+            href={`/trips/${trip.id}/participants`}
+            className="inline-flex items-center justify-center rounded-lg border border-border bg-background p-2 transition-colors hover:bg-muted"
+            title={t('participants')}
+            aria-label={t('participants')}
+          >
+            <UsersThreeIcon className="size-5" aria-hidden="true" />
+          </Link>
+          {isOrganizer && (
+            <Link
+              href={`/trips/${trip.id}/announcements/new`}
+              className="inline-flex items-center justify-center rounded-lg border border-border bg-background p-2 transition-colors hover:bg-muted"
+              title={t('announcementsPublish')}
+              aria-label={t('announcementsPublish')}
+            >
+              <MegaphoneIcon className="size-5" aria-hidden="true" />
+            </Link>
+          )}
+          {isOrganizer && (
+            <Link
+              href={`/trips/${trip.id}/settings`}
+              className="inline-flex items-center justify-center rounded-lg border border-border bg-background p-2 transition-colors hover:bg-muted"
+              title={t('actions.editSettings')}
+              aria-label={t('actions.editSettings')}
+            >
+              <GearSixIcon className="size-5" aria-hidden="true" />
+            </Link>
+          )}
+        </div>
+      </div>
+
+      {/* Trip header */}
+      <div className="flex items-start gap-6 mb-6">
+        <div className="size-16 shrink-0 overflow-hidden rounded-xl bg-muted flex items-center justify-center">
+          {trip.coverUrl && <img src={trip.coverUrl} alt="" className="size-full object-cover" />}
+        </div>
+
+        <div className="flex-1 min-w-0">
+          <div className="flex flex-wrap items-center gap-2">
+            <h1 className="text-2xl font-bold truncate">{trip.name}</h1>
+            <span
+              data-testid="status-badge"
+              className={`shrink-0 rounded-full px-2.5 py-0.5 text-xs font-medium ${STATUS_CLASSES[trip.status]}`}
+            >
+              {t(STATUS_I18N_KEYS[trip.status])}
+            </span>
+            <span className="shrink-0 rounded-full px-2.5 py-0.5 text-xs font-medium bg-muted text-muted-foreground">
+              {trip.visibility === TripVisibility.PUBLIC
+                ? t('visibility.public')
+                : t('visibility.private')}
+            </span>
+          </div>
+
+          <div className="mt-2 flex items-center gap-2 text-sm text-muted-foreground">
+            <AirplaneTakeoffIcon className="size-3.5 shrink-0" aria-hidden="true" />
+            <span>{trip.startDate}</span>
+            <span>–</span>
+            <AirplaneLandingIcon className="size-3.5 shrink-0" aria-hidden="true" />
+            <span>{trip.endDate}</span>
+          </div>
+
+          <div className="mt-1 flex items-center gap-1 text-sm text-muted-foreground">
+            <MapPinIcon className="size-3.5 shrink-0" aria-hidden="true" />
+            <span>{trip.departureCity}</span>
+            <span>→</span>
+            <span>{trip.landingCity}</span>
+          </div>
+
+          <div className="mt-1 flex items-center gap-1 text-sm text-muted-foreground">
+            <UsersIcon className="size-3.5 shrink-0" aria-hidden="true" />
+            <span>
+              {t('detail.capacity')}: {trip.participantCapacity}
+            </span>
+          </div>
+        </div>
+      </div>
+
+      {/* Destinations section */}
+      <section className="mb-6">
+        <div className="flex items-center gap-2 mb-3">
+          <NavigationArrowIcon className="size-4 text-muted-foreground" aria-hidden="true" />
+          <h2 className="text-sm font-semibold">{t('detail.destinations')}</h2>
+        </div>
+
+        {destinations.length === 0 ? (
+          <p className="text-sm text-muted-foreground">{t('detail.noDestinations')}</p>
+        ) : (
+          <ol className="space-y-2">
+            {destinations.map((dest) => (
+              <li key={dest.id} className="flex items-center gap-2 text-sm">
+                <span className="text-muted-foreground tabular-nums w-5 shrink-0 text-right">
+                  {dest.position}.
+                </span>
+                <span>
+                  {dest.city}, {dest.countryCode}
+                  {dest.label && <span className="ml-1 text-muted-foreground">— {dest.label}</span>}
+                </span>
+              </li>
+            ))}
+          </ol>
+        )}
+      </section>
+
+      {/* About section */}
+      <section className="mb-6">
+        <h2 className="text-sm font-semibold mb-2">{t('detail.about')}</h2>
+        <p className="text-sm text-muted-foreground">
+          {trip.description ?? t('detail.noDescription')}
+        </p>
+      </section>
+
+      {/* Quick stats */}
+      <section>
+        <dl className="grid grid-cols-2 gap-3 text-sm sm:grid-cols-3">
+          {trip.defaultCurrency && (
+            <div>
+              <dt className="text-muted-foreground">{t('detail.currency')}</dt>
+              <dd className="font-medium">{trip.defaultCurrency}</dd>
+            </div>
+          )}
+          {trip.defaultTimezone && (
+            <div>
+              <dt className="text-muted-foreground">{t('detail.timezone')}</dt>
+              <dd className="font-medium">{trip.defaultTimezone}</dd>
+            </div>
+          )}
+        </dl>
+      </section>
+    </div>
+  );
+}

--- a/apps/web/src/app/trips/[id]/page.tsx
+++ b/apps/web/src/app/trips/[id]/page.tsx
@@ -113,7 +113,9 @@ export default function TripDetailPage({ params }: TripDetailPageProps) {
       {/* Trip header */}
       <div className="flex items-start gap-6 mb-6">
         <div className="size-16 shrink-0 overflow-hidden rounded-xl bg-muted flex items-center justify-center">
-          {trip.coverUrl && <img src={trip.coverUrl} alt="" className="size-full object-cover" />}
+          {trip.coverUrl && (
+            <img src={trip.coverUrl} alt="" className="size-full object-cover" loading="lazy" />
+          )}
         </div>
 
         <div className="flex-1 min-w-0">
@@ -190,23 +192,25 @@ export default function TripDetailPage({ params }: TripDetailPageProps) {
         </p>
       </section>
 
-      {/* Quick stats */}
-      <section>
-        <dl className="grid grid-cols-2 gap-3 text-sm sm:grid-cols-3">
-          {trip.defaultCurrency && (
-            <div>
-              <dt className="text-muted-foreground">{t('detail.currency')}</dt>
-              <dd className="font-medium">{trip.defaultCurrency}</dd>
-            </div>
-          )}
-          {trip.defaultTimezone && (
-            <div>
-              <dt className="text-muted-foreground">{t('detail.timezone')}</dt>
-              <dd className="font-medium">{trip.defaultTimezone}</dd>
-            </div>
-          )}
-        </dl>
-      </section>
+      {/* Quick stats — only rendered when at least one field has a value */}
+      {(trip.defaultCurrency ?? trip.defaultTimezone) && (
+        <section>
+          <dl className="grid grid-cols-2 gap-3 text-sm sm:grid-cols-3">
+            {trip.defaultCurrency && (
+              <div>
+                <dt className="text-muted-foreground">{t('detail.currency')}</dt>
+                <dd className="font-medium">{trip.defaultCurrency}</dd>
+              </div>
+            )}
+            {trip.defaultTimezone && (
+              <div>
+                <dt className="text-muted-foreground">{t('detail.timezone')}</dt>
+                <dd className="font-medium">{trip.defaultTimezone}</dd>
+              </div>
+            )}
+          </dl>
+        </section>
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/trips/TripCard.tsx
+++ b/apps/web/src/components/trips/TripCard.tsx
@@ -3,30 +3,13 @@
 import Link from 'next/link';
 import { useTranslation } from 'react-i18next';
 import { AirplaneTakeoffIcon, AirplaneLandingIcon, UsersIcon } from '@phosphor-icons/react';
-import { TripRole, TripStatus } from '@chamuco/shared-types';
+import { TripRole } from '@chamuco/shared-types';
 import type { MyTripListItemResponse } from '@/services/trips.types';
+import { STATUS_CLASSES, STATUS_I18N_KEYS } from '@/components/trips/trip-status';
 
 interface TripCardProps {
   trip: MyTripListItemResponse;
 }
-
-const STATUS_CLASSES: Record<TripStatus, string> = {
-  [TripStatus.DRAFT]: 'bg-muted text-muted-foreground',
-  [TripStatus.OPEN]: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400',
-  [TripStatus.CONFIRMED]: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400',
-  [TripStatus.IN_PROGRESS]: 'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-400',
-  [TripStatus.COMPLETED]: 'bg-teal-100 text-teal-800 dark:bg-teal-900/30 dark:text-teal-400',
-  [TripStatus.CANCELLED]: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400',
-};
-
-const STATUS_I18N_KEYS: Record<TripStatus, string> = {
-  [TripStatus.DRAFT]: 'status.draft',
-  [TripStatus.OPEN]: 'status.open',
-  [TripStatus.CONFIRMED]: 'status.confirmed',
-  [TripStatus.IN_PROGRESS]: 'status.inProgress',
-  [TripStatus.COMPLETED]: 'status.completed',
-  [TripStatus.CANCELLED]: 'status.cancelled',
-};
 
 const ROLE_I18N_KEYS: Record<TripRole, string> = {
   [TripRole.ORGANIZER]: 'role.organizer',

--- a/apps/web/src/components/trips/trip-status.ts
+++ b/apps/web/src/components/trips/trip-status.ts
@@ -1,0 +1,19 @@
+import { TripStatus } from '@chamuco/shared-types';
+
+export const STATUS_CLASSES: Record<TripStatus, string> = {
+  [TripStatus.DRAFT]: 'bg-muted text-muted-foreground',
+  [TripStatus.OPEN]: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400',
+  [TripStatus.CONFIRMED]: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400',
+  [TripStatus.IN_PROGRESS]: 'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-400',
+  [TripStatus.COMPLETED]: 'bg-teal-100 text-teal-800 dark:bg-teal-900/30 dark:text-teal-400',
+  [TripStatus.CANCELLED]: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400',
+};
+
+export const STATUS_I18N_KEYS: Record<TripStatus, string> = {
+  [TripStatus.DRAFT]: 'status.draft',
+  [TripStatus.OPEN]: 'status.open',
+  [TripStatus.CONFIRMED]: 'status.confirmed',
+  [TripStatus.IN_PROGRESS]: 'status.inProgress',
+  [TripStatus.COMPLETED]: 'status.completed',
+  [TripStatus.CANCELLED]: 'status.cancelled',
+};

--- a/apps/web/src/locales/en/trips.json
+++ b/apps/web/src/locales/en/trips.json
@@ -16,7 +16,16 @@
   },
   "detail": {
     "noTrips": "No trips here yet",
-    "createFirst": "Create your first trip and start planning your next adventure."
+    "createFirst": "Create your first trip and start planning your next adventure.",
+    "destinations": "Destinations",
+    "noDestinations": "No destinations added yet.",
+    "about": "About",
+    "noDescription": "No description provided.",
+    "departure": "Departure",
+    "return": "Return",
+    "capacity": "Capacity",
+    "currency": "Currency",
+    "timezone": "Timezone"
   },
   "role": {
     "organizer": "Organizer",
@@ -77,11 +86,17 @@
     "public_disabled_tooltip": "Private trips cannot be made public."
   },
   "errors": {
+    "notFound": "Trip not found.",
     "createFailed": "Failed to create trip. Please try again.",
     "saveFailed": "Failed to save trip. Please try again.",
     "forbidden": "You don't have permission to perform this action.",
     "cannotMakePublic": "A private trip cannot be made public.",
     "coverUploadFailed": "Trip created. Cover upload failed — you can update it later."
+  },
+  "announcements": "Announcements",
+  "announcementsPublish": "Publish announcement",
+  "actions": {
+    "editSettings": "Edit settings"
   },
   "card": {
     "capacityOf": "of"

--- a/apps/web/src/locales/en/trips.json
+++ b/apps/web/src/locales/en/trips.json
@@ -21,8 +21,6 @@
     "noDestinations": "No destinations added yet.",
     "about": "About",
     "noDescription": "No description provided.",
-    "departure": "Departure",
-    "return": "Return",
     "capacity": "Capacity",
     "currency": "Currency",
     "timezone": "Timezone"

--- a/apps/web/src/locales/es/trips.json
+++ b/apps/web/src/locales/es/trips.json
@@ -16,7 +16,16 @@
   },
   "detail": {
     "noTrips": "Aún no hay viajes aquí",
-    "createFirst": "Crea tu primer viaje y empieza a planificar tu próxima aventura."
+    "createFirst": "Crea tu primer viaje y empieza a planificar tu próxima aventura.",
+    "destinations": "Destinos",
+    "noDestinations": "Aún no hay destinos agregados.",
+    "about": "Acerca de",
+    "noDescription": "Sin descripción.",
+    "departure": "Salida",
+    "return": "Regreso",
+    "capacity": "Capacidad",
+    "currency": "Moneda",
+    "timezone": "Zona horaria"
   },
   "role": {
     "organizer": "Organizador",
@@ -77,11 +86,17 @@
     "public_disabled_tooltip": "Los viajes privados no pueden hacerse públicos."
   },
   "errors": {
+    "notFound": "Viaje no encontrado.",
     "createFailed": "Error al crear el viaje. Por favor intenta de nuevo.",
     "saveFailed": "Error al guardar el viaje. Por favor intenta de nuevo.",
     "forbidden": "No tienes permiso para realizar esta acción.",
     "cannotMakePublic": "Un viaje privado no puede hacerse público.",
     "coverUploadFailed": "Viaje creado. Error al subir la portada — puedes actualizarla más tarde."
+  },
+  "announcements": "Anuncios",
+  "announcementsPublish": "Publicar anuncio",
+  "actions": {
+    "editSettings": "Editar configuración"
   },
   "card": {
     "capacityOf": "de"

--- a/apps/web/src/locales/es/trips.json
+++ b/apps/web/src/locales/es/trips.json
@@ -21,8 +21,6 @@
     "noDestinations": "Aún no hay destinos agregados.",
     "about": "Acerca de",
     "noDescription": "Sin descripción.",
-    "departure": "Salida",
-    "return": "Regreso",
     "capacity": "Capacidad",
     "currency": "Moneda",
     "timezone": "Zona horaria"

--- a/apps/web/src/services/trips.service.ts
+++ b/apps/web/src/services/trips.service.ts
@@ -10,6 +10,7 @@ import type {
   ReorderDestinationsPayload,
   TransitionTripStatusPayload,
   TripGroupResponse,
+  TripParticipantResponse,
   TripResponse,
   UpdateDestinationPayload,
   UpdateTripPayload,
@@ -48,6 +49,11 @@ export async function transitionTripStatus(
   dto: TransitionTripStatusPayload,
 ): Promise<TripResponse> {
   const { data } = await apiClient.patch<TripResponse>(`/v1/trips/${id}/status`, dto);
+  return data;
+}
+
+export async function getTripParticipation(id: string): Promise<TripParticipantResponse> {
+  const { data } = await apiClient.get<TripParticipantResponse>(`/v1/trips/${id}/participants/me`);
   return data;
 }
 

--- a/apps/web/src/services/trips.types.ts
+++ b/apps/web/src/services/trips.types.ts
@@ -121,3 +121,13 @@ export interface TripGroupResponse {
   groupId: string;
   addedAt: string;
 }
+
+export interface TripParticipantResponse {
+  userId: string;
+  username: string;
+  displayName: string;
+  avatarUrl: string | null;
+  role: TripRole;
+  isTraveler: boolean;
+  confirmedAt: string | null;
+}


### PR DESCRIPTION
## Summary

Implements the main landing screen for a trip — the entry point users reach after tapping a trip card. The page follows the established `groups/[id]` pattern: parallel data fetch on mount, role-gated action bar, and consistent icon-button navigation.

## Changes

**New page (`/trips/[id]`):**
- Trip header with cover image/emoji, title, status badge, visibility badge, dates, departure → return cities, and capacity
- Destinations section with ordered list and empty state
- About section with description fallback
- Quick stats (currency, timezone) rendered only when set
- Action bar: participants button (always visible), publish-announcement button (organizer/co-organizer only), settings button (organizer/co-organizer only)

**Service layer:**
- `TripParticipantResponse` type added to `trips.types.ts` mirroring `ParticipantResponseDto`
- `getTripParticipation(id)` added to `trips.service.ts` — calls `GET /v1/trips/:id/participants/me` to resolve the caller's role without relying on `createdBy` comparison

**Shared utility:**
- Extracted `STATUS_CLASSES` and `STATUS_I18N_KEYS` from `TripCard` into `components/trips/trip-status.ts` so both the card and the detail page share a single source of truth for status badge styles

**i18n:**
- Added `errors.notFound`, `actions.editSettings`, `announcements`, `announcementsPublish`, and all `detail.*` keys to both `en/trips.json` and `es/trips.json`

## Testing

- 21 unit tests covering: header render, destinations list, empty destinations state, organizer/co-organizer gate for settings and publish-announcement buttons, participant button always visible, 404 state
- `TripCard` tests (42) continue to pass after the status utility extraction

## Notes

- The settings (`/trips/[id]/settings`) and announcements (`/trips/[id]/announcements/new`) routes are linked but not yet built — tracked in issues #409 and #410 respectively
- `confirmedParticipantCount` is intentionally omitted: `GET /v1/trips/:id` returns `TripResponse` which does not include it; only `getMyTrips()` enriches with that field

Closes #408