### PR TITLE
feat(trips): add status badge component and organizer transition UI

### DIFF
--- a/apps/web/src/app/trips/[id]/page.test.tsx
+++ b/apps/web/src/app/trips/[id]/page.test.tsx
@@ -52,6 +52,16 @@ vi.mock('@phosphor-icons/react', () => ({
   NavigationArrowIcon: () => null,
 }));
 
+vi.mock('@/components/trips/TripStatusBadge', () => ({
+  TripStatusBadge: ({ status }: { status: string }) => (
+    <span data-testid="status-badge">{status}</span>
+  ),
+}));
+
+vi.mock('@/components/trips/TripStatusTransition', () => ({
+  TripStatusTransition: () => null,
+}));
+
 vi.mock('@/components/trips/DestinationList', () => ({
   DestinationList: ({
     initialDestinations,

--- a/apps/web/src/app/trips/[id]/page.tsx
+++ b/apps/web/src/app/trips/[id]/page.tsx
@@ -18,7 +18,8 @@ import {
 
 import { getTrip, getTripDestinations, getTripParticipation } from '@/services/trips.service';
 import { useAuth } from '@/hooks/useAuth';
-import { STATUS_CLASSES, STATUS_I18N_KEYS } from '@/components/trips/trip-status';
+import { TripStatusBadge } from '@/components/trips/TripStatusBadge';
+import { TripStatusTransition } from '@/components/trips/TripStatusTransition';
 import { DestinationList } from '@/components/trips/DestinationList';
 import type { TripResponse, DestinationResponse } from '@/services/trips.types';
 
@@ -122,12 +123,7 @@ export default function TripDetailPage({ params }: TripDetailPageProps) {
         <div className="flex-1 min-w-0">
           <div className="flex flex-wrap items-center gap-2">
             <h1 className="text-2xl font-bold truncate">{trip.name}</h1>
-            <span
-              data-testid="status-badge"
-              className={`shrink-0 rounded-full px-2.5 py-0.5 text-xs font-medium ${STATUS_CLASSES[trip.status]}`}
-            >
-              {t(STATUS_I18N_KEYS[trip.status])}
-            </span>
+            <TripStatusBadge status={trip.status} />
             <span className="shrink-0 rounded-full px-2.5 py-0.5 text-xs font-medium bg-muted text-muted-foreground">
               {trip.visibility === TripVisibility.PUBLIC
                 ? t('visibility.public')
@@ -158,6 +154,13 @@ export default function TripDetailPage({ params }: TripDetailPageProps) {
           </div>
         </div>
       </div>
+
+      {/* Organizer status transitions */}
+      {isOrganizer && (
+        <section className="mb-6">
+          <TripStatusTransition tripId={id} currentStatus={trip.status} onTransitioned={setTrip} />
+        </section>
+      )}
 
       {/* Destinations section */}
       <section className="mb-6">

--- a/apps/web/src/components/trips/TripCard.tsx
+++ b/apps/web/src/components/trips/TripCard.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next';
 import { AirplaneTakeoffIcon, AirplaneLandingIcon, UsersIcon } from '@phosphor-icons/react';
 import { TripRole } from '@chamuco/shared-types';
 import type { MyTripListItemResponse } from '@/services/trips.types';
-import { STATUS_CLASSES, STATUS_I18N_KEYS } from '@/components/trips/trip-status';
+import { TripStatusBadge } from '@/components/trips/TripStatusBadge';
 
 interface TripCardProps {
   trip: MyTripListItemResponse;
@@ -55,12 +55,7 @@ export function TripCard({ trip }: TripCardProps) {
       </div>
 
       <div className="flex shrink-0 flex-col items-end gap-1.5">
-        <span
-          data-testid="status-badge"
-          className={`rounded-full px-2.5 py-0.5 text-xs font-medium ${STATUS_CLASSES[trip.status]}`}
-        >
-          {t(STATUS_I18N_KEYS[trip.status])}
-        </span>
+        <TripStatusBadge status={trip.status} />
         <span className="rounded-full bg-muted px-2.5 py-0.5 text-xs font-medium text-muted-foreground">
           {t(ROLE_I18N_KEYS[trip.userRole])}
         </span>

--- a/apps/web/src/components/trips/TripStatusBadge.test.tsx
+++ b/apps/web/src/components/trips/TripStatusBadge.test.tsx
@@ -1,0 +1,99 @@
+import { render, screen } from '@testing-library/react';
+import { TripStatus } from '@chamuco/shared-types';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+import { TripStatusBadge } from './TripStatusBadge';
+import { STATUS_CLASSES, STATUS_I18N_KEYS } from './trip-status';
+
+describe('TripStatusBadge', () => {
+  describe('i18n keys', () => {
+    it('renders DRAFT i18n key', () => {
+      render(<TripStatusBadge status={TripStatus.DRAFT} />);
+      expect(screen.getByTestId('status-badge')).toHaveTextContent(
+        STATUS_I18N_KEYS[TripStatus.DRAFT],
+      );
+    });
+
+    it('renders OPEN i18n key', () => {
+      render(<TripStatusBadge status={TripStatus.OPEN} />);
+      expect(screen.getByTestId('status-badge')).toHaveTextContent(
+        STATUS_I18N_KEYS[TripStatus.OPEN],
+      );
+    });
+
+    it('renders CONFIRMED i18n key', () => {
+      render(<TripStatusBadge status={TripStatus.CONFIRMED} />);
+      expect(screen.getByTestId('status-badge')).toHaveTextContent(
+        STATUS_I18N_KEYS[TripStatus.CONFIRMED],
+      );
+    });
+
+    it('renders IN_PROGRESS i18n key', () => {
+      render(<TripStatusBadge status={TripStatus.IN_PROGRESS} />);
+      expect(screen.getByTestId('status-badge')).toHaveTextContent(
+        STATUS_I18N_KEYS[TripStatus.IN_PROGRESS],
+      );
+    });
+
+    it('renders COMPLETED i18n key', () => {
+      render(<TripStatusBadge status={TripStatus.COMPLETED} />);
+      expect(screen.getByTestId('status-badge')).toHaveTextContent(
+        STATUS_I18N_KEYS[TripStatus.COMPLETED],
+      );
+    });
+
+    it('renders CANCELLED i18n key', () => {
+      render(<TripStatusBadge status={TripStatus.CANCELLED} />);
+      expect(screen.getByTestId('status-badge')).toHaveTextContent(
+        STATUS_I18N_KEYS[TripStatus.CANCELLED],
+      );
+    });
+  });
+
+  describe('CSS classes', () => {
+    it('applies DRAFT color class', () => {
+      render(<TripStatusBadge status={TripStatus.DRAFT} />);
+      expect(screen.getByTestId('status-badge').className).toContain(
+        STATUS_CLASSES[TripStatus.DRAFT].split(' ')[0],
+      );
+    });
+
+    it('applies OPEN color class', () => {
+      render(<TripStatusBadge status={TripStatus.OPEN} />);
+      expect(screen.getByTestId('status-badge').className).toContain(
+        STATUS_CLASSES[TripStatus.OPEN].split(' ')[0],
+      );
+    });
+
+    it('applies CONFIRMED color class', () => {
+      render(<TripStatusBadge status={TripStatus.CONFIRMED} />);
+      expect(screen.getByTestId('status-badge').className).toContain(
+        STATUS_CLASSES[TripStatus.CONFIRMED].split(' ')[0],
+      );
+    });
+
+    it('applies IN_PROGRESS color class', () => {
+      render(<TripStatusBadge status={TripStatus.IN_PROGRESS} />);
+      expect(screen.getByTestId('status-badge').className).toContain(
+        STATUS_CLASSES[TripStatus.IN_PROGRESS].split(' ')[0],
+      );
+    });
+
+    it('applies COMPLETED color class', () => {
+      render(<TripStatusBadge status={TripStatus.COMPLETED} />);
+      expect(screen.getByTestId('status-badge').className).toContain(
+        STATUS_CLASSES[TripStatus.COMPLETED].split(' ')[0],
+      );
+    });
+
+    it('applies CANCELLED color class', () => {
+      render(<TripStatusBadge status={TripStatus.CANCELLED} />);
+      expect(screen.getByTestId('status-badge').className).toContain(
+        STATUS_CLASSES[TripStatus.CANCELLED].split(' ')[0],
+      );
+    });
+  });
+});

--- a/apps/web/src/components/trips/TripStatusBadge.tsx
+++ b/apps/web/src/components/trips/TripStatusBadge.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import { useTranslation } from 'react-i18next';
+import type { TripStatus } from '@chamuco/shared-types';
+
+import { STATUS_CLASSES, STATUS_I18N_KEYS } from '@/components/trips/trip-status';
+
+interface TripStatusBadgeProps {
+  status: TripStatus;
+}
+
+export function TripStatusBadge({ status }: TripStatusBadgeProps) {
+  const { t } = useTranslation('trips');
+  return (
+    <span
+      data-testid="status-badge"
+      className={`shrink-0 rounded-full px-2.5 py-0.5 text-xs font-medium ${STATUS_CLASSES[status]}`}
+    >
+      {t(STATUS_I18N_KEYS[status])}
+    </span>
+  );
+}

--- a/apps/web/src/components/trips/TripStatusTransition.test.tsx
+++ b/apps/web/src/components/trips/TripStatusTransition.test.tsx
@@ -1,0 +1,272 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { TripStatus, TripVisibility } from '@chamuco/shared-types';
+import type { TripResponse } from '@/services/trips.types';
+
+const mocks = vi.hoisted(() => ({
+  transitionTripStatus: vi.fn(),
+  toastError: vi.fn(),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, string>) => {
+      if (opts) {
+        return Object.entries(opts).reduce((acc, [k, v]) => acc.replace(`{{${k}}}`, v), key);
+      }
+      return key;
+    },
+  }),
+}));
+
+vi.mock('@/services/trips.service', () => ({
+  transitionTripStatus: mocks.transitionTripStatus,
+}));
+
+vi.mock('@/components/ui/toast', () => ({
+  toast: { error: mocks.toastError },
+}));
+
+import { TripStatusTransition } from './TripStatusTransition';
+
+const baseTripResponse: TripResponse = {
+  id: 'trip-1',
+  name: 'Test Trip',
+  description: null,
+  status: TripStatus.OPEN,
+  visibility: TripVisibility.PUBLIC,
+  startDate: '2026-12-01',
+  endDate: '2026-12-08',
+  participantCapacity: 10,
+  departureCountry: 'MX',
+  departureCity: 'CDMX',
+  landingCountry: 'MX',
+  landingCity: 'CANCUN',
+  defaultTimezone: null,
+  defaultCurrency: null,
+  itineraryNotes: null,
+  agencyId: null,
+  createdBy: 'user-1',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+  requiresConfirmation: false,
+  feedbackOpenUntil: null,
+  coverUrl: null,
+};
+
+describe('TripStatusTransition', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('button rendering by status', () => {
+    it('renders OPEN and CANCELLED buttons for DRAFT', () => {
+      render(
+        <TripStatusTransition
+          tripId="trip-1"
+          currentStatus={TripStatus.DRAFT}
+          onTransitioned={vi.fn()}
+        />,
+      );
+      expect(screen.getByTestId('transition-btn-OPEN')).toBeInTheDocument();
+      expect(screen.getByTestId('transition-btn-CANCELLED')).toBeInTheDocument();
+    });
+
+    it('renders CONFIRMED and CANCELLED buttons for OPEN', () => {
+      render(
+        <TripStatusTransition
+          tripId="trip-1"
+          currentStatus={TripStatus.OPEN}
+          onTransitioned={vi.fn()}
+        />,
+      );
+      expect(screen.getByTestId('transition-btn-CONFIRMED')).toBeInTheDocument();
+      expect(screen.getByTestId('transition-btn-CANCELLED')).toBeInTheDocument();
+    });
+
+    it('renders IN_PROGRESS and CANCELLED buttons for CONFIRMED', () => {
+      render(
+        <TripStatusTransition
+          tripId="trip-1"
+          currentStatus={TripStatus.CONFIRMED}
+          onTransitioned={vi.fn()}
+        />,
+      );
+      expect(screen.getByTestId('transition-btn-IN_PROGRESS')).toBeInTheDocument();
+      expect(screen.getByTestId('transition-btn-CANCELLED')).toBeInTheDocument();
+    });
+
+    it('renders only COMPLETED button for IN_PROGRESS', () => {
+      render(
+        <TripStatusTransition
+          tripId="trip-1"
+          currentStatus={TripStatus.IN_PROGRESS}
+          onTransitioned={vi.fn()}
+        />,
+      );
+      expect(screen.getByTestId('transition-btn-COMPLETED')).toBeInTheDocument();
+      expect(screen.queryByTestId('transition-btn-CANCELLED')).not.toBeInTheDocument();
+    });
+
+    it('renders nothing for COMPLETED (terminal)', () => {
+      const { container } = render(
+        <TripStatusTransition
+          tripId="trip-1"
+          currentStatus={TripStatus.COMPLETED}
+          onTransitioned={vi.fn()}
+        />,
+      );
+      expect(container).toBeEmptyDOMElement();
+    });
+
+    it('renders nothing for CANCELLED (terminal)', () => {
+      const { container } = render(
+        <TripStatusTransition
+          tripId="trip-1"
+          currentStatus={TripStatus.CANCELLED}
+          onTransitioned={vi.fn()}
+        />,
+      );
+      expect(container).toBeEmptyDOMElement();
+    });
+  });
+
+  describe('confirmation dialog', () => {
+    it('opens dialog when transition button is clicked', async () => {
+      const user = userEvent.setup();
+      render(
+        <TripStatusTransition
+          tripId="trip-1"
+          currentStatus={TripStatus.OPEN}
+          onTransitioned={vi.fn()}
+        />,
+      );
+      await user.click(screen.getByTestId('transition-btn-CONFIRMED'));
+      expect(screen.getByText('transitions.dialogTitle')).toBeInTheDocument();
+    });
+
+    it('shows cancel warning for CANCELLED target', async () => {
+      const user = userEvent.setup();
+      render(
+        <TripStatusTransition
+          tripId="trip-1"
+          currentStatus={TripStatus.OPEN}
+          onTransitioned={vi.fn()}
+        />,
+      );
+      await user.click(screen.getByTestId('transition-btn-CANCELLED'));
+      expect(screen.getByText('transitions.cancelWarning')).toBeInTheDocument();
+    });
+
+    it('does not show cancel warning for non-CANCELLED target', async () => {
+      const user = userEvent.setup();
+      render(
+        <TripStatusTransition
+          tripId="trip-1"
+          currentStatus={TripStatus.OPEN}
+          onTransitioned={vi.fn()}
+        />,
+      );
+      await user.click(screen.getByTestId('transition-btn-CONFIRMED'));
+      expect(screen.queryByText('transitions.cancelWarning')).not.toBeInTheDocument();
+    });
+
+    it('closes dialog when cancel button is clicked', async () => {
+      const user = userEvent.setup();
+      render(
+        <TripStatusTransition
+          tripId="trip-1"
+          currentStatus={TripStatus.OPEN}
+          onTransitioned={vi.fn()}
+        />,
+      );
+      await user.click(screen.getByTestId('transition-btn-CONFIRMED'));
+      expect(screen.getByText('transitions.dialogTitle')).toBeInTheDocument();
+      await user.click(screen.getByText('transitions.cancelButton'));
+      expect(screen.queryByText('transitions.dialogTitle')).not.toBeInTheDocument();
+    });
+
+    it('does not call API when cancel button is clicked', async () => {
+      const user = userEvent.setup();
+      render(
+        <TripStatusTransition
+          tripId="trip-1"
+          currentStatus={TripStatus.OPEN}
+          onTransitioned={vi.fn()}
+        />,
+      );
+      await user.click(screen.getByTestId('transition-btn-CONFIRMED'));
+      await user.click(screen.getByText('transitions.cancelButton'));
+      expect(mocks.transitionTripStatus).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('API interaction', () => {
+    it('calls transitionTripStatus with correct args on confirm', async () => {
+      const user = userEvent.setup();
+      const updatedTrip = { ...baseTripResponse, status: TripStatus.CONFIRMED };
+      mocks.transitionTripStatus.mockResolvedValueOnce(updatedTrip);
+
+      render(
+        <TripStatusTransition
+          tripId="trip-1"
+          currentStatus={TripStatus.OPEN}
+          onTransitioned={vi.fn()}
+        />,
+      );
+
+      await user.click(screen.getByTestId('transition-btn-CONFIRMED'));
+      await user.click(screen.getByTestId('transition-confirm-btn'));
+
+      await waitFor(() => {
+        expect(mocks.transitionTripStatus).toHaveBeenCalledWith('trip-1', {
+          status: TripStatus.CONFIRMED,
+        });
+      });
+    });
+
+    it('calls onTransitioned with updated trip on success', async () => {
+      const user = userEvent.setup();
+      const updatedTrip = { ...baseTripResponse, status: TripStatus.CONFIRMED };
+      mocks.transitionTripStatus.mockResolvedValueOnce(updatedTrip);
+      const onTransitioned = vi.fn();
+
+      render(
+        <TripStatusTransition
+          tripId="trip-1"
+          currentStatus={TripStatus.OPEN}
+          onTransitioned={onTransitioned}
+        />,
+      );
+
+      await user.click(screen.getByTestId('transition-btn-CONFIRMED'));
+      await user.click(screen.getByTestId('transition-confirm-btn'));
+
+      await waitFor(() => {
+        expect(onTransitioned).toHaveBeenCalledWith(updatedTrip);
+      });
+    });
+
+    it('shows error toast and does not call onTransitioned on failure', async () => {
+      const user = userEvent.setup();
+      mocks.transitionTripStatus.mockRejectedValueOnce(new Error('API error'));
+      const onTransitioned = vi.fn();
+
+      render(
+        <TripStatusTransition
+          tripId="trip-1"
+          currentStatus={TripStatus.OPEN}
+          onTransitioned={onTransitioned}
+        />,
+      );
+
+      await user.click(screen.getByTestId('transition-btn-CONFIRMED'));
+      await user.click(screen.getByTestId('transition-confirm-btn'));
+
+      await waitFor(() => {
+        expect(mocks.toastError).toHaveBeenCalledWith('transitions.error');
+      });
+      expect(onTransitioned).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/web/src/components/trips/TripStatusTransition.test.tsx
+++ b/apps/web/src/components/trips/TripStatusTransition.test.tsx
@@ -247,6 +247,54 @@ describe('TripStatusTransition', () => {
       });
     });
 
+    it('closes dialog after successful transition', async () => {
+      const user = userEvent.setup();
+      const updatedTrip = { ...baseTripResponse, status: TripStatus.CONFIRMED };
+      mocks.transitionTripStatus.mockResolvedValueOnce(updatedTrip);
+
+      render(
+        <TripStatusTransition
+          tripId="trip-1"
+          currentStatus={TripStatus.OPEN}
+          onTransitioned={vi.fn()}
+        />,
+      );
+
+      await user.click(screen.getByTestId('transition-btn-CONFIRMED'));
+      expect(screen.getByText('transitions.dialogTitle')).toBeInTheDocument();
+
+      await user.click(screen.getByTestId('transition-confirm-btn'));
+
+      await waitFor(() => {
+        expect(screen.queryByText('transitions.dialogTitle')).not.toBeInTheDocument();
+      });
+    });
+
+    it('disables confirm button while transition is in flight', async () => {
+      const user = userEvent.setup();
+      let resolveTransition!: (value: typeof baseTripResponse) => void;
+      mocks.transitionTripStatus.mockReturnValueOnce(
+        new Promise<typeof baseTripResponse>((resolve) => {
+          resolveTransition = resolve;
+        }),
+      );
+
+      render(
+        <TripStatusTransition
+          tripId="trip-1"
+          currentStatus={TripStatus.OPEN}
+          onTransitioned={vi.fn()}
+        />,
+      );
+
+      await user.click(screen.getByTestId('transition-btn-CONFIRMED'));
+      await user.click(screen.getByTestId('transition-confirm-btn'));
+
+      expect(screen.getByTestId('transition-confirm-btn')).toBeDisabled();
+
+      resolveTransition({ ...baseTripResponse, status: TripStatus.CONFIRMED });
+    });
+
     it('shows error toast and does not call onTransitioned on failure', async () => {
       const user = userEvent.setup();
       mocks.transitionTripStatus.mockRejectedValueOnce(new Error('API error'));

--- a/apps/web/src/components/trips/TripStatusTransition.tsx
+++ b/apps/web/src/components/trips/TripStatusTransition.tsx
@@ -1,0 +1,133 @@
+'use client';
+
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { TripStatus } from '@chamuco/shared-types';
+
+import { Button } from '@/components/ui/button';
+import { toast } from '@/components/ui/toast';
+import {
+  Dialog,
+  DialogPopup,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+  DialogClose,
+} from '@/components/ui/dialog';
+import { transitionTripStatus } from '@/services/trips.service';
+import type { TripResponse } from '@/services/trips.types';
+
+const VALID_TRANSITIONS: Partial<Record<TripStatus, TripStatus[]>> = {
+  [TripStatus.DRAFT]: [TripStatus.OPEN, TripStatus.CANCELLED],
+  [TripStatus.OPEN]: [TripStatus.CONFIRMED, TripStatus.CANCELLED],
+  [TripStatus.CONFIRMED]: [TripStatus.IN_PROGRESS, TripStatus.CANCELLED],
+  [TripStatus.IN_PROGRESS]: [TripStatus.COMPLETED],
+};
+
+interface TripStatusTransitionProps {
+  tripId: string;
+  currentStatus: TripStatus;
+  onTransitioned: (trip: TripResponse) => void;
+}
+
+export function TripStatusTransition({
+  tripId,
+  currentStatus,
+  onTransitioned,
+}: TripStatusTransitionProps) {
+  const { t } = useTranslation('trips');
+  const [pendingTransition, setPendingTransition] = useState<TripStatus | null>(null);
+  const [isTransitioning, setIsTransitioning] = useState(false);
+
+  const targets = VALID_TRANSITIONS[currentStatus];
+  if (!targets?.length) return null;
+
+  function handleButtonClick(target: TripStatus) {
+    setPendingTransition(target);
+  }
+
+  function handleDialogClose() {
+    if (isTransitioning) return;
+    setPendingTransition(null);
+  }
+
+  async function handleConfirm() {
+    if (!pendingTransition) return;
+    setIsTransitioning(true);
+    try {
+      const updated = await transitionTripStatus(tripId, { status: pendingTransition });
+      setPendingTransition(null);
+      onTransitioned(updated);
+    } catch {
+      toast.error(t('transitions.error'));
+    } finally {
+      setIsTransitioning(false);
+    }
+  }
+
+  const isCancelTarget = pendingTransition === TripStatus.CANCELLED;
+
+  return (
+    <>
+      <div className="flex flex-wrap gap-2">
+        {targets.map((target) => (
+          <Button
+            key={target}
+            type="button"
+            variant={target === TripStatus.CANCELLED ? 'destructive' : 'outline'}
+            size="sm"
+            onClick={() => handleButtonClick(target)}
+            data-testid={`transition-btn-${target}`}
+          >
+            {t(`transitions.${target}`)}
+          </Button>
+        ))}
+      </div>
+
+      <Dialog
+        open={pendingTransition !== null}
+        onOpenChange={(open) => !open && handleDialogClose()}
+      >
+        <DialogPopup>
+          <DialogClose />
+          <DialogHeader>
+            <DialogTitle>{t('transitions.dialogTitle')}</DialogTitle>
+            <DialogDescription>
+              {t('transitions.dialogDescription', {
+                status: pendingTransition ? t(`transitions.${pendingTransition}`) : '',
+              })}
+            </DialogDescription>
+            {isCancelTarget && (
+              <p className="text-sm font-medium text-destructive">
+                {t('transitions.cancelWarning')}
+              </p>
+            )}
+          </DialogHeader>
+
+          <DialogFooter className="mt-4">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={handleDialogClose}
+              disabled={isTransitioning}
+            >
+              {t('transitions.cancelButton')}
+            </Button>
+            <Button
+              type="button"
+              variant={isCancelTarget ? 'destructive' : 'default'}
+              size="sm"
+              onClick={handleConfirm}
+              disabled={isTransitioning}
+              data-testid="transition-confirm-btn"
+            >
+              {t('transitions.confirmButton')}
+            </Button>
+          </DialogFooter>
+        </DialogPopup>
+      </Dialog>
+    </>
+  );
+}

--- a/apps/web/src/locales/en/trips.json
+++ b/apps/web/src/locales/en/trips.json
@@ -99,6 +99,19 @@
   "card": {
     "capacityOf": "of"
   },
+  "transitions": {
+    "OPEN": "Open for Registration",
+    "CONFIRMED": "Confirm Trip",
+    "IN_PROGRESS": "Start Trip",
+    "COMPLETED": "Mark as Completed",
+    "CANCELLED": "Cancel Trip",
+    "dialogTitle": "Confirm action",
+    "dialogDescription": "Change the trip status to {{status}}?",
+    "cancelWarning": "This action cannot be undone.",
+    "confirmButton": "Confirm",
+    "cancelButton": "Go back",
+    "error": "Failed to update trip status. Please try again."
+  },
   "destinations": {
     "addButton": "Add destination",
     "addTitle": "Add destination",

--- a/apps/web/src/locales/es/trips.json
+++ b/apps/web/src/locales/es/trips.json
@@ -99,6 +99,19 @@
   "card": {
     "capacityOf": "de"
   },
+  "transitions": {
+    "OPEN": "Abrir inscripciones",
+    "CONFIRMED": "Confirmar viaje",
+    "IN_PROGRESS": "Iniciar viaje",
+    "COMPLETED": "Marcar como completado",
+    "CANCELLED": "Cancelar viaje",
+    "dialogTitle": "Confirmar acción",
+    "dialogDescription": "¿Cambiar el estado del viaje a {{status}}?",
+    "cancelWarning": "Esta acción no se puede deshacer.",
+    "confirmButton": "Confirmar",
+    "cancelButton": "Volver",
+    "error": "Error al actualizar el estado del viaje. Por favor intenta de nuevo."
+  },
   "destinations": {
     "addButton": "Agregar destino",
     "addTitle": "Agregar destino",


### PR DESCRIPTION
## Summary

Organizers had no way to advance or cancel a trip through its lifecycle from the UI. This PR adds the missing status transition controls while also extracting the inline status badge into a reusable component used across `TripCard` and the trip detail page.

## Changes

**New components**
- `TripStatusBadge` — reusable color-coded badge wrapping the existing `STATUS_CLASSES`/`STATUS_I18N_KEYS` records; replaces duplicate inline spans in `TripCard` and `page.tsx`
- `TripStatusTransition` — organizer-only action bar rendering valid next-state buttons for the current lifecycle position; confirmation dialog before every transition, with an irreversibility warning and destructive styling for the CANCELLED target

**Page integration**
- `page.tsx` — uses `TripStatusBadge` for the header badge; renders `TripStatusTransition` in a dedicated organizer section between the trip header and destinations; `onTransitioned` updates the page's `trip` state so the badge reflects the new status after API confirmation

**i18n**
- Added `transitions.*` keys to `en/trips.json` and `es/trips.json` (11 keys each)

## Testing

- `TripStatusBadge.test.tsx` — 12 tests: correct i18n key and CSS class for all 6 statuses
- `TripStatusTransition.test.tsx` — 13 tests: correct buttons per status, terminal states render nothing, dialog opens/closes, CANCELLED warning shown only for that target, API called with correct args, `onTransitioned` invoked on success, toast shown and callback not called on error

All 1803 tests pass. Typecheck and lint clean.

## Notes

`TripCard.test.tsx` required no changes — the `data-testid="status-badge"` attribute is preserved inside `TripStatusBadge`, so existing assertions continue to pass unmodified.

Closes #410