### PR TITLE
feat(trips): add settings page with cover editor for /trips/[id]/settings

### DIFF
--- a/apps/web/src/app/trips/[id]/settings/page.test.tsx
+++ b/apps/web/src/app/trips/[id]/settings/page.test.tsx
@@ -1,0 +1,360 @@
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { type ReactNode } from 'react';
+import { TripRole, TripStatus, TripVisibility } from '@chamuco/shared-types';
+import type { TripResponse } from '@/services/trips.types';
+
+const mocks = vi.hoisted(() => ({
+  mockApiGet: vi.fn(),
+  mockApiPatch: vi.fn(),
+  mockUseAuth: vi.fn(),
+  mockRouterReplace: vi.fn(),
+  mockRouterPush: vi.fn(),
+  mockToastSuccess: vi.fn(),
+  mockToastError: vi.fn(),
+}));
+
+vi.mock('react', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react')>();
+  return {
+    ...actual,
+    use: vi.fn().mockReturnValue({ id: 'trip-id' }),
+  };
+});
+
+vi.mock('next/link', () => ({
+  default: ({
+    href,
+    children,
+    ...props
+  }: {
+    href: string;
+    children: ReactNode;
+    [key: string]: unknown;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    replace: mocks.mockRouterReplace,
+    push: mocks.mockRouterPush,
+  }),
+}));
+
+vi.mock('@/services/api-client', () => ({
+  apiClient: {
+    get: mocks.mockApiGet,
+    patch: mocks.mockApiPatch,
+  },
+}));
+
+vi.mock('@/hooks/useAuth', () => ({
+  useAuth: mocks.mockUseAuth,
+}));
+
+vi.mock('@/components/trips/TripCoverEditor', () => ({
+  TripCoverEditor: ({ trip }: { trip: { id: string; coverUrl: string | null } }) => (
+    <div data-testid="trip-cover-editor" data-trip-id={trip.id} />
+  ),
+}));
+
+vi.mock('@/components/trips/TripForm', () => ({
+  TripForm: ({
+    initialValues,
+    onSuccess,
+  }: {
+    mode: string;
+    tripId: string;
+    initialValues: { name: string };
+    onSuccess: (trip: TripResponse) => void;
+  }) => (
+    <div>
+      <span data-testid="form-name">{initialValues.name}</span>
+      <button type="button" onClick={() => onSuccess({ id: 'trip-id' } as TripResponse)}>
+        save-form
+      </button>
+    </div>
+  ),
+}));
+
+vi.mock('@/components/ui/toast', () => ({
+  toast: {
+    success: mocks.mockToastSuccess,
+    error: mocks.mockToastError,
+  },
+}));
+
+vi.mock('@phosphor-icons/react', () => ({
+  ArrowLeftIcon: () => null,
+  XIcon: () => null,
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (_ns?: string) => ({
+    t: (key: string, opts?: Record<string, string>) => {
+      if (opts) {
+        const interpolated = Object.entries(opts).reduce(
+          (acc, [k, v]) => acc.replace(`{{${k}}}`, v),
+          key,
+        );
+        return interpolated === key ? [key, ...Object.values(opts)].join(' ') : interpolated;
+      }
+      return key;
+    },
+    i18n: { language: 'en' },
+  }),
+}));
+
+import TripSettingsPage from './page';
+
+const mockTrip: TripResponse = {
+  id: 'trip-id',
+  name: 'Cancún 2026',
+  description: 'Beach trip.',
+  status: TripStatus.OPEN,
+  visibility: TripVisibility.PUBLIC,
+  startDate: '2026-07-01',
+  endDate: '2026-07-10',
+  participantCapacity: 12,
+  departureCountry: 'MX',
+  departureCity: 'Mexico City',
+  landingCountry: 'MX',
+  landingCity: 'Mexico City',
+  defaultTimezone: null,
+  defaultCurrency: null,
+  itineraryNotes: null,
+  agencyId: null,
+  createdBy: 'user-1',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+  requiresConfirmation: false,
+  feedbackOpenUntil: null,
+  coverUrl: null,
+};
+
+function setupMocks({
+  role = TripRole.ORGANIZER,
+  tripStatus = TripStatus.OPEN,
+}: {
+  role?: TripRole | null;
+  tripStatus?: TripStatus;
+} = {}) {
+  mocks.mockUseAuth.mockReturnValue({ isLoading: false });
+
+  mocks.mockApiGet.mockImplementation((url: string) => {
+    if (url.includes('/participants/me')) {
+      if (role === null) return Promise.reject(new Error('Not a participant'));
+      return Promise.resolve({
+        data: {
+          userId: 'user-1',
+          username: 'user1',
+          displayName: 'User 1',
+          avatarUrl: null,
+          role,
+          isTraveler: true,
+          confirmedAt: null,
+        },
+      });
+    }
+    return Promise.resolve({ data: { ...mockTrip, status: tripStatus } });
+  });
+}
+
+describe('TripSettingsPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders edit form pre-filled with trip data after load', async () => {
+    setupMocks();
+    render(<TripSettingsPage params={Promise.resolve({ id: 'trip-id' })} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('form-name')).toHaveTextContent('Cancún 2026');
+    });
+  });
+
+  it('renders settings page heading', async () => {
+    setupMocks();
+    render(<TripSettingsPage params={Promise.resolve({ id: 'trip-id' })} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('settings.title')).toBeInTheDocument();
+    });
+  });
+
+  it('shows success toast and stays on page after successful edit', async () => {
+    setupMocks();
+    render(<TripSettingsPage params={Promise.resolve({ id: 'trip-id' })} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('form-name')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText('save-form'));
+
+    await waitFor(() => {
+      expect(mocks.mockToastSuccess).toHaveBeenCalledWith('settings.editSuccess');
+      expect(mocks.mockRouterReplace).not.toHaveBeenCalled();
+      expect(mocks.mockRouterPush).not.toHaveBeenCalled();
+    });
+  });
+
+  it('redirects PARTICIPANT to trip detail', async () => {
+    setupMocks({ role: TripRole.PARTICIPANT });
+    render(<TripSettingsPage params={Promise.resolve({ id: 'trip-id' })} />);
+
+    await waitFor(() => {
+      expect(mocks.mockRouterReplace).toHaveBeenCalledWith('/trips/trip-id');
+    });
+  });
+
+  it('redirects non-participant to trip detail', async () => {
+    setupMocks({ role: null });
+    render(<TripSettingsPage params={Promise.resolve({ id: 'trip-id' })} />);
+
+    await waitFor(() => {
+      expect(mocks.mockRouterReplace).toHaveBeenCalledWith('/trips/trip-id');
+    });
+  });
+
+  it('allows CO_ORGANIZER to access', async () => {
+    setupMocks({ role: TripRole.CO_ORGANIZER });
+    render(<TripSettingsPage params={Promise.resolve({ id: 'trip-id' })} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('form-name')).toBeInTheDocument();
+      expect(mocks.mockRouterReplace).not.toHaveBeenCalled();
+    });
+  });
+
+  it('shows danger zone for OPEN trip', async () => {
+    setupMocks({ tripStatus: TripStatus.OPEN });
+    render(<TripSettingsPage params={Promise.resolve({ id: 'trip-id' })} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('cancel-trip-btn')).toBeInTheDocument();
+    });
+  });
+
+  it('shows danger zone for DRAFT trip', async () => {
+    setupMocks({ tripStatus: TripStatus.DRAFT });
+    render(<TripSettingsPage params={Promise.resolve({ id: 'trip-id' })} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('cancel-trip-btn')).toBeInTheDocument();
+    });
+  });
+
+  it('shows danger zone for CONFIRMED trip', async () => {
+    setupMocks({ tripStatus: TripStatus.CONFIRMED });
+    render(<TripSettingsPage params={Promise.resolve({ id: 'trip-id' })} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('cancel-trip-btn')).toBeInTheDocument();
+    });
+  });
+
+  it('hides danger zone for IN_PROGRESS trip', async () => {
+    setupMocks({ tripStatus: TripStatus.IN_PROGRESS });
+    render(<TripSettingsPage params={Promise.resolve({ id: 'trip-id' })} />);
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('cancel-trip-btn')).not.toBeInTheDocument();
+    });
+  });
+
+  it('hides danger zone for CANCELLED trip', async () => {
+    setupMocks({ tripStatus: TripStatus.CANCELLED });
+    render(<TripSettingsPage params={Promise.resolve({ id: 'trip-id' })} />);
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('cancel-trip-btn')).not.toBeInTheDocument();
+    });
+  });
+
+  it('hides danger zone for COMPLETED trip', async () => {
+    setupMocks({ tripStatus: TripStatus.COMPLETED });
+    render(<TripSettingsPage params={Promise.resolve({ id: 'trip-id' })} />);
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('cancel-trip-btn')).not.toBeInTheDocument();
+    });
+  });
+
+  it('opens cancel dialog when cancel button clicked', async () => {
+    setupMocks();
+    render(<TripSettingsPage params={Promise.resolve({ id: 'trip-id' })} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('cancel-trip-btn')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('cancel-trip-btn'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('cancel-trip-confirm-btn')).toBeInTheDocument();
+    });
+  });
+
+  it('calls transitionTripStatus with CANCELLED on confirm', async () => {
+    mocks.mockApiPatch.mockResolvedValue({ data: { ...mockTrip, status: TripStatus.CANCELLED } });
+    setupMocks();
+    render(<TripSettingsPage params={Promise.resolve({ id: 'trip-id' })} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('cancel-trip-btn')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('cancel-trip-btn'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('cancel-trip-confirm-btn')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('cancel-trip-confirm-btn'));
+
+    await waitFor(() => {
+      expect(mocks.mockApiPatch).toHaveBeenCalledWith('/v1/trips/trip-id/status', {
+        status: TripStatus.CANCELLED,
+      });
+      expect(mocks.mockToastSuccess).toHaveBeenCalledWith('settings.cancelSuccess');
+      expect(mocks.mockRouterReplace).toHaveBeenCalledWith('/trips/trip-id');
+    });
+  });
+
+  it('shows error toast when cancel fails', async () => {
+    mocks.mockApiPatch.mockRejectedValue(new Error('Server error'));
+    setupMocks();
+    render(<TripSettingsPage params={Promise.resolve({ id: 'trip-id' })} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('cancel-trip-btn')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('cancel-trip-btn'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('cancel-trip-confirm-btn')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('cancel-trip-confirm-btn'));
+
+    await waitFor(() => {
+      expect(mocks.mockToastError).toHaveBeenCalledWith('settings.cancelFailed');
+    });
+  });
+
+  it('redirects to trip detail when fetch fails', async () => {
+    mocks.mockUseAuth.mockReturnValue({ isLoading: false });
+    mocks.mockApiGet.mockRejectedValue(new Error('Network error'));
+    render(<TripSettingsPage params={Promise.resolve({ id: 'trip-id' })} />);
+
+    await waitFor(() => {
+      expect(mocks.mockRouterReplace).toHaveBeenCalledWith('/trips/trip-id');
+    });
+  });
+});

--- a/apps/web/src/app/trips/[id]/settings/page.test.tsx
+++ b/apps/web/src/app/trips/[id]/settings/page.test.tsx
@@ -8,7 +8,6 @@ const mocks = vi.hoisted(() => ({
   mockApiPatch: vi.fn(),
   mockUseAuth: vi.fn(),
   mockRouterReplace: vi.fn(),
-  mockRouterPush: vi.fn(),
   mockToastSuccess: vi.fn(),
   mockToastError: vi.fn(),
 }));
@@ -40,7 +39,6 @@ vi.mock('next/link', () => ({
 vi.mock('next/navigation', () => ({
   useRouter: () => ({
     replace: mocks.mockRouterReplace,
-    push: mocks.mockRouterPush,
   }),
 }));
 
@@ -199,7 +197,6 @@ describe('TripSettingsPage', () => {
     await waitFor(() => {
       expect(mocks.mockToastSuccess).toHaveBeenCalledWith('settings.editSuccess');
       expect(mocks.mockRouterReplace).not.toHaveBeenCalled();
-      expect(mocks.mockRouterPush).not.toHaveBeenCalled();
     });
   });
 
@@ -345,6 +342,27 @@ describe('TripSettingsPage', () => {
 
     await waitFor(() => {
       expect(mocks.mockToastError).toHaveBeenCalledWith('settings.cancelFailed');
+    });
+  });
+
+  it('cancel dialog closes when go-back button clicked', async () => {
+    setupMocks();
+    render(<TripSettingsPage params={Promise.resolve({ id: 'trip-id' })} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('cancel-trip-btn')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('cancel-trip-btn'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('cancel-trip-confirm-btn')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText('transitions.cancelButton'));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('cancel-trip-confirm-btn')).not.toBeInTheDocument();
     });
   });
 

--- a/apps/web/src/app/trips/[id]/settings/page.tsx
+++ b/apps/web/src/app/trips/[id]/settings/page.tsx
@@ -126,59 +126,63 @@ export default function TripSettingsPage({ params }: TripSettingsPageProps) {
       />
 
       {canCancel && (
-        <div className="mt-10 rounded-xl border border-destructive/50 p-6">
-          <h2 className="text-base font-semibold text-destructive mb-3">
-            {t('settings.dangerZone')}
-          </h2>
-          <div className="flex items-center justify-between gap-4">
-            <p className="text-sm text-muted-foreground">{t('settings.cancelTripDescription')}</p>
-            <Button
-              type="button"
-              variant="destructive"
-              size="sm"
-              onClick={() => setShowCancelDialog(true)}
-              data-testid="cancel-trip-btn"
-            >
-              {t('settings.cancelTrip')}
-            </Button>
+        <>
+          <div className="mt-10 rounded-xl border border-destructive/50 p-6">
+            <h2 className="text-base font-semibold text-destructive mb-3">
+              {t('settings.dangerZone')}
+            </h2>
+            <div className="flex items-center justify-between gap-4">
+              <p className="text-sm text-muted-foreground">{t('settings.cancelTripDescription')}</p>
+              <Button
+                type="button"
+                variant="destructive"
+                size="sm"
+                onClick={() => setShowCancelDialog(true)}
+                data-testid="cancel-trip-btn"
+              >
+                {t('settings.cancelTrip')}
+              </Button>
+            </div>
           </div>
-        </div>
-      )}
 
-      <Dialog
-        open={showCancelDialog}
-        onOpenChange={(open) => !isCancelling && setShowCancelDialog(open)}
-      >
-        <DialogPopup>
-          <DialogClose />
-          <DialogHeader>
-            <DialogTitle>{t('settings.cancelDialogTitle')}</DialogTitle>
-            <DialogDescription>{t('settings.cancelDialogDescription')}</DialogDescription>
-            <p className="text-sm font-medium text-destructive">{t('transitions.cancelWarning')}</p>
-          </DialogHeader>
-          <DialogFooter className="mt-4">
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              onClick={() => setShowCancelDialog(false)}
-              disabled={isCancelling}
-            >
-              {t('transitions.cancelButton')}
-            </Button>
-            <Button
-              type="button"
-              variant="destructive"
-              size="sm"
-              onClick={() => void handleCancel()}
-              disabled={isCancelling}
-              data-testid="cancel-trip-confirm-btn"
-            >
-              {t('transitions.confirmButton')}
-            </Button>
-          </DialogFooter>
-        </DialogPopup>
-      </Dialog>
+          <Dialog
+            open={showCancelDialog}
+            onOpenChange={(open) => !isCancelling && setShowCancelDialog(open)}
+          >
+            <DialogPopup>
+              <DialogClose />
+              <DialogHeader>
+                <DialogTitle>{t('settings.cancelDialogTitle')}</DialogTitle>
+                <DialogDescription>{t('settings.cancelDialogDescription')}</DialogDescription>
+                <p className="text-sm font-medium text-destructive">
+                  {t('transitions.cancelWarning')}
+                </p>
+              </DialogHeader>
+              <DialogFooter className="mt-4">
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setShowCancelDialog(false)}
+                  disabled={isCancelling}
+                >
+                  {t('transitions.cancelButton')}
+                </Button>
+                <Button
+                  type="button"
+                  variant="destructive"
+                  size="sm"
+                  onClick={() => void handleCancel()}
+                  disabled={isCancelling}
+                  data-testid="cancel-trip-confirm-btn"
+                >
+                  {t('transitions.confirmButton')}
+                </Button>
+              </DialogFooter>
+            </DialogPopup>
+          </Dialog>
+        </>
+      )}
     </div>
   );
 }

--- a/apps/web/src/app/trips/[id]/settings/page.tsx
+++ b/apps/web/src/app/trips/[id]/settings/page.tsx
@@ -1,0 +1,184 @@
+'use client';
+
+import { useCallback, useEffect, useState, use } from 'react';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useTranslation } from 'react-i18next';
+import { TripRole, TripStatus } from '@chamuco/shared-types';
+import { ArrowLeftIcon } from '@phosphor-icons/react';
+
+import { getTrip, getTripParticipation, transitionTripStatus } from '@/services/trips.service';
+import { useAuth } from '@/hooks/useAuth';
+import { TripCoverEditor } from '@/components/trips/TripCoverEditor';
+import { TripForm } from '@/components/trips/TripForm';
+import { toast } from '@/components/ui/toast';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogPopup,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+  DialogClose,
+} from '@/components/ui/dialog';
+import type { TripResponse } from '@/services/trips.types';
+
+interface TripSettingsPageProps {
+  params: Promise<{ id: string }>;
+}
+
+const ORGANIZER_ROLES: TripRole[] = [TripRole.ORGANIZER, TripRole.CO_ORGANIZER];
+const CANCELLABLE_STATUSES: TripStatus[] = [
+  TripStatus.DRAFT,
+  TripStatus.OPEN,
+  TripStatus.CONFIRMED,
+];
+
+export default function TripSettingsPage({ params }: TripSettingsPageProps) {
+  const { id } = use(params);
+  const { t } = useTranslation('trips');
+  const router = useRouter();
+  const { isLoading: isAuthLoading } = useAuth();
+  const [trip, setTrip] = useState<TripResponse | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [showCancelDialog, setShowCancelDialog] = useState(false);
+  const [isCancelling, setIsCancelling] = useState(false);
+
+  const fetchTrip = useCallback(() => {
+    if (isAuthLoading) return;
+    Promise.all([getTrip(id), getTripParticipation(id).catch(() => null)])
+      .then(([tripData, participation]) => {
+        const role = participation?.role ?? null;
+        if (role === null || !ORGANIZER_ROLES.includes(role)) {
+          router.replace(`/trips/${id}`);
+          return;
+        }
+        setTrip(tripData);
+      })
+      .catch(() => router.replace(`/trips/${id}`))
+      .finally(() => setIsLoading(false));
+  }, [id, router, isAuthLoading]);
+
+  useEffect(() => {
+    fetchTrip();
+  }, [fetchTrip]);
+
+  async function handleCancel() {
+    setIsCancelling(true);
+    try {
+      await transitionTripStatus(id, { status: TripStatus.CANCELLED });
+      setShowCancelDialog(false);
+      toast.success(t('settings.cancelSuccess'));
+      router.replace(`/trips/${id}`);
+    } catch {
+      toast.error(t('settings.cancelFailed'));
+    } finally {
+      setIsCancelling(false);
+    }
+  }
+
+  if (isLoading || !trip) return null;
+
+  const canCancel = CANCELLABLE_STATUSES.includes(trip.status);
+
+  return (
+    <div className="p-8 max-w-xl">
+      <div className="mb-6">
+        <Link
+          href={`/trips/${id}`}
+          className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors"
+        >
+          <ArrowLeftIcon className="size-4" />
+          {trip.name}
+        </Link>
+      </div>
+
+      <h1 className="text-3xl font-bold mb-6">{t('settings.title')}</h1>
+
+      <div className="mb-8">
+        <p className="text-sm font-medium mb-3">{t('cover.label')}</p>
+        <TripCoverEditor trip={trip} onUpdate={fetchTrip} />
+      </div>
+
+      <TripForm
+        mode="edit"
+        tripId={trip.id}
+        initialValues={{
+          name: trip.name,
+          description: trip.description,
+          visibility: trip.visibility,
+          startDate: trip.startDate,
+          endDate: trip.endDate,
+          participantCapacity: trip.participantCapacity,
+          departureCountry: trip.departureCountry,
+          departureCity: trip.departureCity,
+          landingCountry: trip.landingCountry,
+          landingCity: trip.landingCity,
+          defaultTimezone: trip.defaultTimezone,
+          defaultCurrency: trip.defaultCurrency,
+          itineraryNotes: trip.itineraryNotes,
+        }}
+        onSuccess={(updated) => {
+          setTrip(updated);
+          toast.success(t('settings.editSuccess'));
+        }}
+      />
+
+      {canCancel && (
+        <div className="mt-10 rounded-xl border border-destructive/50 p-6">
+          <h2 className="text-base font-semibold text-destructive mb-3">
+            {t('settings.dangerZone')}
+          </h2>
+          <div className="flex items-center justify-between gap-4">
+            <p className="text-sm text-muted-foreground">{t('settings.cancelTripDescription')}</p>
+            <Button
+              type="button"
+              variant="destructive"
+              size="sm"
+              onClick={() => setShowCancelDialog(true)}
+              data-testid="cancel-trip-btn"
+            >
+              {t('settings.cancelTrip')}
+            </Button>
+          </div>
+        </div>
+      )}
+
+      <Dialog
+        open={showCancelDialog}
+        onOpenChange={(open) => !isCancelling && setShowCancelDialog(open)}
+      >
+        <DialogPopup>
+          <DialogClose />
+          <DialogHeader>
+            <DialogTitle>{t('settings.cancelDialogTitle')}</DialogTitle>
+            <DialogDescription>{t('settings.cancelDialogDescription')}</DialogDescription>
+            <p className="text-sm font-medium text-destructive">{t('transitions.cancelWarning')}</p>
+          </DialogHeader>
+          <DialogFooter className="mt-4">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => setShowCancelDialog(false)}
+              disabled={isCancelling}
+            >
+              {t('transitions.cancelButton')}
+            </Button>
+            <Button
+              type="button"
+              variant="destructive"
+              size="sm"
+              onClick={() => void handleCancel()}
+              disabled={isCancelling}
+              data-testid="cancel-trip-confirm-btn"
+            >
+              {t('transitions.confirmButton')}
+            </Button>
+          </DialogFooter>
+        </DialogPopup>
+      </Dialog>
+    </div>
+  );
+}

--- a/apps/web/src/components/trips/TripCoverEditor.test.tsx
+++ b/apps/web/src/components/trips/TripCoverEditor.test.tsx
@@ -1,0 +1,261 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+const mocks = vi.hoisted(() => ({
+  mockPatch: vi.fn(),
+  mockToastSuccess: vi.fn(),
+  mockToastError: vi.fn(),
+  mockOnUpdate: vi.fn(),
+  mockUpload: vi.fn(),
+}));
+
+vi.mock('@/services/api-client', () => ({
+  apiClient: { patch: mocks.mockPatch },
+}));
+
+vi.mock('@/components/ui/toast', () => ({
+  toast: {
+    success: mocks.mockToastSuccess,
+    error: mocks.mockToastError,
+  },
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key.replace(/^common:/, ''),
+  }),
+}));
+
+vi.mock('@/hooks/useFileUpload', () => ({
+  useFileUpload: () => ({
+    upload: mocks.mockUpload,
+    progress: 0,
+    isUploading: false,
+    error: null,
+    reset: vi.fn(),
+  }),
+}));
+
+vi.mock('@/components/ui/crop-modal', () => ({
+  CropModal: ({
+    onConfirm,
+    onCancel,
+  }: {
+    file: File;
+    onConfirm: (blob: Blob) => void;
+    onCancel: () => void;
+    isConfirming: boolean;
+    uploadProgress: number;
+    isUploading: boolean;
+    title: string;
+    confirmLabel: string;
+  }) => (
+    <div data-testid="crop-modal">
+      <button
+        data-testid="crop-confirm"
+        onClick={() => onConfirm(new Blob(['jpeg'], { type: 'image/jpeg' }))}
+      >
+        confirm
+      </button>
+      <button data-testid="crop-cancel" onClick={onCancel}>
+        cancel
+      </button>
+    </div>
+  ),
+}));
+
+vi.mock('@phosphor-icons/react', () => ({
+  AirplaneTakeoffIcon: (props: Record<string, unknown>) => (
+    <svg data-testid={props['data-testid'] as string} aria-hidden="true" />
+  ),
+  XIcon: () => null,
+}));
+
+vi.mock('@chamuco/shared-utils', () => ({
+  getTwemojiUrl: (emoji: string) => `https://twemoji.example.com/${emoji}.svg`,
+}));
+
+vi.mock('@/lib/avatar-emojis', () => ({
+  AVATAR_EMOJIS: ['😀', '✈️'],
+}));
+
+import { TripCoverEditor } from './TripCoverEditor';
+
+const baseTrip: { id: string; coverUrl: string | null } = {
+  id: 'trip-uuid',
+  coverUrl: 'https://twemoji.example.com/🏖️.svg',
+};
+
+function setup(tripOverride?: Partial<typeof baseTrip>) {
+  const user = userEvent.setup();
+  render(<TripCoverEditor trip={{ ...baseTrip, ...tripOverride }} onUpdate={mocks.mockOnUpdate} />);
+  return { user };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.mockPatch.mockResolvedValue({});
+  mocks.mockUpload.mockResolvedValue('trip-covers/trip-uuid/cover.jpg');
+});
+
+describe('TripCoverEditor', () => {
+  describe('rendering', () => {
+    it('renders cover image when coverUrl is set', () => {
+      setup();
+      const img = screen.getByTestId('trip-cover');
+      expect(img).toHaveAttribute('src', 'https://twemoji.example.com/🏖️.svg');
+    });
+
+    it('renders placeholder when coverUrl is null', () => {
+      setup({ coverUrl: null });
+      expect(screen.getByTestId('trip-cover-placeholder')).toBeInTheDocument();
+      expect(screen.queryByTestId('trip-cover')).not.toBeInTheDocument();
+    });
+
+    it('renders the edit button', () => {
+      setup();
+      expect(screen.getByText('cover.editButton')).toBeInTheDocument();
+    });
+  });
+
+  describe('dialog', () => {
+    it('opens dialog when edit button is clicked', async () => {
+      const { user } = setup();
+      await user.click(screen.getByText('cover.editButton'));
+      expect(screen.getByText('cover.tabImage')).toBeInTheDocument();
+      expect(screen.getByText('cover.tabEmoji')).toBeInTheDocument();
+    });
+
+    it('shows photo tab by default with file input', async () => {
+      const { user } = setup();
+      await user.click(screen.getByText('cover.editButton'));
+      expect(document.querySelector('input[type="file"]')).toBeInTheDocument();
+    });
+
+    it('switches to emoji tab', async () => {
+      const { user } = setup();
+      await user.click(screen.getByText('cover.editButton'));
+      await user.click(screen.getByText('cover.tabEmoji'));
+      expect(screen.getByAltText('😀')).toBeInTheDocument();
+    });
+
+    it('shows current cover inside dialog when coverUrl is set', async () => {
+      const { user } = setup({
+        coverUrl: 'https://storage.googleapis.com/bucket/trip-covers/trip-uuid/cover.jpg',
+      });
+      await user.click(screen.getByText('cover.editButton'));
+      expect(screen.getByText('cover.currentCover')).toBeInTheDocument();
+    });
+
+    it('hides current cover inside dialog when coverUrl is null', async () => {
+      const { user } = setup({ coverUrl: null });
+      await user.click(screen.getByText('cover.editButton'));
+      expect(screen.queryByText('cover.currentCover')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('photo upload', () => {
+    it('shows crop modal after file selection', async () => {
+      const { user } = setup();
+      await user.click(screen.getByText('cover.editButton'));
+
+      const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+      const testFile = new File(['test'], 'cover.jpg', { type: 'image/jpeg' });
+      await user.upload(fileInput, testFile);
+
+      expect(screen.getByTestId('crop-modal')).toBeInTheDocument();
+    });
+
+    it('calls PATCH with gcs source after crop confirm', async () => {
+      const { user } = setup();
+      await user.click(screen.getByText('cover.editButton'));
+
+      const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+      await user.upload(fileInput, new File(['test'], 'cover.jpg', { type: 'image/jpeg' }));
+      await user.click(screen.getByTestId('crop-confirm'));
+
+      await waitFor(() => {
+        expect(mocks.mockPatch).toHaveBeenCalledWith('/v1/trips/trip-uuid', {
+          cover: {
+            source: 'gcs',
+            target: 'trip-covers/trip-uuid/cover.jpg',
+            fileSize: expect.any(Number),
+          },
+        });
+      });
+      expect(mocks.mockOnUpdate).toHaveBeenCalled();
+      expect(mocks.mockToastSuccess).toHaveBeenCalledWith('cover.photoSuccess');
+    });
+
+    it('hides crop modal after cancel', async () => {
+      const { user } = setup();
+      await user.click(screen.getByText('cover.editButton'));
+
+      const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+      await user.upload(fileInput, new File(['test'], 'cover.jpg', { type: 'image/jpeg' }));
+
+      expect(screen.getByTestId('crop-modal')).toBeInTheDocument();
+      await user.click(screen.getByTestId('crop-cancel'));
+      expect(screen.queryByTestId('crop-modal')).not.toBeInTheDocument();
+    });
+
+    it('shows error toast when upload fails', async () => {
+      mocks.mockUpload.mockRejectedValue(new Error('Upload failed'));
+      const { user } = setup();
+      await user.click(screen.getByText('cover.editButton'));
+
+      const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+      await user.upload(fileInput, new File(['test'], 'cover.jpg', { type: 'image/jpeg' }));
+      await user.click(screen.getByTestId('crop-confirm'));
+
+      await waitFor(() => {
+        expect(mocks.mockToastError).toHaveBeenCalledWith('cover.photoError');
+      });
+      expect(mocks.mockOnUpdate).not.toHaveBeenCalled();
+    });
+
+    it('shows error toast when PATCH fails', async () => {
+      mocks.mockPatch.mockRejectedValue(new Error('Network error'));
+      const { user } = setup();
+      await user.click(screen.getByText('cover.editButton'));
+
+      const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+      await user.upload(fileInput, new File(['test'], 'cover.jpg', { type: 'image/jpeg' }));
+      await user.click(screen.getByTestId('crop-confirm'));
+
+      await waitFor(() => {
+        expect(mocks.mockToastError).toHaveBeenCalledWith('cover.photoError');
+      });
+      expect(mocks.mockOnUpdate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('emoji selection', () => {
+    it('calls PATCH with emoji source after emoji click', async () => {
+      const { user } = setup();
+      await user.click(screen.getByText('cover.editButton'));
+      await user.click(screen.getByText('cover.tabEmoji'));
+      await user.click(screen.getByAltText('😀'));
+
+      await waitFor(() => {
+        expect(mocks.mockPatch).toHaveBeenCalledWith('/v1/trips/trip-uuid', {
+          cover: { source: 'emoji', target: '😀' },
+        });
+      });
+      expect(mocks.mockOnUpdate).toHaveBeenCalled();
+      expect(mocks.mockToastSuccess).toHaveBeenCalledWith('cover.emojiSuccess');
+    });
+
+    it('shows error toast when emoji PATCH fails', async () => {
+      mocks.mockPatch.mockRejectedValue(new Error('Network error'));
+      const { user } = setup();
+      await user.click(screen.getByText('cover.editButton'));
+      await user.click(screen.getByText('cover.tabEmoji'));
+      await user.click(screen.getByAltText('😀'));
+
+      await waitFor(() => {
+        expect(mocks.mockToastError).toHaveBeenCalledWith('cover.emojiError');
+      });
+    });
+  });
+});

--- a/apps/web/src/components/trips/TripCoverEditor.tsx
+++ b/apps/web/src/components/trips/TripCoverEditor.tsx
@@ -1,0 +1,218 @@
+'use client';
+
+import { useState, useRef, type ChangeEvent } from 'react';
+import { useTranslation } from 'react-i18next';
+import { getTwemojiUrl } from '@chamuco/shared-utils';
+import { UploadType } from '@chamuco/shared-types';
+import { AirplaneTakeoffIcon } from '@phosphor-icons/react';
+
+import {
+  Dialog,
+  DialogTrigger,
+  DialogPopup,
+  DialogHeader,
+  DialogTitle,
+  DialogClose,
+} from '@/components/ui/dialog';
+import { toast } from '@/components/ui/toast';
+import { updateTrip } from '@/services/trips.service';
+import { useFileUpload } from '@/hooks/useFileUpload';
+import { AVATAR_EMOJIS } from '@/lib/avatar-emojis';
+import { CropModal } from '@/components/ui/crop-modal';
+
+type Tab = 'photo' | 'emoji';
+
+interface TripCoverEditorProps {
+  trip: { id: string; coverUrl: string | null };
+  onUpdate: () => void;
+}
+
+export function TripCoverEditor({ trip, onUpdate }: TripCoverEditorProps) {
+  const { t } = useTranslation(['trips', 'common']);
+  const [open, setOpen] = useState(false);
+  const [activeTab, setActiveTab] = useState<Tab>('photo');
+  const [isSaving, setIsSaving] = useState(false);
+  const [cropFile, setCropFile] = useState<File | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const { upload, progress, isUploading } = useFileUpload({
+    uploadType: UploadType.TRIP_COVER,
+    contextId: trip.id,
+  });
+
+  function handleFileChange(e: ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    if (fileInputRef.current) fileInputRef.current.value = '';
+    setCropFile(file);
+  }
+
+  async function handleCropConfirm(blob: Blob) {
+    setIsSaving(true);
+    try {
+      const file = new File([blob], 'cover.jpg', { type: 'image/jpeg' });
+      const objectKey = await upload(file);
+      await updateTrip(trip.id, {
+        cover: { source: 'gcs', target: objectKey, fileSize: blob.size },
+      });
+      toast.success(t('cover.photoSuccess'));
+      onUpdate();
+      setCropFile(null);
+      setOpen(false);
+    } catch {
+      toast.error(t('cover.photoError'));
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  function handleCropCancel() {
+    setCropFile(null);
+  }
+
+  async function handleEmojiSelect(emoji: string) {
+    setIsSaving(true);
+    try {
+      await updateTrip(trip.id, {
+        cover: { source: 'emoji', target: emoji },
+      });
+      toast.success(t('cover.emojiSuccess'));
+      onUpdate();
+      setOpen(false);
+    } catch {
+      toast.error(t('cover.emojiError'));
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  function handleOpenChange(next: boolean) {
+    if (!next) setCropFile(null);
+    setOpen(next);
+  }
+
+  return (
+    <div className="flex items-center gap-4">
+      <div className="size-12 overflow-hidden rounded-lg bg-muted flex items-center justify-center">
+        {trip.coverUrl ? (
+          <img
+            data-testid="trip-cover"
+            src={trip.coverUrl}
+            alt=""
+            className="size-full object-cover"
+          />
+        ) : (
+          <AirplaneTakeoffIcon
+            data-testid="trip-cover-placeholder"
+            className="size-6 text-muted-foreground"
+            aria-hidden="true"
+          />
+        )}
+      </div>
+      <Dialog open={open} onOpenChange={handleOpenChange}>
+        <DialogTrigger className="text-sm font-medium underline-offset-2 hover:underline">
+          {t('cover.editButton')}
+        </DialogTrigger>
+        <DialogPopup>
+          <DialogHeader>
+            <DialogTitle>{t('cover.editButton')}</DialogTitle>
+          </DialogHeader>
+          <DialogClose />
+
+          {cropFile ? (
+            <CropModal
+              file={cropFile}
+              onConfirm={(blob) => void handleCropConfirm(blob)}
+              onCancel={handleCropCancel}
+              isConfirming={isSaving}
+              uploadProgress={progress}
+              isUploading={isUploading}
+              title={t('cover.cropTitle')}
+              confirmLabel={t('cover.usePhoto')}
+            />
+          ) : (
+            <>
+              {trip.coverUrl && (
+                <div className="mt-6 flex items-center gap-3">
+                  <div className="size-12 overflow-hidden rounded-lg bg-muted flex items-center justify-center">
+                    <img src={trip.coverUrl} alt="" className="size-full object-cover" />
+                  </div>
+                  <span className="text-sm text-muted-foreground">{t('cover.currentCover')}</span>
+                </div>
+              )}
+
+              <div className="mt-4 flex gap-2 border-b">
+                <button
+                  type="button"
+                  onClick={() => setActiveTab('photo')}
+                  className={`pb-2 text-sm font-medium transition-colors ${
+                    activeTab === 'photo'
+                      ? 'border-b-2 border-primary text-primary'
+                      : 'text-muted-foreground hover:text-foreground'
+                  }`}
+                >
+                  {t('cover.tabImage')}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setActiveTab('emoji')}
+                  className={`pb-2 text-sm font-medium transition-colors ${
+                    activeTab === 'emoji'
+                      ? 'border-b-2 border-primary text-primary'
+                      : 'text-muted-foreground hover:text-foreground'
+                  }`}
+                >
+                  {t('cover.tabEmoji')}
+                </button>
+              </div>
+
+              <div className="mt-4">
+                {activeTab === 'photo' && (
+                  <>
+                    <input
+                      ref={fileInputRef}
+                      type="file"
+                      accept="image/jpeg,image/png,image/webp"
+                      onChange={handleFileChange}
+                      className="hidden"
+                      aria-hidden="true"
+                    />
+                    <button
+                      type="button"
+                      onClick={() => fileInputRef.current?.click()}
+                      disabled={isSaving}
+                      className="inline-flex w-full items-center justify-center gap-2 rounded-lg border border-border bg-background px-3 py-1.5 text-sm font-medium transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50"
+                    >
+                      {t('common:upload.chooseFile')}
+                    </button>
+                  </>
+                )}
+                {activeTab === 'emoji' && (
+                  <div className="grid grid-cols-8 gap-2">
+                    {AVATAR_EMOJIS.map((emoji) => (
+                      <button
+                        key={emoji}
+                        type="button"
+                        onClick={() => void handleEmojiSelect(emoji)}
+                        disabled={isSaving}
+                        aria-label={emoji}
+                        className="flex size-10 items-center justify-center rounded-lg hover:bg-muted disabled:opacity-50"
+                      >
+                        <img
+                          src={getTwemojiUrl(emoji)}
+                          alt={emoji}
+                          className="size-6"
+                          aria-hidden="true"
+                        />
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </div>
+            </>
+          )}
+        </DialogPopup>
+      </Dialog>
+    </div>
+  );
+}

--- a/apps/web/src/locales/en/trips.json
+++ b/apps/web/src/locales/en/trips.json
@@ -96,6 +96,30 @@
   "actions": {
     "editSettings": "Edit settings"
   },
+  "cover": {
+    "label": "Cover",
+    "editButton": "Edit cover",
+    "tabImage": "Photo",
+    "tabEmoji": "Emoji",
+    "photoSuccess": "Cover updated",
+    "photoError": "Failed to update cover photo",
+    "emojiSuccess": "Cover updated",
+    "emojiError": "Failed to update cover emoji",
+    "currentCover": "Current cover",
+    "cropTitle": "Crop photo",
+    "usePhoto": "Use photo"
+  },
+  "settings": {
+    "title": "Trip Settings",
+    "editSuccess": "Trip updated.",
+    "dangerZone": "Danger Zone",
+    "cancelTrip": "Cancel Trip",
+    "cancelTripDescription": "This action is irreversible. All participants will be notified.",
+    "cancelDialogTitle": "Cancel this trip?",
+    "cancelDialogDescription": "Are you sure you want to cancel this trip? All confirmed participants will be notified.",
+    "cancelSuccess": "Trip cancelled.",
+    "cancelFailed": "Failed to cancel trip. Please try again."
+  },
   "card": {
     "capacityOf": "of"
   },

--- a/apps/web/src/locales/en/trips.json
+++ b/apps/web/src/locales/en/trips.json
@@ -113,7 +113,7 @@
     "title": "Trip Settings",
     "editSuccess": "Trip updated.",
     "dangerZone": "Danger Zone",
-    "cancelTrip": "Cancel Trip",
+    "cancelTrip": "Cancel trip",
     "cancelTripDescription": "This action is irreversible. All participants will be notified.",
     "cancelDialogTitle": "Cancel this trip?",
     "cancelDialogDescription": "Are you sure you want to cancel this trip? All confirmed participants will be notified.",

--- a/apps/web/src/locales/es/trips.json
+++ b/apps/web/src/locales/es/trips.json
@@ -96,6 +96,30 @@
   "actions": {
     "editSettings": "Editar configuración"
   },
+  "cover": {
+    "label": "Portada",
+    "editButton": "Editar portada",
+    "tabImage": "Foto",
+    "tabEmoji": "Emoji",
+    "photoSuccess": "Portada actualizada",
+    "photoError": "Error al actualizar la foto de portada",
+    "emojiSuccess": "Portada actualizada",
+    "emojiError": "Error al actualizar el emoji de portada",
+    "currentCover": "Portada actual",
+    "cropTitle": "Recortar foto",
+    "usePhoto": "Usar foto"
+  },
+  "settings": {
+    "title": "Configuración del viaje",
+    "editSuccess": "Viaje actualizado.",
+    "dangerZone": "Zona de peligro",
+    "cancelTrip": "Cancelar viaje",
+    "cancelTripDescription": "Esta acción es irreversible. Todos los participantes serán notificados.",
+    "cancelDialogTitle": "¿Cancelar este viaje?",
+    "cancelDialogDescription": "¿Estás seguro de que deseas cancelar este viaje? Todos los participantes confirmados serán notificados.",
+    "cancelSuccess": "Viaje cancelado.",
+    "cancelFailed": "Error al cancelar el viaje. Por favor intenta de nuevo."
+  },
   "card": {
     "capacityOf": "de"
   },


### PR DESCRIPTION
## Summary

Organizers need a dedicated page to edit trip details and manage the trip cover independently from the creation flow. This adds `/trips/[id]/settings` mirroring the existing `/groups/[id]/settings` pattern — edit form pre-filled with current values, a cover editor, and a danger zone for cancellation.

## Changes

**New: `TripSettingsPage` (`/trips/[id]/settings`)**
- Organizer-only access — non-organizers and non-participants are redirected to `/trips/[id]`
- `TripForm` in edit mode pre-filled with all current trip values
- Success toast on save; page stays mounted with updated state
- Danger zone renders only for DRAFT, OPEN, and CONFIRMED trips; shows a confirmation dialog before calling `transitionTripStatus(id, { status: 'CANCELLED' })`

**New: `TripCoverEditor` component**
- Mirrors `GroupCoverEditor` — photo upload via crop → GCS → PATCH and emoji picker
- Handles `null` `coverUrl` with a placeholder icon
- Hides "Current cover" preview inside the dialog when `coverUrl` is null

**i18n**
- Added `cover.*` key group (label, tabs, success/error toasts, crop copy) to `trips.json` en + es
- Added `settings.*` key group (title, editSuccess, dangerZone, cancelTrip, cancel dialog copy) to `trips.json` en + es

## Testing

**`TripSettingsPage` — 16 tests**
- Renders form pre-filled with trip name
- Shows success toast and stays on page after edit
- Redirects PARTICIPANT, non-participant, and fetch-error cases to trip detail
- Allows CO_ORGANIZER access
- Danger zone visible for DRAFT / OPEN / CONFIRMED, hidden for IN_PROGRESS / CANCELLED / COMPLETED
- Cancel dialog opens, confirms with correct API call, shows error toast on failure

**`TripCoverEditor` — 16 tests**
- Renders cover image when set; renders placeholder when `coverUrl` is null
- Dialog opens with photo/emoji tabs
- Photo upload → crop confirm → PATCH with `gcs` source; error toast on upload or PATCH failure
- Crop modal hidden on cancel
- Emoji click → PATCH with `emoji` source; error toast on failure
- "Current cover" shown/hidden based on `coverUrl`

Closes #411