### PR TITLE
feat(trips): add participants admin view and global invitations

### DIFF
--- a/apps/api/src/modules/trips/invitations/trip-invitations.service.spec.ts
+++ b/apps/api/src/modules/trips/invitations/trip-invitations.service.spec.ts
@@ -269,7 +269,7 @@ describe('TripInvitationsService', () => {
   // ─── acceptInvitation ────────────────────────────────────────────────────────
 
   describe('acceptInvitation', () => {
-    it('transitions INVITED → ACCEPTED, sets confirmedAt, and notifies organizers', async () => {
+    it('transitions INVITED → ACCEPTED and notifies organizers', async () => {
       mockTripParticipantsFindMany.mockResolvedValueOnce([organizerParticipation]);
 
       await service.acceptInvitation(TRIP_ID, USER_ID);

--- a/apps/api/src/modules/trips/invitations/trip-invitations.service.ts
+++ b/apps/api/src/modules/trips/invitations/trip-invitations.service.ts
@@ -162,7 +162,6 @@ export class TripInvitationsService {
       .set({
         status: TripParticipantStatus.ACCEPTED,
         decidedBy: requestingUserId,
-        confirmedAt: now,
         updatedAt: now,
       })
       .where(

--- a/apps/api/src/modules/trips/join-requests/trip-join-requests.service.ts
+++ b/apps/api/src/modules/trips/join-requests/trip-join-requests.service.ts
@@ -105,7 +105,6 @@ export class TripJoinRequestsService {
       .set({
         status: TripParticipantStatus.ACCEPTED,
         decidedBy: organizerUserId,
-        confirmedAt: now,
         updatedAt: now,
       })
       .where(and(eq(tripParticipants.tripId, tripId), eq(tripParticipants.userId, targetUserId)));

--- a/apps/api/src/modules/trips/participants/dto/participant-response.dto.ts
+++ b/apps/api/src/modules/trips/participants/dto/participant-response.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 
-import { TripRole } from '@chamuco/shared-types';
+import { TripParticipantStatus, TripRole } from '@chamuco/shared-types';
 
 export class ParticipantResponseDto {
   @ApiProperty({ example: '550e8400-e29b-41d4-a716-446655440000' })
@@ -20,6 +20,12 @@ export class ParticipantResponseDto {
 
   @ApiProperty({ example: true })
   isTraveler!: boolean;
+
+  @ApiProperty({
+    enum: [TripParticipantStatus.ACCEPTED, TripParticipantStatus.CONFIRMED],
+    example: TripParticipantStatus.ACCEPTED,
+  })
+  status!: TripParticipantStatus.ACCEPTED | TripParticipantStatus.CONFIRMED;
 
   @ApiProperty({ example: '2026-01-01T00:00:00.000Z', nullable: true })
   confirmedAt!: string | null;

--- a/apps/api/src/modules/trips/participants/trip-participants.controller.spec.ts
+++ b/apps/api/src/modules/trips/participants/trip-participants.controller.spec.ts
@@ -43,7 +43,8 @@ const mockParticipant: ParticipantResponseDto = {
   avatarUrl: null,
   role: TripRole.PARTICIPANT,
   isTraveler: true,
-  confirmedAt: '2026-01-01T00:00:00.000Z',
+  status: TripParticipantStatus.ACCEPTED,
+  confirmedAt: null,
 };
 
 const mockPending: PendingParticipantResponseDto = {

--- a/apps/api/src/modules/trips/participants/trip-participants.controller.ts
+++ b/apps/api/src/modules/trips/participants/trip-participants.controller.ts
@@ -76,6 +76,28 @@ export class TripParticipantsController {
     return this.tripParticipantsService.removeParticipant(id, userId, user.id);
   }
 
+  @Patch(':id/participants/:userId/confirmation')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({
+    summary: 'Toggle participant confirmation',
+    description:
+      'Toggles a participant confirmation status between ACCEPTED and CONFIRMED. ' +
+      'Organizer and co-organizer only.',
+  })
+  @ApiParam({ name: 'id', type: String, description: 'Trip UUID' })
+  @ApiParam({ name: 'userId', type: String, description: 'User UUID of the target participant' })
+  @ApiResponse({ status: 204, description: 'Confirmation toggled.' })
+  @ApiUnauthorizedResponse({ description: 'Unauthenticated.' })
+  @ApiForbiddenResponse({ description: 'Caller is not a trip organizer or co-organizer.' })
+  @ApiNotFoundResponse({ description: 'Trip or active participant not found.' })
+  async toggleParticipantConfirmation(
+    @CurrentUser() user: AuthenticatedUser,
+    @Param('id', ParseUUIDPipe) id: string,
+    @Param('userId', ParseUUIDPipe) userId: string,
+  ): Promise<void> {
+    return this.tripParticipantsService.toggleParticipantConfirmation(id, userId, user.id);
+  }
+
   @Patch(':id/participants/:userId/role')
   @HttpCode(HttpStatus.NO_CONTENT)
   @ApiOperation({

--- a/apps/api/src/modules/trips/participants/trip-participants.service.spec.ts
+++ b/apps/api/src/modules/trips/participants/trip-participants.service.spec.ts
@@ -630,6 +630,60 @@ describe('TripParticipantsService', () => {
     });
   });
 
+  // ─── toggleParticipantConfirmation ───────────────────────────────────────────
+
+  describe('toggleParticipantConfirmation', () => {
+    it('toggles ACCEPTED → CONFIRMED', async () => {
+      const acceptedTarget = makeParticipation(TARGET_ID, TripParticipantStatus.ACCEPTED);
+      mockTripParticipantsFindFirst
+        .mockResolvedValueOnce(organizerParticipation) // assertTripOrganizer
+        .mockResolvedValueOnce(acceptedTarget); // target lookup
+
+      await service.toggleParticipantConfirmation(TRIP_ID, TARGET_ID, ORGANIZER_ID);
+
+      expect(mockUpdateSet).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: TripParticipantStatus.CONFIRMED,
+          confirmedAt: expect.any(Date),
+        }),
+      );
+    });
+
+    it('toggles CONFIRMED → ACCEPTED', async () => {
+      const confirmedTarget = makeParticipation(TARGET_ID, TripParticipantStatus.CONFIRMED);
+      mockTripParticipantsFindFirst
+        .mockResolvedValueOnce(organizerParticipation)
+        .mockResolvedValueOnce(confirmedTarget);
+
+      await service.toggleParticipantConfirmation(TRIP_ID, TARGET_ID, ORGANIZER_ID);
+
+      expect(mockUpdateSet).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: TripParticipantStatus.ACCEPTED,
+          confirmedAt: null,
+        }),
+      );
+    });
+
+    it('throws ForbiddenException when requester is not organizer', async () => {
+      mockTripParticipantsFindFirst.mockResolvedValueOnce(undefined);
+
+      await expect(
+        service.toggleParticipantConfirmation(TRIP_ID, TARGET_ID, USER_ID),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('throws NotFoundException when target is not an active participant', async () => {
+      mockTripParticipantsFindFirst
+        .mockResolvedValueOnce(organizerParticipation)
+        .mockResolvedValueOnce(undefined);
+
+      await expect(
+        service.toggleParticipantConfirmation(TRIP_ID, TARGET_ID, ORGANIZER_ID),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
   // ─── notification error tolerance ────────────────────────────────────────────
 
   describe('notification error tolerance', () => {

--- a/apps/api/src/modules/trips/participants/trip-participants.service.spec.ts
+++ b/apps/api/src/modules/trips/participants/trip-participants.service.spec.ts
@@ -682,6 +682,21 @@ describe('TripParticipantsService', () => {
         service.toggleParticipantConfirmation(TRIP_ID, TARGET_ID, ORGANIZER_ID),
       ).rejects.toThrow(NotFoundException);
     });
+
+    it('throws ForbiddenException when target is the ORGANIZER role', async () => {
+      const organizerTarget = makeParticipation(
+        TARGET_ID,
+        TripParticipantStatus.CONFIRMED,
+        TripRole.ORGANIZER,
+      );
+      mockTripParticipantsFindFirst
+        .mockResolvedValueOnce(organizerParticipation)
+        .mockResolvedValueOnce(organizerTarget);
+
+      await expect(
+        service.toggleParticipantConfirmation(TRIP_ID, TARGET_ID, ORGANIZER_ID),
+      ).rejects.toThrow(ForbiddenException);
+    });
   });
 
   // ─── notification error tolerance ────────────────────────────────────────────

--- a/apps/api/src/modules/trips/participants/trip-participants.service.ts
+++ b/apps/api/src/modules/trips/participants/trip-participants.service.ts
@@ -208,6 +208,35 @@ export class TripParticipantsService {
       });
   }
 
+  // ─── Confirmation toggle ──────────────────────────────────────────────────────
+
+  async toggleParticipantConfirmation(
+    tripId: string,
+    targetUserId: string,
+    requestingUserId: string,
+  ): Promise<void> {
+    await this.assertTripOrganizer(tripId, requestingUserId);
+
+    const targetParticipation = await this.db.query.tripParticipants.findFirst({
+      where: and(
+        eq(tripParticipants.tripId, tripId),
+        eq(tripParticipants.userId, targetUserId),
+        inArray(tripParticipants.status, [...ACTIVE_STATUSES]),
+      ),
+    });
+    if (!targetParticipation) throw new NotFoundException('Active participant not found');
+
+    const isConfirmed = targetParticipation.status === TripParticipantStatus.CONFIRMED;
+    await this.db
+      .update(tripParticipants)
+      .set({
+        status: isConfirmed ? TripParticipantStatus.ACCEPTED : TripParticipantStatus.CONFIRMED,
+        confirmedAt: isConfirmed ? null : new Date(),
+        updatedAt: new Date(),
+      })
+      .where(and(eq(tripParticipants.tripId, tripId), eq(tripParticipants.userId, targetUserId)));
+  }
+
   // ─── My participation ─────────────────────────────────────────────────────────
 
   async getMyParticipation(tripId: string, userId: string): Promise<MyParticipationResponseDto> {
@@ -300,6 +329,9 @@ export class TripParticipantsService {
         avatarUrl: avatarUrlMap.get(user.id) ?? null,
         role: participation.role as TripRole,
         isTraveler: participation.isTraveler,
+        status: participation.status as
+          | TripParticipantStatus.ACCEPTED
+          | TripParticipantStatus.CONFIRMED,
         confirmedAt: participation.confirmedAt?.toISOString() ?? null,
       };
     });

--- a/apps/api/src/modules/trips/participants/trip-participants.service.ts
+++ b/apps/api/src/modules/trips/participants/trip-participants.service.ts
@@ -225,14 +225,17 @@ export class TripParticipantsService {
       ),
     });
     if (!targetParticipation) throw new NotFoundException('Active participant not found');
+    if (targetParticipation.role === TripRole.ORGANIZER)
+      throw new ForbiddenException('Cannot toggle confirmation for the trip organizer');
 
+    const now = new Date();
     const isConfirmed = targetParticipation.status === TripParticipantStatus.CONFIRMED;
     await this.db
       .update(tripParticipants)
       .set({
         status: isConfirmed ? TripParticipantStatus.ACCEPTED : TripParticipantStatus.CONFIRMED,
-        confirmedAt: isConfirmed ? null : new Date(),
-        updatedAt: new Date(),
+        confirmedAt: isConfirmed ? null : now,
+        updatedAt: now,
       })
       .where(and(eq(tripParticipants.tripId, tripId), eq(tripParticipants.userId, targetUserId)));
   }

--- a/apps/api/src/modules/trips/trips.module.ts
+++ b/apps/api/src/modules/trips/trips.module.ts
@@ -18,11 +18,14 @@ import { TripJoinRequestsService } from './join-requests/trip-join-requests.serv
 @Module({
   imports: [NotificationsModule],
   controllers: [
+    // TripParticipantsController must come before TripsController so that
+    // GET /v1/trips/invitations (static) registers before GET /v1/trips/:id (param)
+    // and NestJS resolves the static route first.
+    TripParticipantsController,
     TripsController,
     TripsDestinationsController,
     TripsGroupsController,
     TripAnnouncementsController,
-    TripParticipantsController,
     TripInvitationsController,
     TripJoinRequestsController,
   ],

--- a/apps/web/src/app/trips/[id]/page.test.tsx
+++ b/apps/web/src/app/trips/[id]/page.test.tsx
@@ -300,7 +300,7 @@ describe('TripDetailPage', () => {
     render(<TripDetailPage params={Promise.resolve({ id: 'trip-id' })} />);
 
     await waitFor(() => {
-      const link = screen.getByRole('link', { name: 'participants' });
+      const link = screen.getByRole('link', { name: 'participants.title' });
       expect(link).toBeInTheDocument();
       expect(link).toHaveAttribute('href', '/trips/trip-id/participants');
     });
@@ -311,7 +311,7 @@ describe('TripDetailPage', () => {
     render(<TripDetailPage params={Promise.resolve({ id: 'trip-id' })} />);
 
     await waitFor(() => {
-      expect(screen.getByRole('link', { name: 'participants' })).toBeInTheDocument();
+      expect(screen.getByRole('link', { name: 'participants.title' })).toBeInTheDocument();
     });
   });
 

--- a/apps/web/src/app/trips/[id]/page.tsx
+++ b/apps/web/src/app/trips/[id]/page.tsx
@@ -84,8 +84,8 @@ export default function TripDetailPage({ params }: TripDetailPageProps) {
           <Link
             href={`/trips/${trip.id}/participants`}
             className="inline-flex items-center justify-center rounded-lg border border-border bg-background p-2 transition-colors hover:bg-muted"
-            title={t('participants')}
-            aria-label={t('participants')}
+            title={t('participants.title')}
+            aria-label={t('participants.title')}
           >
             <UsersThreeIcon className="size-5" aria-hidden="true" />
           </Link>

--- a/apps/web/src/app/trips/[id]/participants/page.tsx
+++ b/apps/web/src/app/trips/[id]/participants/page.tsx
@@ -1,0 +1,168 @@
+'use client';
+
+import { useEffect, useState, use } from 'react';
+import Link from 'next/link';
+import { useTranslation } from 'react-i18next';
+import { TripParticipantStatus, TripRole, TripVisibility } from '@chamuco/shared-types';
+import { ArrowLeftIcon } from '@phosphor-icons/react';
+import {
+  getTrip,
+  getTripParticipants,
+  getTripParticipation,
+  getPendingTripParticipants,
+} from '@/services/trips.service';
+import { useAuth } from '@/hooks/useAuth';
+import { useUser } from '@/hooks/useUser';
+import { ParticipantList } from '@/components/trips/participants/ParticipantList';
+import { PendingParticipantsPanel } from '@/components/trips/participants/PendingParticipantsPanel';
+import { TripInvitationResponseButtons } from '@/components/trips/participants/TripInvitationResponseButtons';
+import { JoinTripButton } from '@/components/trips/participants/JoinTripButton';
+import { LeaveTripButton } from '@/components/trips/participants/LeaveTripButton';
+import type {
+  TripResponse,
+  TripParticipantResponse,
+  PendingTripParticipantResponse,
+  MyTripParticipationResponse,
+} from '@/services/trips.types';
+
+interface ParticipantsPageProps {
+  params: Promise<{ id: string }>;
+}
+
+type PageState = 'loading' | 'not-found' | 'not-participant' | 'ready';
+
+const ORGANIZER_ROLES: TripRole[] = [TripRole.ORGANIZER, TripRole.CO_ORGANIZER];
+
+export default function TripParticipantsPage({ params }: ParticipantsPageProps) {
+  const { id } = use(params);
+  const { t } = useTranslation('trips');
+  const { isLoading: isAuthLoading } = useAuth();
+  const { appUser, isLoading: isUserLoading } = useUser();
+
+  const [pageState, setPageState] = useState<PageState>('loading');
+  const [trip, setTrip] = useState<TripResponse | null>(null);
+  const [participants, setParticipants] = useState<TripParticipantResponse[]>([]);
+  const [pending, setPending] = useState<PendingTripParticipantResponse[]>([]);
+  const [participation, setParticipation] = useState<MyTripParticipationResponse | null>(null);
+
+  const callerRole = participation?.role ?? null;
+  const isOrganizer = callerRole !== null && ORGANIZER_ROLES.includes(callerRole);
+
+  const loadData = async () => {
+    try {
+      const [tripData, participationData, participantsData] = await Promise.all([
+        getTrip(id),
+        getTripParticipation(id).catch(() => null),
+        getTripParticipants(id).catch(() => null),
+      ]);
+
+      setTrip(tripData);
+      setParticipation(participationData);
+
+      if (!participantsData) {
+        setPageState('not-participant');
+        return;
+      }
+
+      setParticipants(participantsData);
+
+      const me = appUser ? participantsData.find((p) => p.userId === appUser.id) : undefined;
+      const meRole = me?.role ?? null;
+
+      if (meRole && ORGANIZER_ROLES.includes(meRole)) {
+        const pendingData = await getPendingTripParticipants(id).catch(() => null);
+        if (pendingData) setPending(pendingData);
+      }
+
+      setPageState('ready');
+    } catch {
+      setPageState('not-found');
+    }
+  };
+
+  useEffect(() => {
+    if (isAuthLoading || isUserLoading) return;
+    void loadData();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [id, isAuthLoading, isUserLoading]);
+
+  if (pageState === 'loading') return null;
+
+  if (pageState === 'not-found' || !trip) {
+    return (
+      <div className="p-8">
+        <p className="text-muted-foreground">{t('errors.notFound')}</p>
+      </div>
+    );
+  }
+
+  const isActiveParticipant = pageState === 'ready' && callerRole !== null;
+  const pendingStatus = participation?.status ?? null;
+  const isInvited = pendingStatus === TripParticipantStatus.INVITED;
+  const hasPendingRequest = pendingStatus === TripParticipantStatus.PENDING_REQUEST;
+  const canRequestJoin =
+    !isInvited && !hasPendingRequest && trip.visibility === TripVisibility.PUBLIC;
+
+  const excludedIds = [...participants.map((p) => p.userId), ...pending.map((p) => p.userId)];
+
+  return (
+    <div className="p-8 max-w-2xl space-y-6">
+      <div className="flex items-center gap-3">
+        <Link
+          href={`/trips/${id}`}
+          className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors"
+        >
+          <ArrowLeftIcon className="size-4" />
+          {trip.name}
+        </Link>
+      </div>
+
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">{t('participants.title')}</h1>
+
+        {pageState === 'not-participant' && isInvited && (
+          <TripInvitationResponseButtons tripId={id} onSuccess={() => void loadData()} />
+        )}
+
+        {pageState === 'not-participant' && (hasPendingRequest || canRequestJoin) && (
+          <JoinTripButton
+            tripId={id}
+            hasPendingRequest={hasPendingRequest}
+            onSuccess={() => void loadData()}
+          />
+        )}
+
+        {isActiveParticipant && !isOrganizer && appUser && (
+          <LeaveTripButton tripId={id} userId={appUser.id} />
+        )}
+      </div>
+
+      {pageState === 'not-participant' && (
+        <p className="text-sm text-muted-foreground">{t('errors.forbidden')}</p>
+      )}
+
+      {pageState === 'ready' && (
+        <>
+          {isOrganizer && pending.length > 0 && (
+            <PendingParticipantsPanel
+              tripId={id}
+              items={pending}
+              onUpdate={() => void loadData()}
+            />
+          )}
+
+          <ParticipantList
+            tripId={id}
+            participants={participants}
+            capacity={trip.participantCapacity}
+            currentUserId={appUser?.id ?? null}
+            callerRole={callerRole}
+            onInviteSuccess={() => void loadData()}
+            onParticipantAction={() => void loadData()}
+            excludedIds={excludedIds}
+          />
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/trips/page.test.tsx
+++ b/apps/web/src/app/trips/page.test.tsx
@@ -38,6 +38,10 @@ vi.mock('@/components/trips/TripCard', () => ({
   ),
 }));
 
+vi.mock('@/components/trips/TripInvitationsSection', () => ({
+  TripInvitationsSection: () => null,
+}));
+
 import { getMyTrips } from '@/services/trips.service';
 import TripsPage from './page';
 

--- a/apps/web/src/app/trips/page.tsx
+++ b/apps/web/src/app/trips/page.tsx
@@ -9,6 +9,7 @@ import { TripStatus } from '@chamuco/shared-types';
 import { getMyTrips } from '@/services/trips.service';
 import { useAuth } from '@/hooks/useAuth';
 import { TripCard } from '@/components/trips/TripCard';
+import { TripInvitationsSection } from '@/components/trips/TripInvitationsSection';
 import type { MyTripListItemResponse } from '@/services/trips.types';
 
 type Tab = 'upcoming' | 'past';
@@ -27,12 +28,17 @@ export default function TripsPage() {
   const [isLoading, setIsLoading] = useState(true);
   const [activeTab, setActiveTab] = useState<Tab>('upcoming');
 
-  useEffect(() => {
-    if (isAuthLoading) return;
+  function fetchTrips() {
+    setIsLoading(true);
     getMyTrips()
       .then((data) => setTrips(data))
       .catch(() => setTrips([]))
       .finally(() => setIsLoading(false));
+  }
+
+  useEffect(() => {
+    if (isAuthLoading) return;
+    fetchTrips();
   }, [isAuthLoading]);
 
   const tabs: { key: Tab; label: string }[] = [
@@ -69,6 +75,8 @@ export default function TripsPage() {
           </Link>
         </div>
       </div>
+
+      <TripInvitationsSection onSuccess={fetchTrips} />
 
       <div
         role="tablist"

--- a/apps/web/src/components/groups/members/MemberListItem.tsx
+++ b/apps/web/src/components/groups/members/MemberListItem.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { GroupMemberTier, GroupRole } from '@chamuco/shared-types';
 import { ShieldStarIcon, UserMinusIcon } from '@phosphor-icons/react';
+import { getInitials } from '@/lib/name-utils';
 import { Avatar } from '@/components/ui/avatar';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -46,13 +47,6 @@ export function MemberListItem({
   const [isRemoving, setIsRemoving] = useState(false);
   const [isPromoting, setIsPromoting] = useState(false);
   const [isDemoting, setIsDemoting] = useState(false);
-
-  const initials = member.displayName
-    .split(' ')
-    .map((n) => n[0])
-    .join('')
-    .slice(0, 2)
-    .toUpperCase();
 
   const isAdmin = currentUserRole !== null && ADMIN_ROLES.includes(currentUserRole);
   const isSelf = member.userId === currentUserId;
@@ -106,7 +100,7 @@ export function MemberListItem({
       <Avatar
         src={member.avatarUrl ?? undefined}
         alt={member.displayName}
-        fallback={initials}
+        fallback={getInitials(member.displayName)}
         size="md"
         className="mt-0.5 sm:mt-0"
       />

--- a/apps/web/src/components/groups/members/PendingRequestsPanel.tsx
+++ b/apps/web/src/components/groups/members/PendingRequestsPanel.tsx
@@ -2,6 +2,7 @@
 
 import { useTranslation } from 'react-i18next';
 import { GroupMemberStatus } from '@chamuco/shared-types';
+import { getInitials } from '@/lib/name-utils';
 import { Avatar } from '@/components/ui/avatar';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -53,19 +54,12 @@ export function PendingRequestsPanel({ groupId, items, onUpdate }: PendingReques
 
       <ul className="divide-y divide-border">
         {items.map((item) => {
-          const initials = item.displayName
-            .split(' ')
-            .map((n) => n[0])
-            .join('')
-            .slice(0, 2)
-            .toUpperCase();
-
           return (
             <li key={item.userId} className="flex items-center gap-3 py-3">
               <Avatar
                 src={item.avatarUrl ?? undefined}
                 alt={item.displayName}
-                fallback={initials}
+                fallback={getInitials(item.displayName)}
                 size="sm"
               />
 

--- a/apps/web/src/components/header/NotificationPanel.test.tsx
+++ b/apps/web/src/components/header/NotificationPanel.test.tsx
@@ -133,16 +133,41 @@ describe('NotificationPanel', () => {
 
     it('navigates to url on row click when url is present', async () => {
       const user = userEvent.setup();
-      const notif = makeNotification({ url: '/groups/g1' });
+      const notif = makeNotification({
+        type: NotificationType.GROUP_INVITATION,
+        url: '/groups/g1',
+      });
       renderPanel([notif]);
 
       await user.click(screen.getByText(notif.title));
       expect(mocks.mockRouterPush).toHaveBeenCalledWith('/groups/g1');
     });
 
-    it('does not navigate when url is null', async () => {
+    it('navigates to /trips for TRIP_INVITATION regardless of notif.url', async () => {
       const user = userEvent.setup();
-      const notif = makeNotification({ url: null });
+      const notif = makeNotification({
+        type: NotificationType.TRIP_INVITATION,
+        url: '/trips/trip-1',
+      });
+      renderPanel([notif]);
+
+      await user.click(screen.getByText(notif.title));
+      expect(mocks.mockRouterPush).toHaveBeenCalledWith('/trips');
+      expect(mocks.mockRouterPush).not.toHaveBeenCalledWith('/trips/trip-1');
+    });
+
+    it('navigates to /trips for TRIP_INVITATION even when url is null', async () => {
+      const user = userEvent.setup();
+      const notif = makeNotification({ type: NotificationType.TRIP_INVITATION, url: null });
+      renderPanel([notif]);
+
+      await user.click(screen.getByText(notif.title));
+      expect(mocks.mockRouterPush).toHaveBeenCalledWith('/trips');
+    });
+
+    it('does not navigate when url is null for non-TRIP_INVITATION', async () => {
+      const user = userEvent.setup();
+      const notif = makeNotification({ type: NotificationType.GROUP_INVITATION, url: null });
       renderPanel([notif]);
 
       await user.click(screen.getByText(notif.title));

--- a/apps/web/src/components/header/NotificationPanel.tsx
+++ b/apps/web/src/components/header/NotificationPanel.tsx
@@ -71,7 +71,9 @@ export function NotificationPanel({
 
   function handleItemClick(notif: NotificationItem) {
     onMarkRead(notif.id);
-    if (notif.url) {
+    if (notif.type === NotificationType.TRIP_INVITATION) {
+      router.push('/trips');
+    } else if (notif.url) {
       router.push(notif.url);
     }
   }

--- a/apps/web/src/components/layout/AppShell.test.tsx
+++ b/apps/web/src/components/layout/AppShell.test.tsx
@@ -33,6 +33,16 @@ vi.mock('@/store/group-invitations', () => ({
   })),
 }));
 
+vi.mock('@/store/trip-invitations', () => ({
+  TripInvitationsProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+  useTripInvitations: vi.fn(() => ({
+    invitations: [],
+    count: 0,
+    isLoading: false,
+    refresh: vi.fn(),
+  })),
+}));
+
 describe('AppShell', () => {
   describe('standard layout (non-auth pages)', () => {
     it('renders Header component', () => {

--- a/apps/web/src/components/layout/AppShell.tsx
+++ b/apps/web/src/components/layout/AppShell.tsx
@@ -6,6 +6,7 @@ import { Header } from '@/components/header';
 import { MobileBottomNav, DesktopSideNav } from '@/components/navigation';
 import { FeedbackButton } from '@/components/feedback/FeedbackButton';
 import { GroupInvitationsProvider } from '@/store/group-invitations';
+import { TripInvitationsProvider } from '@/store/trip-invitations';
 // TODO: re-enable once notifications/banners are fully designed
 // import { ProfileCompletionBanner } from '@/components/ProfileCompletionBanner';
 
@@ -31,14 +32,16 @@ export function AppShell({ children }: AppShellProps) {
 
   return (
     <GroupInvitationsProvider>
-      <Header />
-      <DesktopSideNav />
-      <MobileBottomNav />
-      {/* <div className="md:pl-sidebar"><ProfileCompletionBanner /></div> */}
-      <main className="relative pt-header-safe pb-nav-safe md:pb-0 md:pl-sidebar md:transition-[padding-left] md:duration-200 md:ease-in-out min-h-screen">
-        {children}
-      </main>
-      <FeedbackButton />
+      <TripInvitationsProvider>
+        <Header />
+        <DesktopSideNav />
+        <MobileBottomNav />
+        {/* <div className="md:pl-sidebar"><ProfileCompletionBanner /></div> */}
+        <main className="relative pt-header-safe pb-nav-safe md:pb-0 md:pl-sidebar md:transition-[padding-left] md:duration-200 md:ease-in-out min-h-screen">
+          {children}
+        </main>
+        <FeedbackButton />
+      </TripInvitationsProvider>
     </GroupInvitationsProvider>
   );
 }

--- a/apps/web/src/components/trips/TripInvitationsSection.test.tsx
+++ b/apps/web/src/components/trips/TripInvitationsSection.test.tsx
@@ -1,0 +1,192 @@
+import { render, screen } from '@testing-library/react';
+import type { MyTripInvitationResponse } from '@/services/trips.types';
+
+const mocks = vi.hoisted(() => ({
+  mockUseTripInvitations: vi.fn(),
+  mockOnSuccess: vi.fn(),
+}));
+
+vi.mock('@/store/trip-invitations', () => ({
+  useTripInvitations: mocks.mockUseTripInvitations,
+}));
+
+vi.mock('@/components/trips/participants/TripInvitationResponseButtons', () => ({
+  TripInvitationResponseButtons: ({
+    tripId,
+    onSuccess,
+  }: {
+    tripId: string;
+    onSuccess: () => void;
+    showMessage?: boolean;
+  }) => (
+    <div data-testid={`invite-buttons-${tripId}`}>
+      <button onClick={onSuccess}>accept</button>
+      <button>decline</button>
+    </div>
+  ),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (_ns?: string) => ({
+    t: (key: string, opts?: Record<string, unknown>) => {
+      if (opts) {
+        return Object.entries(opts).reduce(
+          (acc, [k, v]) => acc.replace(`{{${k}}}`, String(v)),
+          key,
+        );
+      }
+      return key;
+    },
+    i18n: { language: 'en' },
+  }),
+}));
+
+import { TripInvitationsSection } from './TripInvitationsSection';
+
+const mockInvitation: MyTripInvitationResponse = {
+  trip: {
+    id: 'trip-1',
+    name: 'Cancún 2026',
+    coverUrl: 'https://cdn.example.com/cover.jpg',
+  },
+  initiatedAt: '2026-01-15T00:00:00.000Z',
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('TripInvitationsSection', () => {
+  it('renders nothing when count is 0', () => {
+    mocks.mockUseTripInvitations.mockReturnValue({
+      invitations: [],
+      count: 0,
+      isLoading: false,
+      refresh: vi.fn(),
+    });
+
+    const { container } = render(<TripInvitationsSection />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders section when there are invitations', () => {
+    mocks.mockUseTripInvitations.mockReturnValue({
+      invitations: [mockInvitation],
+      count: 1,
+      isLoading: false,
+      refresh: vi.fn(),
+    });
+
+    render(<TripInvitationsSection />);
+    expect(screen.getByRole('region')).toBeInTheDocument();
+  });
+
+  it('renders heading with count', () => {
+    mocks.mockUseTripInvitations.mockReturnValue({
+      invitations: [mockInvitation],
+      count: 1,
+      isLoading: false,
+      refresh: vi.fn(),
+    });
+
+    render(<TripInvitationsSection />);
+    expect(screen.getByText('invitations.titleWithCount', { exact: false })).toBeInTheDocument();
+  });
+
+  it('renders trip name for each invitation', () => {
+    mocks.mockUseTripInvitations.mockReturnValue({
+      invitations: [mockInvitation],
+      count: 1,
+      isLoading: false,
+      refresh: vi.fn(),
+    });
+
+    render(<TripInvitationsSection />);
+    expect(screen.getByText('Cancún 2026')).toBeInTheDocument();
+  });
+
+  it('renders accept/decline buttons for each invitation', () => {
+    mocks.mockUseTripInvitations.mockReturnValue({
+      invitations: [mockInvitation],
+      count: 1,
+      isLoading: false,
+      refresh: vi.fn(),
+    });
+
+    render(<TripInvitationsSection />);
+    expect(screen.getByTestId('invite-buttons-trip-1')).toBeInTheDocument();
+  });
+
+  it('renders cover image when coverUrl is set', () => {
+    mocks.mockUseTripInvitations.mockReturnValue({
+      invitations: [mockInvitation],
+      count: 1,
+      isLoading: false,
+      refresh: vi.fn(),
+    });
+
+    const { container } = render(<TripInvitationsSection />);
+    const img = container.querySelector('img');
+    expect(img).toBeInTheDocument();
+    expect(img).toHaveAttribute('src', 'https://cdn.example.com/cover.jpg');
+  });
+
+  it('renders multiple invitations', () => {
+    const second: MyTripInvitationResponse = {
+      trip: { id: 'trip-2', name: 'Bacalar Trip', coverUrl: null },
+      initiatedAt: '2026-02-01T00:00:00.000Z',
+    };
+    mocks.mockUseTripInvitations.mockReturnValue({
+      invitations: [mockInvitation, second],
+      count: 2,
+      isLoading: false,
+      refresh: vi.fn(),
+    });
+
+    render(<TripInvitationsSection />);
+    expect(screen.getByText('Cancún 2026')).toBeInTheDocument();
+    expect(screen.getByText('Bacalar Trip')).toBeInTheDocument();
+  });
+
+  it('calls store refresh on button action', () => {
+    const refresh = vi.fn();
+    mocks.mockUseTripInvitations.mockReturnValue({
+      invitations: [mockInvitation],
+      count: 1,
+      isLoading: false,
+      refresh,
+    });
+
+    render(<TripInvitationsSection />);
+    screen.getByText('accept').click();
+    expect(refresh).toHaveBeenCalledOnce();
+  });
+
+  it('calls onSuccess prop on button action', () => {
+    const onSuccess = vi.fn();
+    mocks.mockUseTripInvitations.mockReturnValue({
+      invitations: [mockInvitation],
+      count: 1,
+      isLoading: false,
+      refresh: vi.fn(),
+    });
+
+    render(<TripInvitationsSection onSuccess={onSuccess} />);
+    screen.getByText('accept').click();
+    expect(onSuccess).toHaveBeenCalledOnce();
+  });
+
+  it('does not throw when onSuccess is not provided', () => {
+    mocks.mockUseTripInvitations.mockReturnValue({
+      invitations: [mockInvitation],
+      count: 1,
+      isLoading: false,
+      refresh: vi.fn(),
+    });
+
+    expect(() => {
+      render(<TripInvitationsSection />);
+      screen.getByText('accept').click();
+    }).not.toThrow();
+  });
+});

--- a/apps/web/src/components/trips/TripInvitationsSection.tsx
+++ b/apps/web/src/components/trips/TripInvitationsSection.tsx
@@ -9,7 +9,7 @@ interface TripInvitationsSectionProps {
 }
 
 export function TripInvitationsSection({ onSuccess }: TripInvitationsSectionProps) {
-  const { t } = useTranslation('trips');
+  const { t, i18n } = useTranslation('trips');
   const { invitations, count, refresh } = useTripInvitations();
 
   function handleSuccess() {
@@ -44,7 +44,7 @@ export function TripInvitationsSection({ onSuccess }: TripInvitationsSectionProp
             <div className="min-w-50 flex-1">
               <p className="truncate font-semibold text-sm">{trip.name}</p>
               <p className="text-xs text-muted-foreground">
-                {new Date(initiatedAt).toLocaleDateString(undefined, {
+                {new Date(initiatedAt).toLocaleDateString(i18n.language, {
                   month: 'short',
                   day: 'numeric',
                 })}

--- a/apps/web/src/components/trips/TripInvitationsSection.tsx
+++ b/apps/web/src/components/trips/TripInvitationsSection.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import { useTranslation } from 'react-i18next';
+import { useTripInvitations } from '@/store/trip-invitations';
+import { TripInvitationResponseButtons } from '@/components/trips/participants/TripInvitationResponseButtons';
+
+interface TripInvitationsSectionProps {
+  onSuccess?: () => void;
+}
+
+export function TripInvitationsSection({ onSuccess }: TripInvitationsSectionProps) {
+  const { t } = useTranslation('trips');
+  const { invitations, count, refresh } = useTripInvitations();
+
+  function handleSuccess() {
+    void refresh();
+    onSuccess?.();
+  }
+
+  if (count === 0) return null;
+
+  return (
+    <section
+      aria-labelledby="trip-invitations-heading"
+      className="mb-8 pb-8 border-b border-border"
+    >
+      <h2
+        id="trip-invitations-heading"
+        className="mb-3 text-sm font-semibold uppercase tracking-wide text-orange-500"
+      >
+        {t('invitations.titleWithCount', { count })}
+      </h2>
+      <div className="flex flex-col gap-3">
+        {invitations.map(({ trip, initiatedAt }) => (
+          <div
+            key={trip.id}
+            className="flex flex-wrap items-center gap-3 rounded-xl border border-orange-200 bg-orange-50/50 p-4 dark:border-orange-900/40 dark:bg-orange-950/20"
+          >
+            <div className="size-10 shrink-0 overflow-hidden rounded-lg bg-muted flex items-center justify-center">
+              {trip.coverUrl && (
+                <img src={trip.coverUrl} alt="" className="size-full object-cover" />
+              )}
+            </div>
+            <div className="min-w-50 flex-1">
+              <p className="truncate font-semibold text-sm">{trip.name}</p>
+              <p className="text-xs text-muted-foreground">
+                {new Date(initiatedAt).toLocaleDateString(undefined, {
+                  month: 'short',
+                  day: 'numeric',
+                })}
+              </p>
+            </div>
+            <div className="ml-auto shrink-0">
+              <TripInvitationResponseButtons
+                tripId={trip.id}
+                onSuccess={handleSuccess}
+                showMessage={false}
+              />
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/trips/participants/InviteParticipantModal.test.tsx
+++ b/apps/web/src/components/trips/participants/InviteParticipantModal.test.tsx
@@ -1,0 +1,233 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { InvitationResult } from '@chamuco/shared-types';
+import type { UserSearchResult } from '@/types/user';
+
+const mocks = vi.hoisted(() => ({
+  mockInvite: vi.fn(),
+  mockOnSuccess: vi.fn(),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('@/services/trips.service', () => ({
+  inviteTripParticipants: mocks.mockInvite,
+}));
+
+vi.mock('@/components/ui/user-autocomplete', () => ({
+  UserAutocomplete: ({
+    onSelect,
+    placeholder,
+  }: {
+    onSelect: (user: UserSearchResult) => void;
+    placeholder: string;
+    value: string;
+    onChange: (v: string) => void;
+  }) => (
+    <div>
+      <input placeholder={placeholder} readOnly />
+      <button
+        type="button"
+        onClick={() =>
+          onSelect({ id: 'user-1', username: 'janedoe', displayName: 'Jane Doe', avatar: null })
+        }
+      >
+        select-user
+      </button>
+    </div>
+  ),
+}));
+
+import { InviteParticipantModal } from './InviteParticipantModal';
+
+const TRIP_ID = 'trip-1';
+
+function setup(excludedIds?: string[]) {
+  const user = userEvent.setup();
+  render(
+    <InviteParticipantModal
+      tripId={TRIP_ID}
+      onSuccess={mocks.mockOnSuccess}
+      excludedIds={excludedIds}
+    />,
+  );
+  return { user };
+}
+
+async function openDialog(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(screen.getByText('participants.invite.button'));
+}
+
+async function selectUser(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(screen.getByText('select-user'));
+}
+
+function makeResults(statuses: InvitationResult['status'][]): { results: InvitationResult[] } {
+  return {
+    results: statuses.map((status, i) => ({ username: `user${i}`, status })),
+  };
+}
+
+describe('InviteParticipantModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.mockInvite.mockResolvedValue(makeResults([]));
+  });
+
+  describe('trigger and dialog open/close', () => {
+    it('renders trigger button', () => {
+      setup();
+      expect(screen.getByText('participants.invite.button')).toBeInTheDocument();
+    });
+
+    it('dialog not visible initially', () => {
+      setup();
+      expect(screen.queryByText('participants.invite.title')).not.toBeInTheDocument();
+    });
+
+    it('opens dialog on trigger click', async () => {
+      const { user } = setup();
+      await openDialog(user);
+      expect(
+        screen.getByRole('heading', { name: 'participants.invite.title' }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('user selection', () => {
+    it('submit button disabled when no users selected', async () => {
+      const { user } = setup();
+      await openDialog(user);
+      expect(screen.getByRole('button', { name: 'participants.invite.submit' })).toBeDisabled();
+    });
+
+    it('shows chip after selecting user', async () => {
+      const { user } = setup();
+      await openDialog(user);
+      await selectUser(user);
+      expect(screen.getByText('@janedoe')).toBeInTheDocument();
+    });
+
+    it('submit enabled after selecting user', async () => {
+      const { user } = setup();
+      await openDialog(user);
+      await selectUser(user);
+      expect(screen.getByRole('button', { name: 'participants.invite.submit' })).not.toBeDisabled();
+    });
+
+    it('removes chip when × button clicked', async () => {
+      const { user } = setup();
+      await openDialog(user);
+      await selectUser(user);
+
+      await user.click(screen.getByRole('button', { name: 'participants.invite.removeUser' }));
+
+      expect(screen.queryByText('@janedoe')).not.toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'participants.invite.submit' })).toBeDisabled();
+    });
+
+    it('shows alreadyExcluded error when selecting excluded user', async () => {
+      const { user } = setup(['user-1']);
+      await openDialog(user);
+      await selectUser(user);
+
+      expect(screen.getByText('participants.invite.alreadyExcluded')).toBeInTheDocument();
+      expect(screen.queryByText('@janedoe')).not.toBeInTheDocument();
+    });
+
+    it('does not add duplicate user if selected twice', async () => {
+      const { user } = setup();
+      await openDialog(user);
+      await selectUser(user);
+      await selectUser(user);
+
+      expect(screen.getAllByText('@janedoe')).toHaveLength(1);
+    });
+  });
+
+  describe('submission', () => {
+    it('calls inviteTripParticipants with correct payload', async () => {
+      const { user } = setup();
+      await openDialog(user);
+      await selectUser(user);
+      await user.click(screen.getByRole('button', { name: 'participants.invite.submit' }));
+
+      await waitFor(() => {
+        expect(mocks.mockInvite).toHaveBeenCalledWith(TRIP_ID, { usernames: ['janedoe'] });
+      });
+    });
+
+    it('shows sending label while in flight', async () => {
+      let resolve!: (val: unknown) => void;
+      mocks.mockInvite.mockReturnValue(new Promise((r) => (resolve = r)));
+
+      const { user } = setup();
+      await openDialog(user);
+      await selectUser(user);
+      await user.click(screen.getByRole('button', { name: 'participants.invite.submit' }));
+
+      expect(screen.getByRole('button', { name: 'participants.invite.sending' })).toBeDisabled();
+      resolve(makeResults([]));
+    });
+
+    it('shows results view after successful submission', async () => {
+      mocks.mockInvite.mockResolvedValue(makeResults(['INVITED', 'ALREADY_MEMBER']));
+      const { user } = setup();
+      await openDialog(user);
+      await selectUser(user);
+      await user.click(screen.getByRole('button', { name: 'participants.invite.submit' }));
+
+      await waitFor(() => {
+        expect(screen.getByText('participants.invite.results.title')).toBeInTheDocument();
+        expect(screen.getByText('participants.invite.result.INVITED')).toBeInTheDocument();
+        expect(screen.getByText('participants.invite.result.ALREADY_MEMBER')).toBeInTheDocument();
+      });
+    });
+
+    it('shows error message on submission failure', async () => {
+      mocks.mockInvite.mockRejectedValueOnce(new Error('fail'));
+      const { user } = setup();
+      await openDialog(user);
+      await selectUser(user);
+      await user.click(screen.getByRole('button', { name: 'participants.invite.submit' }));
+
+      await waitFor(() => {
+        expect(screen.getByText('participants.invite.error')).toBeInTheDocument();
+      });
+      expect(mocks.mockOnSuccess).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('done / close', () => {
+    it('calls onSuccess and closes when Done clicked after INVITED result', async () => {
+      mocks.mockInvite.mockResolvedValue(makeResults(['INVITED']));
+      const { user } = setup();
+      await openDialog(user);
+      await selectUser(user);
+      await user.click(screen.getByRole('button', { name: 'participants.invite.submit' }));
+
+      await waitFor(() => screen.getByRole('button', { name: 'participants.invite.done' }));
+      await user.click(screen.getByRole('button', { name: 'participants.invite.done' }));
+
+      await waitFor(() => {
+        expect(mocks.mockOnSuccess).toHaveBeenCalledOnce();
+        expect(screen.queryByText('participants.invite.title')).not.toBeInTheDocument();
+      });
+    });
+
+    it('does not call onSuccess when Done clicked with no INVITED results', async () => {
+      mocks.mockInvite.mockResolvedValue(makeResults(['ALREADY_MEMBER']));
+      const { user } = setup();
+      await openDialog(user);
+      await selectUser(user);
+      await user.click(screen.getByRole('button', { name: 'participants.invite.submit' }));
+
+      await waitFor(() => screen.getByRole('button', { name: 'participants.invite.done' }));
+      await user.click(screen.getByRole('button', { name: 'participants.invite.done' }));
+
+      expect(mocks.mockOnSuccess).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/web/src/components/trips/participants/InviteParticipantModal.tsx
+++ b/apps/web/src/components/trips/participants/InviteParticipantModal.tsx
@@ -1,0 +1,178 @@
+'use client';
+
+import { useState, type SubmitEvent } from 'react';
+import { useTranslation } from 'react-i18next';
+import { UserPlusIcon } from '@phosphor-icons/react';
+import type { InvitationResult } from '@chamuco/shared-types';
+import { inviteTripParticipants } from '@/services/trips.service';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogTrigger,
+  DialogPopup,
+  DialogTitle,
+  DialogDescription,
+  DialogClose,
+} from '@/components/ui/dialog';
+import { UserAutocomplete } from '@/components/ui/user-autocomplete';
+import type { UserSearchResult } from '@/types/user';
+
+interface InviteParticipantModalProps {
+  tripId: string;
+  onSuccess: () => void;
+  excludedIds?: string[];
+}
+
+export function InviteParticipantModal({
+  tripId,
+  onSuccess,
+  excludedIds,
+}: InviteParticipantModalProps) {
+  const { t } = useTranslation('trips');
+  const [open, setOpen] = useState(false);
+  const [inputValue, setInputValue] = useState('');
+  const [selectedUsers, setSelectedUsers] = useState<UserSearchResult[]>([]);
+  const [isSending, setIsSending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [selectionError, setSelectionError] = useState<string | null>(null);
+  const [results, setResults] = useState<InvitationResult[] | null>(null);
+
+  function handleOpenChange(next: boolean) {
+    setOpen(next);
+    if (!next) {
+      setInputValue('');
+      setSelectedUsers([]);
+      setError(null);
+      setSelectionError(null);
+      setResults(null);
+    }
+  }
+
+  function addUser(user: UserSearchResult) {
+    if (excludedIds?.includes(user.id)) {
+      setSelectionError(t('participants.invite.alreadyExcluded'));
+      return;
+    }
+    if (selectedUsers.length >= 20) {
+      setSelectionError(t('participants.invite.maxUsers'));
+      return;
+    }
+    setSelectionError(null);
+    setSelectedUsers((prev) => (prev.some((u) => u.id === user.id) ? prev : [...prev, user]));
+  }
+
+  function removeUser(id: string) {
+    setSelectedUsers((prev) => prev.filter((u) => u.id !== id));
+    setSelectionError(null);
+  }
+
+  const handleSubmit = async (e: SubmitEvent) => {
+    e.preventDefault();
+    if (selectedUsers.length === 0) return;
+
+    setIsSending(true);
+    setError(null);
+
+    try {
+      const res = await inviteTripParticipants(tripId, {
+        usernames: selectedUsers.map((u) => u.username),
+      });
+      setResults(res.results);
+    } catch {
+      setError(t('participants.invite.error'));
+    } finally {
+      setIsSending(false);
+    }
+  };
+
+  function handleDone() {
+    const anyInvited = results?.some((r) => r.status === 'INVITED') ?? false;
+    handleOpenChange(false);
+    if (anyInvited) onSuccess();
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogTrigger
+        render={
+          <Button variant="outline" size="sm">
+            <UserPlusIcon />
+            {t('participants.invite.button')}
+          </Button>
+        }
+      />
+
+      <DialogPopup className="p-6">
+        <DialogTitle>{t('participants.invite.title')}</DialogTitle>
+        <DialogDescription className="sr-only">{t('participants.invite.title')}</DialogDescription>
+
+        {results ? (
+          <div className="mt-4 space-y-4">
+            <p className="text-sm font-medium">{t('participants.invite.results.title')}</p>
+            <ul className="space-y-2">
+              {results.map((r) => (
+                <li key={r.username} className="flex items-center justify-between text-sm">
+                  <span className="font-medium">@{r.username}</span>
+                  <span className="text-muted-foreground">
+                    {t(`participants.invite.result.${r.status}`)}
+                  </span>
+                </li>
+              ))}
+            </ul>
+            <div className="flex justify-end">
+              <Button size="sm" type="button" onClick={handleDone}>
+                {t('participants.invite.done')}
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <form onSubmit={handleSubmit} className="mt-4 space-y-4">
+            {selectedUsers.length > 0 && (
+              <div className="flex flex-wrap gap-2">
+                {selectedUsers.map((u) => (
+                  <span
+                    key={u.id}
+                    className="flex items-center gap-1 rounded-full bg-muted px-3 py-1 text-sm"
+                  >
+                    @{u.username}
+                    <button
+                      type="button"
+                      onClick={() => removeUser(u.id)}
+                      className="ml-1 rounded-full hover:text-destructive"
+                      aria-label={t('participants.invite.removeUser', { username: u.username })}
+                    >
+                      ×
+                    </button>
+                  </span>
+                ))}
+              </div>
+            )}
+
+            <UserAutocomplete
+              value={inputValue}
+              onChange={setInputValue}
+              onSelect={addUser}
+              placeholder={t('participants.invite.usernamePlaceholder')}
+            />
+
+            {selectionError && <p className="text-sm text-destructive">{selectionError}</p>}
+            {error && <p className="text-sm text-destructive">{error}</p>}
+
+            <div className="flex justify-end gap-2">
+              <DialogClose
+                render={
+                  <Button variant="outline" size="sm" type="button">
+                    {t('participants.invite.cancel')}
+                  </Button>
+                }
+              />
+              <Button size="sm" type="submit" disabled={isSending || selectedUsers.length === 0}>
+                {isSending ? t('participants.invite.sending') : t('participants.invite.submit')}
+              </Button>
+            </div>
+          </form>
+        )}
+      </DialogPopup>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/trips/participants/InviteParticipantModal.tsx
+++ b/apps/web/src/components/trips/participants/InviteParticipantModal.tsx
@@ -66,7 +66,7 @@ export function InviteParticipantModal({
     setSelectionError(null);
   }
 
-  const handleSubmit = async (e: SubmitEvent) => {
+  const handleSubmit = async (e: SubmitEvent<HTMLFormElement>) => {
     e.preventDefault();
     if (selectedUsers.length === 0) return;
 

--- a/apps/web/src/components/trips/participants/JoinTripButton.test.tsx
+++ b/apps/web/src/components/trips/participants/JoinTripButton.test.tsx
@@ -18,6 +18,20 @@ vi.mock('@/services/api-client', () => ({
   },
 }));
 
+function makeAxios409() {
+  return Object.assign(new Error('409'), {
+    isAxiosError: true,
+    response: { status: 409 },
+  });
+}
+
+function makeAxios500() {
+  return Object.assign(new Error('500'), {
+    isAxiosError: true,
+    response: { status: 500 },
+  });
+}
+
 import { JoinTripButton } from './JoinTripButton';
 
 describe('JoinTripButton', () => {
@@ -74,6 +88,31 @@ describe('JoinTripButton', () => {
       ).toBeDisabled();
       resolve();
     });
+
+    it('shows capacityFull error on 409', async () => {
+      mocks.mockPost.mockRejectedValueOnce(makeAxios409());
+      const user = userEvent.setup();
+      render(
+        <JoinTripButton tripId="t1" hasPendingRequest={false} onSuccess={mocks.mockOnSuccess} />,
+      );
+      await user.click(screen.getByRole('button', { name: 'participants.joinRequest.button' }));
+      await waitFor(() => {
+        expect(screen.getByText('participants.joinRequest.capacityFull')).toBeInTheDocument();
+      });
+      expect(mocks.mockOnSuccess).not.toHaveBeenCalled();
+    });
+
+    it('shows generic error on non-409 failure', async () => {
+      mocks.mockPost.mockRejectedValueOnce(makeAxios500());
+      const user = userEvent.setup();
+      render(
+        <JoinTripButton tripId="t1" hasPendingRequest={false} onSuccess={mocks.mockOnSuccess} />,
+      );
+      await user.click(screen.getByRole('button', { name: 'participants.joinRequest.button' }));
+      await waitFor(() => {
+        expect(screen.getByText('participants.joinRequest.error')).toBeInTheDocument();
+      });
+    });
   });
 
   describe('withdraw mode (hasPendingRequest = true)', () => {
@@ -122,6 +161,19 @@ describe('JoinTripButton', () => {
         screen.getByRole('button', { name: 'participants.joinRequest.withdrawing' }),
       ).toBeDisabled();
       resolve();
+    });
+
+    it('shows withdrawError on withdraw failure', async () => {
+      mocks.mockDelete.mockRejectedValueOnce(new Error('fail'));
+      const user = userEvent.setup();
+      render(
+        <JoinTripButton tripId="t1" hasPendingRequest={true} onSuccess={mocks.mockOnSuccess} />,
+      );
+      await user.click(screen.getByRole('button', { name: 'participants.joinRequest.withdraw' }));
+      await waitFor(() => {
+        expect(screen.getByText('participants.joinRequest.withdrawError')).toBeInTheDocument();
+      });
+      expect(mocks.mockOnSuccess).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/web/src/components/trips/participants/JoinTripButton.test.tsx
+++ b/apps/web/src/components/trips/participants/JoinTripButton.test.tsx
@@ -1,0 +1,127 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+const mocks = vi.hoisted(() => ({
+  mockPost: vi.fn(),
+  mockDelete: vi.fn(),
+  mockOnSuccess: vi.fn(),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('@/services/api-client', () => ({
+  apiClient: {
+    post: mocks.mockPost,
+    delete: mocks.mockDelete,
+  },
+}));
+
+import { JoinTripButton } from './JoinTripButton';
+
+describe('JoinTripButton', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.mockPost.mockResolvedValue({ data: {} });
+    mocks.mockDelete.mockResolvedValue({ data: {} });
+  });
+
+  describe('join mode (hasPendingRequest = false)', () => {
+    it('renders join button', () => {
+      render(
+        <JoinTripButton tripId="t1" hasPendingRequest={false} onSuccess={mocks.mockOnSuccess} />,
+      );
+      expect(
+        screen.getByRole('button', { name: 'participants.joinRequest.button' }),
+      ).toBeInTheDocument();
+    });
+
+    it('calls POST join-request when clicked', async () => {
+      const user = userEvent.setup();
+      render(
+        <JoinTripButton tripId="t1" hasPendingRequest={false} onSuccess={mocks.mockOnSuccess} />,
+      );
+      await user.click(screen.getByRole('button', { name: 'participants.joinRequest.button' }));
+      await waitFor(() => {
+        expect(mocks.mockPost).toHaveBeenCalledWith('/v1/trips/t1/join-request');
+      });
+    });
+
+    it('calls onSuccess after successful join request', async () => {
+      const user = userEvent.setup();
+      render(
+        <JoinTripButton tripId="t1" hasPendingRequest={false} onSuccess={mocks.mockOnSuccess} />,
+      );
+      await user.click(screen.getByRole('button', { name: 'participants.joinRequest.button' }));
+      await waitFor(() => {
+        expect(mocks.mockOnSuccess).toHaveBeenCalled();
+      });
+    });
+
+    it('shows requesting label while in flight', async () => {
+      let resolve!: () => void;
+      mocks.mockPost.mockReturnValue(new Promise<void>((r) => (resolve = r)));
+
+      const user = userEvent.setup();
+      render(
+        <JoinTripButton tripId="t1" hasPendingRequest={false} onSuccess={mocks.mockOnSuccess} />,
+      );
+      await user.click(screen.getByRole('button', { name: 'participants.joinRequest.button' }));
+
+      expect(
+        screen.getByRole('button', { name: 'participants.joinRequest.requesting' }),
+      ).toBeDisabled();
+      resolve();
+    });
+  });
+
+  describe('withdraw mode (hasPendingRequest = true)', () => {
+    it('renders withdraw button', () => {
+      render(
+        <JoinTripButton tripId="t1" hasPendingRequest={true} onSuccess={mocks.mockOnSuccess} />,
+      );
+      expect(
+        screen.getByRole('button', { name: 'participants.joinRequest.withdraw' }),
+      ).toBeInTheDocument();
+    });
+
+    it('calls DELETE join-request when clicked', async () => {
+      const user = userEvent.setup();
+      render(
+        <JoinTripButton tripId="t1" hasPendingRequest={true} onSuccess={mocks.mockOnSuccess} />,
+      );
+      await user.click(screen.getByRole('button', { name: 'participants.joinRequest.withdraw' }));
+      await waitFor(() => {
+        expect(mocks.mockDelete).toHaveBeenCalledWith('/v1/trips/t1/join-request');
+      });
+    });
+
+    it('calls onSuccess after successful withdraw', async () => {
+      const user = userEvent.setup();
+      render(
+        <JoinTripButton tripId="t1" hasPendingRequest={true} onSuccess={mocks.mockOnSuccess} />,
+      );
+      await user.click(screen.getByRole('button', { name: 'participants.joinRequest.withdraw' }));
+      await waitFor(() => {
+        expect(mocks.mockOnSuccess).toHaveBeenCalled();
+      });
+    });
+
+    it('shows withdrawing label while in flight', async () => {
+      let resolve!: () => void;
+      mocks.mockDelete.mockReturnValue(new Promise<void>((r) => (resolve = r)));
+
+      const user = userEvent.setup();
+      render(
+        <JoinTripButton tripId="t1" hasPendingRequest={true} onSuccess={mocks.mockOnSuccess} />,
+      );
+      await user.click(screen.getByRole('button', { name: 'participants.joinRequest.withdraw' }));
+
+      expect(
+        screen.getByRole('button', { name: 'participants.joinRequest.withdrawing' }),
+      ).toBeDisabled();
+      resolve();
+    });
+  });
+});

--- a/apps/web/src/components/trips/participants/JoinTripButton.tsx
+++ b/apps/web/src/components/trips/participants/JoinTripButton.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import axios from 'axios';
 import { submitJoinRequest, withdrawJoinRequest } from '@/services/trips.service';
 import { Button } from '@/components/ui/button';
 
@@ -14,12 +15,20 @@ interface JoinTripButtonProps {
 export function JoinTripButton({ tripId, hasPendingRequest, onSuccess }: JoinTripButtonProps) {
   const { t } = useTranslation('trips');
   const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   const handleJoinRequest = async () => {
     setIsLoading(true);
+    setError(null);
     try {
       await submitJoinRequest(tripId);
       onSuccess();
+    } catch (err) {
+      const message =
+        axios.isAxiosError(err) && err.response?.status === 409
+          ? t('participants.joinRequest.capacityFull')
+          : t('participants.joinRequest.error');
+      setError(message);
     } finally {
       setIsLoading(false);
     }
@@ -27,27 +36,33 @@ export function JoinTripButton({ tripId, hasPendingRequest, onSuccess }: JoinTri
 
   const handleWithdraw = async () => {
     setIsLoading(true);
+    setError(null);
     try {
       await withdrawJoinRequest(tripId);
       onSuccess();
+    } catch {
+      setError(t('participants.joinRequest.withdrawError'));
     } finally {
       setIsLoading(false);
     }
   };
 
-  if (hasPendingRequest) {
-    return (
-      <Button variant="outline" size="sm" onClick={handleWithdraw} disabled={isLoading}>
-        {isLoading
-          ? t('participants.joinRequest.withdrawing')
-          : t('participants.joinRequest.withdraw')}
-      </Button>
-    );
-  }
-
   return (
-    <Button size="sm" onClick={handleJoinRequest} disabled={isLoading}>
-      {isLoading ? t('participants.joinRequest.requesting') : t('participants.joinRequest.button')}
-    </Button>
+    <div className="flex flex-col items-end gap-1">
+      {hasPendingRequest ? (
+        <Button variant="outline" size="sm" onClick={handleWithdraw} disabled={isLoading}>
+          {isLoading
+            ? t('participants.joinRequest.withdrawing')
+            : t('participants.joinRequest.withdraw')}
+        </Button>
+      ) : (
+        <Button size="sm" onClick={handleJoinRequest} disabled={isLoading}>
+          {isLoading
+            ? t('participants.joinRequest.requesting')
+            : t('participants.joinRequest.button')}
+        </Button>
+      )}
+      {error && <p className="text-xs text-destructive">{error}</p>}
+    </div>
   );
 }

--- a/apps/web/src/components/trips/participants/JoinTripButton.tsx
+++ b/apps/web/src/components/trips/participants/JoinTripButton.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { submitJoinRequest, withdrawJoinRequest } from '@/services/trips.service';
+import { Button } from '@/components/ui/button';
+
+interface JoinTripButtonProps {
+  tripId: string;
+  hasPendingRequest: boolean;
+  onSuccess: () => void;
+}
+
+export function JoinTripButton({ tripId, hasPendingRequest, onSuccess }: JoinTripButtonProps) {
+  const { t } = useTranslation('trips');
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleJoinRequest = async () => {
+    setIsLoading(true);
+    try {
+      await submitJoinRequest(tripId);
+      onSuccess();
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleWithdraw = async () => {
+    setIsLoading(true);
+    try {
+      await withdrawJoinRequest(tripId);
+      onSuccess();
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  if (hasPendingRequest) {
+    return (
+      <Button variant="outline" size="sm" onClick={handleWithdraw} disabled={isLoading}>
+        {isLoading
+          ? t('participants.joinRequest.withdrawing')
+          : t('participants.joinRequest.withdraw')}
+      </Button>
+    );
+  }
+
+  return (
+    <Button size="sm" onClick={handleJoinRequest} disabled={isLoading}>
+      {isLoading ? t('participants.joinRequest.requesting') : t('participants.joinRequest.button')}
+    </Button>
+  );
+}

--- a/apps/web/src/components/trips/participants/LeaveTripButton.test.tsx
+++ b/apps/web/src/components/trips/participants/LeaveTripButton.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+const mocks = vi.hoisted(() => ({
+  mockDelete: vi.fn(),
+  mockRouterPush: vi.fn(),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mocks.mockRouterPush }),
+}));
+
+vi.mock('@/services/api-client', () => ({
+  apiClient: { delete: mocks.mockDelete },
+}));
+
+import { LeaveTripButton } from './LeaveTripButton';
+
+describe('LeaveTripButton', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders leave button', () => {
+    render(<LeaveTripButton tripId="t1" userId="u1" />);
+    expect(screen.getByRole('button', { name: 'participants.leave.button' })).toBeInTheDocument();
+  });
+
+  it('opens confirmation dialog on click', async () => {
+    const user = userEvent.setup();
+    render(<LeaveTripButton tripId="t1" userId="u1" />);
+    await user.click(screen.getByRole('button', { name: 'participants.leave.button' }));
+    expect(screen.getByText('participants.leave.confirm')).toBeInTheDocument();
+  });
+
+  it('calls DELETE and redirects on confirm', async () => {
+    mocks.mockDelete.mockResolvedValue({ data: {} });
+    const user = userEvent.setup();
+    render(<LeaveTripButton tripId="t1" userId="u1" />);
+    await user.click(screen.getByRole('button', { name: 'participants.leave.button' }));
+    await user.click(screen.getByRole('button', { name: 'participants.leave.confirmButton' }));
+
+    await waitFor(() => {
+      expect(mocks.mockDelete).toHaveBeenCalledWith('/v1/trips/t1/participants/u1');
+      expect(mocks.mockRouterPush).toHaveBeenCalledWith('/trips');
+    });
+  });
+
+  it('shows lastOrganizer error on 409', async () => {
+    const err = Object.assign(new Error('409'), {
+      isAxiosError: true,
+      response: { status: 409 },
+    });
+    mocks.mockDelete.mockRejectedValueOnce(err);
+
+    const user = userEvent.setup();
+    render(<LeaveTripButton tripId="t1" userId="u1" />);
+    await user.click(screen.getByRole('button', { name: 'participants.leave.button' }));
+    await user.click(screen.getByRole('button', { name: 'participants.leave.confirmButton' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('participants.leave.lastOrganizer')).toBeInTheDocument();
+    });
+  });
+
+  it('shows generic error on non-409 failure', async () => {
+    const err = Object.assign(new Error('500'), {
+      isAxiosError: true,
+      response: { status: 500 },
+    });
+    mocks.mockDelete.mockRejectedValueOnce(err);
+
+    const user = userEvent.setup();
+    render(<LeaveTripButton tripId="t1" userId="u1" />);
+    await user.click(screen.getByRole('button', { name: 'participants.leave.button' }));
+    await user.click(screen.getByRole('button', { name: 'participants.leave.confirmButton' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('participants.leave.error')).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/src/components/trips/participants/LeaveTripButton.tsx
+++ b/apps/web/src/components/trips/participants/LeaveTripButton.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useRouter } from 'next/navigation';
+import axios from 'axios';
+import { removeTripParticipant } from '@/services/trips.service';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogClose,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogPopup,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+
+interface LeaveTripButtonProps {
+  tripId: string;
+  userId: string;
+}
+
+export function LeaveTripButton({ tripId, userId }: LeaveTripButtonProps) {
+  const { t } = useTranslation('trips');
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [isLeaving, setIsLeaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleConfirm = async () => {
+    setIsLeaving(true);
+    setError(null);
+    try {
+      await removeTripParticipant(tripId, userId);
+      setOpen(false);
+      router.push('/trips');
+    } catch (err) {
+      const message =
+        axios.isAxiosError(err) && err.response?.status === 409
+          ? t('participants.leave.lastOrganizer')
+          : t('participants.leave.error');
+      setError(message);
+      setIsLeaving(false);
+    }
+  };
+
+  return (
+    <div>
+      <Dialog
+        open={open}
+        onOpenChange={(newOpen) => {
+          if (!isLeaving) setOpen(newOpen);
+        }}
+      >
+        <DialogTrigger
+          render={
+            <Button variant="destructive" size="sm">
+              {t('participants.leave.button')}
+            </Button>
+          }
+        />
+        <DialogPopup>
+          <DialogClose />
+          <DialogHeader>
+            <DialogTitle>{t('participants.leave.button')}</DialogTitle>
+            <DialogDescription>{t('participants.leave.confirm')}</DialogDescription>
+          </DialogHeader>
+          {error && <p className="mt-2 text-sm text-destructive">{error}</p>}
+          <DialogFooter className="mt-4">
+            <DialogClose
+              render={
+                <Button variant="outline" size="sm" disabled={isLeaving}>
+                  {t('participants.leave.cancel')}
+                </Button>
+              }
+            />
+            <Button variant="destructive" size="sm" onClick={handleConfirm} disabled={isLeaving}>
+              {isLeaving ? t('participants.leave.leaving') : t('participants.leave.confirmButton')}
+            </Button>
+          </DialogFooter>
+        </DialogPopup>
+      </Dialog>
+    </div>
+  );
+}

--- a/apps/web/src/components/trips/participants/LeaveTripButton.tsx
+++ b/apps/web/src/components/trips/participants/LeaveTripButton.tsx
@@ -47,41 +47,39 @@ export function LeaveTripButton({ tripId, userId }: LeaveTripButtonProps) {
   };
 
   return (
-    <div>
-      <Dialog
-        open={open}
-        onOpenChange={(newOpen) => {
-          if (!isLeaving) setOpen(newOpen);
-        }}
-      >
-        <DialogTrigger
-          render={
-            <Button variant="destructive" size="sm">
-              {t('participants.leave.button')}
-            </Button>
-          }
-        />
-        <DialogPopup>
-          <DialogClose />
-          <DialogHeader>
-            <DialogTitle>{t('participants.leave.button')}</DialogTitle>
-            <DialogDescription>{t('participants.leave.confirm')}</DialogDescription>
-          </DialogHeader>
-          {error && <p className="mt-2 text-sm text-destructive">{error}</p>}
-          <DialogFooter className="mt-4">
-            <DialogClose
-              render={
-                <Button variant="outline" size="sm" disabled={isLeaving}>
-                  {t('participants.leave.cancel')}
-                </Button>
-              }
-            />
-            <Button variant="destructive" size="sm" onClick={handleConfirm} disabled={isLeaving}>
-              {isLeaving ? t('participants.leave.leaving') : t('participants.leave.confirmButton')}
-            </Button>
-          </DialogFooter>
-        </DialogPopup>
-      </Dialog>
-    </div>
+    <Dialog
+      open={open}
+      onOpenChange={(newOpen) => {
+        if (!isLeaving) setOpen(newOpen);
+      }}
+    >
+      <DialogTrigger
+        render={
+          <Button variant="destructive" size="sm">
+            {t('participants.leave.button')}
+          </Button>
+        }
+      />
+      <DialogPopup>
+        <DialogClose />
+        <DialogHeader>
+          <DialogTitle>{t('participants.leave.button')}</DialogTitle>
+          <DialogDescription>{t('participants.leave.confirm')}</DialogDescription>
+        </DialogHeader>
+        {error && <p className="mt-2 text-sm text-destructive">{error}</p>}
+        <DialogFooter className="mt-4">
+          <DialogClose
+            render={
+              <Button variant="outline" size="sm" disabled={isLeaving}>
+                {t('participants.leave.cancel')}
+              </Button>
+            }
+          />
+          <Button variant="destructive" size="sm" onClick={handleConfirm} disabled={isLeaving}>
+            {isLeaving ? t('participants.leave.leaving') : t('participants.leave.confirmButton')}
+          </Button>
+        </DialogFooter>
+      </DialogPopup>
+    </Dialog>
   );
 }

--- a/apps/web/src/components/trips/participants/ParticipantList.tsx
+++ b/apps/web/src/components/trips/participants/ParticipantList.tsx
@@ -78,7 +78,7 @@ export function ParticipantList({
     <div className="rounded-xl border border-border">
       <div className="flex items-center justify-between px-4 pt-4 pb-2">
         <p className="text-sm font-semibold">
-          {t('participants.capacity', { confirmed: participants.length, total: capacity })}
+          {t('participants.capacity', { active: participants.length, total: capacity })}
         </p>
         {isOrganizer && (
           <InviteParticipantModal

--- a/apps/web/src/components/trips/participants/ParticipantList.tsx
+++ b/apps/web/src/components/trips/participants/ParticipantList.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useTranslation } from 'react-i18next';
-import { TripRole } from '@chamuco/shared-types';
+import { TripParticipantStatus, TripRole } from '@chamuco/shared-types';
 import { ParticipantListItem } from './ParticipantListItem';
 import { InviteParticipantModal } from './InviteParticipantModal';
 import type { TripParticipantResponse } from '@/services/trips.types';
@@ -19,6 +19,43 @@ interface ParticipantListProps {
 
 const ORGANIZER_ROLES: TripRole[] = [TripRole.ORGANIZER, TripRole.CO_ORGANIZER];
 
+function Section({
+  label,
+  participants,
+  tripId,
+  currentUserId,
+  callerRole,
+  onParticipantAction,
+}: {
+  label: string;
+  participants: TripParticipantResponse[];
+  tripId: string;
+  currentUserId: string | null;
+  callerRole: TripRole | null;
+  onParticipantAction: () => void;
+}) {
+  if (participants.length === 0) return null;
+  return (
+    <div>
+      <p className="px-4 pt-3 pb-1 text-xs font-medium text-muted-foreground uppercase tracking-wide">
+        {label}
+      </p>
+      <ul className="divide-y divide-border px-4">
+        {participants.map((participant) => (
+          <ParticipantListItem
+            key={participant.userId}
+            participant={participant}
+            tripId={tripId}
+            currentUserId={currentUserId}
+            callerRole={callerRole}
+            onActionSuccess={onParticipantAction}
+          />
+        ))}
+      </ul>
+    </div>
+  );
+}
+
 export function ParticipantList({
   tripId,
   participants,
@@ -31,6 +68,11 @@ export function ParticipantList({
 }: ParticipantListProps) {
   const { t } = useTranslation('trips');
   const isOrganizer = callerRole !== null && ORGANIZER_ROLES.includes(callerRole);
+
+  const confirmed = participants.filter((p) => p.status === TripParticipantStatus.CONFIRMED);
+  const pendingConfirmation = participants.filter(
+    (p) => p.status === TripParticipantStatus.ACCEPTED,
+  );
 
   return (
     <div className="rounded-xl border border-border">
@@ -50,18 +92,26 @@ export function ParticipantList({
       {participants.length === 0 ? (
         <p className="px-4 pb-4 text-sm text-muted-foreground">{t('participants.empty')}</p>
       ) : (
-        <ul className="divide-y divide-border px-4">
-          {participants.map((participant) => (
-            <ParticipantListItem
-              key={participant.userId}
-              participant={participant}
-              tripId={tripId}
-              currentUserId={currentUserId}
-              callerRole={callerRole}
-              onActionSuccess={onParticipantAction}
-            />
-          ))}
-        </ul>
+        <div className="pb-2">
+          <Section
+            label={t('participants.sections.confirmed', { count: confirmed.length })}
+            participants={confirmed}
+            tripId={tripId}
+            currentUserId={currentUserId}
+            callerRole={callerRole}
+            onParticipantAction={onParticipantAction}
+          />
+          <Section
+            label={t('participants.sections.pendingConfirmation', {
+              count: pendingConfirmation.length,
+            })}
+            participants={pendingConfirmation}
+            tripId={tripId}
+            currentUserId={currentUserId}
+            callerRole={callerRole}
+            onParticipantAction={onParticipantAction}
+          />
+        </div>
       )}
     </div>
   );

--- a/apps/web/src/components/trips/participants/ParticipantList.tsx
+++ b/apps/web/src/components/trips/participants/ParticipantList.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import { useTranslation } from 'react-i18next';
+import { TripRole } from '@chamuco/shared-types';
+import { ParticipantListItem } from './ParticipantListItem';
+import { InviteParticipantModal } from './InviteParticipantModal';
+import type { TripParticipantResponse } from '@/services/trips.types';
+
+interface ParticipantListProps {
+  tripId: string;
+  participants: TripParticipantResponse[];
+  capacity: number;
+  currentUserId: string | null;
+  callerRole: TripRole | null;
+  onInviteSuccess: () => void;
+  onParticipantAction: () => void;
+  excludedIds?: string[];
+}
+
+const ORGANIZER_ROLES: TripRole[] = [TripRole.ORGANIZER, TripRole.CO_ORGANIZER];
+
+export function ParticipantList({
+  tripId,
+  participants,
+  capacity,
+  currentUserId,
+  callerRole,
+  onInviteSuccess,
+  onParticipantAction,
+  excludedIds,
+}: ParticipantListProps) {
+  const { t } = useTranslation('trips');
+  const isOrganizer = callerRole !== null && ORGANIZER_ROLES.includes(callerRole);
+
+  return (
+    <div className="rounded-xl border border-border">
+      <div className="flex items-center justify-between px-4 pt-4 pb-2">
+        <p className="text-sm font-semibold">
+          {t('participants.capacity', { confirmed: participants.length, total: capacity })}
+        </p>
+        {isOrganizer && (
+          <InviteParticipantModal
+            tripId={tripId}
+            onSuccess={onInviteSuccess}
+            excludedIds={excludedIds}
+          />
+        )}
+      </div>
+
+      {participants.length === 0 ? (
+        <p className="px-4 pb-4 text-sm text-muted-foreground">{t('participants.empty')}</p>
+      ) : (
+        <ul className="divide-y divide-border px-4">
+          {participants.map((participant) => (
+            <ParticipantListItem
+              key={participant.userId}
+              participant={participant}
+              tripId={tripId}
+              currentUserId={currentUserId}
+              callerRole={callerRole}
+              onActionSuccess={onParticipantAction}
+            />
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/trips/participants/ParticipantListItem.test.tsx
+++ b/apps/web/src/components/trips/participants/ParticipantListItem.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { TripRole } from '@chamuco/shared-types';
+import { TripParticipantStatus, TripRole } from '@chamuco/shared-types';
 import type { TripParticipantResponse } from '@/services/trips.types';
 
 const mocks = vi.hoisted(() => ({
@@ -33,6 +33,7 @@ const baseParticipant: TripParticipantResponse = {
   avatarUrl: null,
   role: TripRole.PARTICIPANT,
   isTraveler: true,
+  status: TripParticipantStatus.ACCEPTED,
   confirmedAt: null,
 };
 
@@ -65,29 +66,65 @@ describe('ParticipantListItem', () => {
       expect(screen.getByText('@juan_viajero')).toBeInTheDocument();
     });
 
-    it('renders role badge via t key', () => {
-      renderItem();
-      expect(screen.getByText(`participants.role.${TripRole.PARTICIPANT}`)).toBeInTheDocument();
+    it('does not render role badge for PARTICIPANT (role is obvious)', () => {
+      renderItem({ role: TripRole.PARTICIPANT });
+      expect(
+        screen.queryByText(`participants.role.${TripRole.PARTICIPANT}`),
+      ).not.toBeInTheDocument();
     });
 
-    it('renders ORGANIZER role badge', () => {
+    it('renders role badge for ORGANIZER', () => {
       renderItem({ role: TripRole.ORGANIZER });
       expect(screen.getByText(`participants.role.${TripRole.ORGANIZER}`)).toBeInTheDocument();
     });
 
-    it('renders CO_ORGANIZER role badge', () => {
+    it('renders role badge for CO_ORGANIZER', () => {
       renderItem({ role: TripRole.CO_ORGANIZER });
       expect(screen.getByText(`participants.role.${TripRole.CO_ORGANIZER}`)).toBeInTheDocument();
     });
 
-    it('renders traveler badge when isTraveler is true', () => {
-      renderItem({ isTraveler: true });
+    it('renders traveler badge for ORGANIZER when isTraveler is true', () => {
+      renderItem({ isTraveler: true, role: TripRole.ORGANIZER });
       expect(screen.getByText('participants.traveler')).toBeInTheDocument();
+    });
+
+    it('renders traveler badge for CO_ORGANIZER when isTraveler is true', () => {
+      renderItem({ isTraveler: true, role: TripRole.CO_ORGANIZER });
+      expect(screen.getByText('participants.traveler')).toBeInTheDocument();
+    });
+
+    it('does not render traveler badge for PARTICIPANT even when isTraveler is true', () => {
+      renderItem({ isTraveler: true, role: TripRole.PARTICIPANT });
+      expect(screen.queryByText('participants.traveler')).not.toBeInTheDocument();
     });
 
     it('does not render traveler badge when isTraveler is false', () => {
       renderItem({ isTraveler: false });
       expect(screen.queryByText('participants.traveler')).not.toBeInTheDocument();
+    });
+
+    it('renders confirm button (not confirmed) for organizer', () => {
+      renderItem({ confirmedAt: null });
+      expect(screen.getByTitle('participants.actions.confirm')).toBeInTheDocument();
+    });
+
+    it('renders unconfirm button (confirmed) for organizer', () => {
+      renderItem({
+        status: TripParticipantStatus.CONFIRMED,
+        confirmedAt: '2026-01-01T00:00:00.000Z',
+      });
+      expect(screen.getByTitle('participants.actions.unconfirm')).toBeInTheDocument();
+    });
+
+    it('does not render confirmation button for non-organizer viewer', () => {
+      renderItem({ confirmedAt: null }, TripRole.PARTICIPANT);
+      expect(screen.queryByTitle('participants.actions.confirm')).not.toBeInTheDocument();
+    });
+
+    it('does not render confirmation toggle for ORGANIZER target', () => {
+      renderItem({ role: TripRole.ORGANIZER, userId: 'other-organizer' }, TripRole.ORGANIZER);
+      expect(screen.queryByTitle('participants.actions.confirm')).not.toBeInTheDocument();
+      expect(screen.queryByTitle('participants.actions.unconfirm')).not.toBeInTheDocument();
     });
 
     it('renders initials as avatar fallback when no avatarUrl', () => {
@@ -237,6 +274,27 @@ describe('ParticipantListItem', () => {
       await userEvent.click(confirmBtn);
 
       expect(mocks.mockToastError).toHaveBeenCalledWith('participants.actions.removeError');
+    });
+
+    it('calls toggle confirmation endpoint and onActionSuccess on click', async () => {
+      const onActionSuccess = vi.fn();
+      renderItem({ confirmedAt: null }, TripRole.ORGANIZER, CURRENT_USER_ID, onActionSuccess);
+
+      await userEvent.click(screen.getByTitle('participants.actions.confirm'));
+
+      expect(mocks.mockPatch).toHaveBeenCalledWith(
+        `/v1/trips/${TRIP_ID}/participants/${baseParticipant.userId}/confirmation`,
+      );
+      expect(onActionSuccess).toHaveBeenCalled();
+    });
+
+    it('shows toast error when confirmation toggle fails', async () => {
+      mocks.mockPatch.mockRejectedValueOnce(new Error('fail'));
+      renderItem({ confirmedAt: null }, TripRole.ORGANIZER, CURRENT_USER_ID, vi.fn());
+
+      await userEvent.click(screen.getByTitle('participants.actions.confirm'));
+
+      expect(mocks.mockToastError).toHaveBeenCalledWith('participants.actions.confirmError');
     });
   });
 });

--- a/apps/web/src/components/trips/participants/ParticipantListItem.test.tsx
+++ b/apps/web/src/components/trips/participants/ParticipantListItem.test.tsx
@@ -1,0 +1,242 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { TripRole } from '@chamuco/shared-types';
+import type { TripParticipantResponse } from '@/services/trips.types';
+
+const mocks = vi.hoisted(() => ({
+  mockDelete: vi.fn(),
+  mockPatch: vi.fn(),
+  mockToastError: vi.fn(),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('@/services/api-client', () => ({
+  apiClient: { delete: mocks.mockDelete, patch: mocks.mockPatch },
+}));
+
+vi.mock('@/components/ui/toast', () => ({
+  toast: { error: mocks.mockToastError },
+}));
+
+import { ParticipantListItem } from './ParticipantListItem';
+
+const TRIP_ID = 'trip-1';
+const CURRENT_USER_ID = 'current-user';
+
+const baseParticipant: TripParticipantResponse = {
+  userId: 'user-1',
+  username: 'juan_viajero',
+  displayName: 'Juan Viajero',
+  avatarUrl: null,
+  role: TripRole.PARTICIPANT,
+  isTraveler: true,
+  confirmedAt: null,
+};
+
+function renderItem(
+  overrides: Partial<TripParticipantResponse> = {},
+  callerRole: TripRole | null = TripRole.ORGANIZER,
+  currentUserId: string | null = CURRENT_USER_ID,
+  onActionSuccess = vi.fn(),
+) {
+  return render(
+    <ParticipantListItem
+      participant={{ ...baseParticipant, ...overrides }}
+      tripId={TRIP_ID}
+      currentUserId={currentUserId}
+      callerRole={callerRole}
+      onActionSuccess={onActionSuccess}
+    />,
+  );
+}
+
+describe('ParticipantListItem', () => {
+  describe('rendering', () => {
+    it('renders display name', () => {
+      renderItem();
+      expect(screen.getByText('Juan Viajero')).toBeInTheDocument();
+    });
+
+    it('renders @username', () => {
+      renderItem();
+      expect(screen.getByText('@juan_viajero')).toBeInTheDocument();
+    });
+
+    it('renders role badge via t key', () => {
+      renderItem();
+      expect(screen.getByText(`participants.role.${TripRole.PARTICIPANT}`)).toBeInTheDocument();
+    });
+
+    it('renders ORGANIZER role badge', () => {
+      renderItem({ role: TripRole.ORGANIZER });
+      expect(screen.getByText(`participants.role.${TripRole.ORGANIZER}`)).toBeInTheDocument();
+    });
+
+    it('renders CO_ORGANIZER role badge', () => {
+      renderItem({ role: TripRole.CO_ORGANIZER });
+      expect(screen.getByText(`participants.role.${TripRole.CO_ORGANIZER}`)).toBeInTheDocument();
+    });
+
+    it('renders traveler badge when isTraveler is true', () => {
+      renderItem({ isTraveler: true });
+      expect(screen.getByText('participants.traveler')).toBeInTheDocument();
+    });
+
+    it('does not render traveler badge when isTraveler is false', () => {
+      renderItem({ isTraveler: false });
+      expect(screen.queryByText('participants.traveler')).not.toBeInTheDocument();
+    });
+
+    it('renders initials as avatar fallback when no avatarUrl', () => {
+      renderItem();
+      expect(screen.getByText('JV')).toBeInTheDocument();
+    });
+  });
+
+  describe('action button visibility', () => {
+    it('hides actions when callerRole is PARTICIPANT', () => {
+      renderItem({}, TripRole.PARTICIPANT);
+      expect(screen.queryByTitle('participants.actions.remove')).not.toBeInTheDocument();
+      expect(screen.queryByTitle('participants.actions.promote')).not.toBeInTheDocument();
+    });
+
+    it('hides actions when callerRole is null', () => {
+      renderItem({}, null);
+      expect(screen.queryByTitle('participants.actions.remove')).not.toBeInTheDocument();
+    });
+
+    it('hides actions on own row', () => {
+      renderItem({}, TripRole.ORGANIZER, 'user-1');
+      expect(screen.queryByTitle('participants.actions.remove')).not.toBeInTheDocument();
+    });
+
+    it('hides actions when target is ORGANIZER', () => {
+      renderItem({ role: TripRole.ORGANIZER, userId: 'other-organizer' });
+      expect(screen.queryByTitle('participants.actions.remove')).not.toBeInTheDocument();
+      expect(screen.queryByTitle('participants.actions.promote')).not.toBeInTheDocument();
+    });
+
+    it('shows promote and remove for ORGANIZER viewing a PARTICIPANT', () => {
+      renderItem({ role: TripRole.PARTICIPANT });
+      expect(screen.getByTitle('participants.actions.promote')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'actions.delete' })).toBeInTheDocument();
+    });
+
+    it('shows demote and remove for ORGANIZER viewing a CO_ORGANIZER', () => {
+      renderItem({ role: TripRole.CO_ORGANIZER });
+      expect(screen.getByTitle('participants.actions.demote')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'actions.delete' })).toBeInTheDocument();
+    });
+
+    it('shows actions when callerRole is CO_ORGANIZER', () => {
+      renderItem({ role: TripRole.PARTICIPANT }, TripRole.CO_ORGANIZER);
+      expect(screen.getByTitle('participants.actions.promote')).toBeInTheDocument();
+    });
+
+    it('does not show promote for CO_ORGANIZER or ORGANIZER targets', () => {
+      renderItem({ role: TripRole.CO_ORGANIZER });
+      expect(screen.queryByTitle('participants.actions.promote')).not.toBeInTheDocument();
+    });
+
+    it('does not show demote for PARTICIPANT target', () => {
+      renderItem({ role: TripRole.PARTICIPANT });
+      expect(screen.queryByTitle('participants.actions.demote')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('actions', () => {
+    beforeEach(() => {
+      mocks.mockDelete.mockResolvedValue(undefined);
+      mocks.mockPatch.mockResolvedValue(undefined);
+    });
+
+    it('calls delete endpoint and onActionSuccess on remove confirm', async () => {
+      const onActionSuccess = vi.fn();
+      renderItem(
+        { role: TripRole.PARTICIPANT },
+        TripRole.ORGANIZER,
+        CURRENT_USER_ID,
+        onActionSuccess,
+      );
+
+      const deleteBtn = screen.getByRole('button', { name: 'actions.delete' });
+      await userEvent.click(deleteBtn);
+      const confirmBtn = screen.getByRole('button', { name: 'actions.deleteConfirm' });
+      await userEvent.click(confirmBtn);
+
+      expect(mocks.mockDelete).toHaveBeenCalledWith(
+        `/v1/trips/${TRIP_ID}/participants/${baseParticipant.userId}`,
+      );
+      expect(onActionSuccess).toHaveBeenCalled();
+    });
+
+    it('calls patch with CO_ORGANIZER role and onActionSuccess on promote', async () => {
+      const onActionSuccess = vi.fn();
+      renderItem(
+        { role: TripRole.PARTICIPANT },
+        TripRole.ORGANIZER,
+        CURRENT_USER_ID,
+        onActionSuccess,
+      );
+
+      await userEvent.click(screen.getByTitle('participants.actions.promote'));
+
+      expect(mocks.mockPatch).toHaveBeenCalledWith(
+        `/v1/trips/${TRIP_ID}/participants/${baseParticipant.userId}/role`,
+        { role: TripRole.CO_ORGANIZER },
+      );
+      expect(onActionSuccess).toHaveBeenCalled();
+    });
+
+    it('calls patch with PARTICIPANT role and onActionSuccess on demote', async () => {
+      const onActionSuccess = vi.fn();
+      renderItem(
+        { role: TripRole.CO_ORGANIZER },
+        TripRole.ORGANIZER,
+        CURRENT_USER_ID,
+        onActionSuccess,
+      );
+
+      await userEvent.click(screen.getByTitle('participants.actions.demote'));
+
+      expect(mocks.mockPatch).toHaveBeenCalledWith(
+        `/v1/trips/${TRIP_ID}/participants/${baseParticipant.userId}/role`,
+        { role: TripRole.PARTICIPANT },
+      );
+      expect(onActionSuccess).toHaveBeenCalled();
+    });
+
+    it('shows toast error when promote fails', async () => {
+      mocks.mockPatch.mockRejectedValueOnce(new Error('fail'));
+      renderItem({ role: TripRole.PARTICIPANT }, TripRole.ORGANIZER, CURRENT_USER_ID, vi.fn());
+
+      await userEvent.click(screen.getByTitle('participants.actions.promote'));
+
+      expect(mocks.mockToastError).toHaveBeenCalledWith('participants.actions.promoteError');
+    });
+
+    it('shows toast error when demote fails', async () => {
+      mocks.mockPatch.mockRejectedValueOnce(new Error('fail'));
+      renderItem({ role: TripRole.CO_ORGANIZER }, TripRole.ORGANIZER, CURRENT_USER_ID, vi.fn());
+
+      await userEvent.click(screen.getByTitle('participants.actions.demote'));
+
+      expect(mocks.mockToastError).toHaveBeenCalledWith('participants.actions.demoteError');
+    });
+
+    it('shows toast error when remove fails', async () => {
+      mocks.mockDelete.mockRejectedValueOnce(new Error('fail'));
+      renderItem({ role: TripRole.PARTICIPANT }, TripRole.ORGANIZER, CURRENT_USER_ID, vi.fn());
+
+      const deleteBtn = screen.getByRole('button', { name: 'actions.delete' });
+      await userEvent.click(deleteBtn);
+      const confirmBtn = screen.getByRole('button', { name: 'actions.deleteConfirm' });
+      await userEvent.click(confirmBtn);
+
+      expect(mocks.mockToastError).toHaveBeenCalledWith('participants.actions.removeError');
+    });
+  });
+});

--- a/apps/web/src/components/trips/participants/ParticipantListItem.tsx
+++ b/apps/web/src/components/trips/participants/ParticipantListItem.tsx
@@ -1,0 +1,157 @@
+'use client';
+
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { TripRole } from '@chamuco/shared-types';
+import { AirplaneIcon, ShieldStarIcon, UserMinusIcon } from '@phosphor-icons/react';
+import { Avatar } from '@/components/ui/avatar';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { DeleteConfirmButton } from '@/components/ui/delete-confirm-button';
+import { toast } from '@/components/ui/toast';
+import { removeTripParticipant, updateTripParticipantRole } from '@/services/trips.service';
+import type { TripParticipantResponse } from '@/services/trips.types';
+
+interface ParticipantListItemProps {
+  participant: TripParticipantResponse;
+  tripId: string;
+  currentUserId: string | null;
+  callerRole: TripRole | null;
+  onActionSuccess: () => void;
+}
+
+const ROLE_VARIANT: Record<TripRole, 'default' | 'secondary' | 'outline'> = {
+  [TripRole.ORGANIZER]: 'default',
+  [TripRole.CO_ORGANIZER]: 'secondary',
+  [TripRole.PARTICIPANT]: 'outline',
+};
+
+const ORGANIZER_ROLES: TripRole[] = [TripRole.ORGANIZER, TripRole.CO_ORGANIZER];
+
+export function ParticipantListItem({
+  participant,
+  tripId,
+  currentUserId,
+  callerRole,
+  onActionSuccess,
+}: ParticipantListItemProps) {
+  const { t } = useTranslation('trips');
+  const [isRemoving, setIsRemoving] = useState(false);
+  const [isPromoting, setIsPromoting] = useState(false);
+  const [isDemoting, setIsDemoting] = useState(false);
+
+  const initials = participant.displayName
+    .split(' ')
+    .map((n) => n[0])
+    .join('')
+    .slice(0, 2)
+    .toUpperCase();
+
+  const isOrganizer = callerRole !== null && ORGANIZER_ROLES.includes(callerRole);
+  const isSelf = participant.userId === currentUserId;
+  const isTargetOrganizer = participant.role === TripRole.ORGANIZER;
+
+  const showActions = isOrganizer && !isSelf && !isTargetOrganizer;
+  const showPromote = showActions && participant.role === TripRole.PARTICIPANT;
+  const showDemote = showActions && participant.role === TripRole.CO_ORGANIZER;
+
+  async function handleRemove() {
+    setIsRemoving(true);
+    try {
+      await removeTripParticipant(tripId, participant.userId);
+      onActionSuccess();
+    } catch {
+      toast.error(t('participants.actions.removeError'));
+    } finally {
+      setIsRemoving(false);
+    }
+  }
+
+  async function handlePromote() {
+    setIsPromoting(true);
+    try {
+      await updateTripParticipantRole(tripId, participant.userId, { role: TripRole.CO_ORGANIZER });
+      onActionSuccess();
+    } catch {
+      toast.error(t('participants.actions.promoteError'));
+    } finally {
+      setIsPromoting(false);
+    }
+  }
+
+  async function handleDemote() {
+    setIsDemoting(true);
+    try {
+      await updateTripParticipantRole(tripId, participant.userId, { role: TripRole.PARTICIPANT });
+      onActionSuccess();
+    } catch {
+      toast.error(t('participants.actions.demoteError'));
+    } finally {
+      setIsDemoting(false);
+    }
+  }
+
+  return (
+    <li className="flex items-start gap-3 py-3 sm:items-center">
+      <Avatar
+        src={participant.avatarUrl ?? undefined}
+        alt={participant.displayName}
+        fallback={initials}
+        size="md"
+        className="mt-0.5 sm:mt-0"
+      />
+
+      <div className="min-w-0 flex-1 flex flex-col sm:flex-row sm:items-center sm:gap-3">
+        <div className="min-w-0 flex-1">
+          <p className="truncate text-sm font-medium">{participant.displayName}</p>
+          <p className="truncate text-xs text-muted-foreground">@{participant.username}</p>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-1 mt-1.5 sm:mt-0 sm:flex-nowrap sm:shrink-0">
+          <Badge variant={ROLE_VARIANT[participant.role]}>
+            {t(`participants.role.${participant.role}`)}
+          </Badge>
+
+          {participant.isTraveler && (
+            <Badge variant="outline" className="gap-1">
+              <AirplaneIcon className="size-3" aria-hidden="true" />
+              {t('participants.traveler')}
+            </Badge>
+          )}
+
+          {showActions && (
+            <div className="flex gap-1 ml-auto sm:ml-0.5 shrink-0">
+              {showPromote && (
+                <Button
+                  type="button"
+                  size="icon"
+                  variant="outline"
+                  onClick={() => void handlePromote()}
+                  disabled={isPromoting}
+                  title={t('participants.actions.promote')}
+                  aria-label={t('participants.actions.promote')}
+                >
+                  <ShieldStarIcon aria-hidden="true" />
+                </Button>
+              )}
+              {showDemote && (
+                <Button
+                  type="button"
+                  size="icon"
+                  variant="outline"
+                  onClick={() => void handleDemote()}
+                  disabled={isDemoting}
+                  title={t('participants.actions.demote')}
+                  aria-label={t('participants.actions.demote')}
+                >
+                  <UserMinusIcon aria-hidden="true" />
+                </Button>
+              )}
+              <DeleteConfirmButton onDelete={handleRemove} disabled={isRemoving} />
+            </div>
+          )}
+        </div>
+      </div>
+    </li>
+  );
+}

--- a/apps/web/src/components/trips/participants/ParticipantListItem.tsx
+++ b/apps/web/src/components/trips/participants/ParticipantListItem.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { TripRole } from '@chamuco/shared-types';
 import { AirplaneIcon, ShieldStarIcon, UserMinusIcon } from '@phosphor-icons/react';
+import { getInitials } from '@/lib/name-utils';
 import { Avatar } from '@/components/ui/avatar';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -39,13 +40,6 @@ export function ParticipantListItem({
   const [isRemoving, setIsRemoving] = useState(false);
   const [isPromoting, setIsPromoting] = useState(false);
   const [isDemoting, setIsDemoting] = useState(false);
-
-  const initials = participant.displayName
-    .split(' ')
-    .map((n) => n[0])
-    .join('')
-    .slice(0, 2)
-    .toUpperCase();
 
   const isOrganizer = callerRole !== null && ORGANIZER_ROLES.includes(callerRole);
   const isSelf = participant.userId === currentUserId;
@@ -96,7 +90,7 @@ export function ParticipantListItem({
       <Avatar
         src={participant.avatarUrl ?? undefined}
         alt={participant.displayName}
-        fallback={initials}
+        fallback={getInitials(participant.displayName)}
         size="md"
         className="mt-0.5 sm:mt-0"
       />

--- a/apps/web/src/components/trips/participants/ParticipantListItem.tsx
+++ b/apps/web/src/components/trips/participants/ParticipantListItem.tsx
@@ -2,15 +2,26 @@
 
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { TripRole } from '@chamuco/shared-types';
-import { AirplaneIcon, ShieldStarIcon, UserMinusIcon } from '@phosphor-icons/react';
+import { TripParticipantStatus, TripRole } from '@chamuco/shared-types';
+import {
+  AirplaneIcon,
+  CheckFatIcon,
+  QuestionMarkIcon,
+  ShieldStarIcon,
+  UserMinusIcon,
+} from '@phosphor-icons/react';
+import { cn } from '@/lib/utils';
 import { getInitials } from '@/lib/name-utils';
 import { Avatar } from '@/components/ui/avatar';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { DeleteConfirmButton } from '@/components/ui/delete-confirm-button';
 import { toast } from '@/components/ui/toast';
-import { removeTripParticipant, updateTripParticipantRole } from '@/services/trips.service';
+import {
+  removeTripParticipant,
+  toggleTripParticipantConfirmation,
+  updateTripParticipantRole,
+} from '@/services/trips.service';
 import type { TripParticipantResponse } from '@/services/trips.types';
 
 interface ParticipantListItemProps {
@@ -40,6 +51,7 @@ export function ParticipantListItem({
   const [isRemoving, setIsRemoving] = useState(false);
   const [isPromoting, setIsPromoting] = useState(false);
   const [isDemoting, setIsDemoting] = useState(false);
+  const [isToggling, setIsToggling] = useState(false);
 
   const isOrganizer = callerRole !== null && ORGANIZER_ROLES.includes(callerRole);
   const isSelf = participant.userId === currentUserId;
@@ -85,6 +97,18 @@ export function ParticipantListItem({
     }
   }
 
+  async function handleToggleConfirmation() {
+    setIsToggling(true);
+    try {
+      await toggleTripParticipantConfirmation(tripId, participant.userId);
+      onActionSuccess();
+    } catch {
+      toast.error(t('participants.actions.confirmError'));
+    } finally {
+      setIsToggling(false);
+    }
+  }
+
   return (
     <li className="flex items-start gap-3 py-3 sm:items-center">
       <Avatar
@@ -102,48 +126,85 @@ export function ParticipantListItem({
         </div>
 
         <div className="flex flex-wrap items-center gap-1 mt-1.5 sm:mt-0 sm:flex-nowrap sm:shrink-0">
-          <Badge variant={ROLE_VARIANT[participant.role]}>
-            {t(`participants.role.${participant.role}`)}
-          </Badge>
-
-          {participant.isTraveler && (
-            <Badge variant="outline" className="gap-1">
-              <AirplaneIcon className="size-3" aria-hidden="true" />
-              {t('participants.traveler')}
+          {participant.role !== TripRole.PARTICIPANT && (
+            <Badge variant={ROLE_VARIANT[participant.role]}>
+              {t(`participants.role.${participant.role}`)}
             </Badge>
           )}
 
-          {showActions && (
-            <div className="flex gap-1 ml-auto sm:ml-0.5 shrink-0">
-              {showPromote && (
-                <Button
-                  type="button"
-                  size="icon"
-                  variant="outline"
-                  onClick={() => void handlePromote()}
-                  disabled={isPromoting}
-                  title={t('participants.actions.promote')}
-                  aria-label={t('participants.actions.promote')}
-                >
-                  <ShieldStarIcon aria-hidden="true" />
-                </Button>
-              )}
-              {showDemote && (
-                <Button
-                  type="button"
-                  size="icon"
-                  variant="outline"
-                  onClick={() => void handleDemote()}
-                  disabled={isDemoting}
-                  title={t('participants.actions.demote')}
-                  aria-label={t('participants.actions.demote')}
-                >
-                  <UserMinusIcon aria-hidden="true" />
-                </Button>
-              )}
-              <DeleteConfirmButton onDelete={handleRemove} disabled={isRemoving} />
-            </div>
-          )}
+          {(participant.role === TripRole.ORGANIZER ||
+            participant.role === TripRole.CO_ORGANIZER) &&
+            participant.isTraveler && (
+              <Badge variant="outline" className="gap-1">
+                <AirplaneIcon className="size-3" aria-hidden="true" />
+                {t('participants.traveler')}
+              </Badge>
+            )}
+
+          <div className="flex gap-1 ml-auto sm:ml-0.5 shrink-0">
+            {isOrganizer && participant.role !== TripRole.ORGANIZER && (
+              <Button
+                type="button"
+                size="icon"
+                variant="ghost"
+                onClick={() => void handleToggleConfirmation()}
+                disabled={isToggling}
+                className={cn(
+                  participant.status === TripParticipantStatus.CONFIRMED
+                    ? 'text-green-600 hover:text-green-600'
+                    : 'text-orange-500 hover:text-orange-500',
+                )}
+                title={t(
+                  participant.status === TripParticipantStatus.CONFIRMED
+                    ? 'participants.actions.unconfirm'
+                    : 'participants.actions.confirm',
+                )}
+                aria-label={t(
+                  participant.status === TripParticipantStatus.CONFIRMED
+                    ? 'participants.actions.unconfirm'
+                    : 'participants.actions.confirm',
+                )}
+              >
+                {participant.status === TripParticipantStatus.CONFIRMED ? (
+                  <CheckFatIcon aria-hidden="true" weight="fill" />
+                ) : (
+                  <QuestionMarkIcon aria-hidden="true" weight="bold" />
+                )}
+              </Button>
+            )}
+
+            {showActions && (
+              <>
+                {showPromote && (
+                  <Button
+                    type="button"
+                    size="icon"
+                    variant="outline"
+                    onClick={() => void handlePromote()}
+                    disabled={isPromoting}
+                    title={t('participants.actions.promote')}
+                    aria-label={t('participants.actions.promote')}
+                  >
+                    <ShieldStarIcon aria-hidden="true" />
+                  </Button>
+                )}
+                {showDemote && (
+                  <Button
+                    type="button"
+                    size="icon"
+                    variant="outline"
+                    onClick={() => void handleDemote()}
+                    disabled={isDemoting}
+                    title={t('participants.actions.demote')}
+                    aria-label={t('participants.actions.demote')}
+                  >
+                    <UserMinusIcon aria-hidden="true" />
+                  </Button>
+                )}
+                <DeleteConfirmButton onDelete={handleRemove} disabled={isRemoving} />
+              </>
+            )}
+          </div>
         </div>
       </div>
     </li>

--- a/apps/web/src/components/trips/participants/PendingParticipantsPanel.test.tsx
+++ b/apps/web/src/components/trips/participants/PendingParticipantsPanel.test.tsx
@@ -7,6 +7,7 @@ const mocks = vi.hoisted(() => ({
   mockPatch: vi.fn(),
   mockDelete: vi.fn(),
   mockOnUpdate: vi.fn(),
+  mockToastError: vi.fn(),
 }));
 
 vi.mock('react-i18next', () => ({
@@ -19,6 +20,17 @@ vi.mock('react-i18next', () => ({
 vi.mock('@/services/api-client', () => ({
   apiClient: { patch: mocks.mockPatch, delete: mocks.mockDelete },
 }));
+
+vi.mock('@/components/ui/toast', () => ({
+  toast: { error: mocks.mockToastError },
+}));
+
+function makeAxios409() {
+  return Object.assign(new Error('409'), {
+    isAxiosError: true,
+    response: { status: 409 },
+  });
+}
 
 import { PendingParticipantsPanel } from './PendingParticipantsPanel';
 
@@ -181,6 +193,73 @@ describe('PendingParticipantsPanel', () => {
       );
       expect(screen.getByText('Request User')).toBeInTheDocument();
       expect(screen.getByText('Invited User')).toBeInTheDocument();
+    });
+  });
+
+  describe('error handling', () => {
+    it('shows capacityFull toast when accept fails with 409', async () => {
+      mocks.mockPatch.mockRejectedValueOnce(makeAxios409());
+      const user = userEvent.setup();
+      render(
+        <PendingParticipantsPanel
+          tripId={TRIP_ID}
+          items={[joinRequest]}
+          onUpdate={mocks.mockOnUpdate}
+        />,
+      );
+      await user.click(screen.getByRole('button', { name: 'participants.pending.accept' }));
+      await waitFor(() => {
+        expect(mocks.mockToastError).toHaveBeenCalledWith('participants.pending.capacityFull');
+      });
+      expect(mocks.mockOnUpdate).not.toHaveBeenCalled();
+    });
+
+    it('shows acceptError toast when accept fails with non-409', async () => {
+      mocks.mockPatch.mockRejectedValueOnce(new Error('fail'));
+      const user = userEvent.setup();
+      render(
+        <PendingParticipantsPanel
+          tripId={TRIP_ID}
+          items={[joinRequest]}
+          onUpdate={mocks.mockOnUpdate}
+        />,
+      );
+      await user.click(screen.getByRole('button', { name: 'participants.pending.accept' }));
+      await waitFor(() => {
+        expect(mocks.mockToastError).toHaveBeenCalledWith('participants.pending.acceptError');
+      });
+    });
+
+    it('shows rejectError toast when reject fails', async () => {
+      mocks.mockPatch.mockRejectedValueOnce(new Error('fail'));
+      const user = userEvent.setup();
+      render(
+        <PendingParticipantsPanel
+          tripId={TRIP_ID}
+          items={[joinRequest]}
+          onUpdate={mocks.mockOnUpdate}
+        />,
+      );
+      await user.click(screen.getByRole('button', { name: 'participants.pending.reject' }));
+      await waitFor(() => {
+        expect(mocks.mockToastError).toHaveBeenCalledWith('participants.pending.rejectError');
+      });
+    });
+
+    it('shows revokeError toast when revoke fails', async () => {
+      mocks.mockDelete.mockRejectedValueOnce(new Error('fail'));
+      const user = userEvent.setup();
+      render(
+        <PendingParticipantsPanel
+          tripId={TRIP_ID}
+          items={[invited]}
+          onUpdate={mocks.mockOnUpdate}
+        />,
+      );
+      await user.click(screen.getByRole('button', { name: 'participants.pending.revoke' }));
+      await waitFor(() => {
+        expect(mocks.mockToastError).toHaveBeenCalledWith('participants.pending.revokeError');
+      });
     });
   });
 });

--- a/apps/web/src/components/trips/participants/PendingParticipantsPanel.test.tsx
+++ b/apps/web/src/components/trips/participants/PendingParticipantsPanel.test.tsx
@@ -1,0 +1,186 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { TripParticipantStatus } from '@chamuco/shared-types';
+import type { PendingTripParticipantResponse } from '@/services/trips.types';
+
+const mocks = vi.hoisted(() => ({
+  mockPatch: vi.fn(),
+  mockDelete: vi.fn(),
+  mockOnUpdate: vi.fn(),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, unknown>) =>
+      opts ? `${key}:${JSON.stringify(opts)}` : key,
+  }),
+}));
+
+vi.mock('@/services/api-client', () => ({
+  apiClient: { patch: mocks.mockPatch, delete: mocks.mockDelete },
+}));
+
+import { PendingParticipantsPanel } from './PendingParticipantsPanel';
+
+const TRIP_ID = 'trip-1';
+
+const joinRequest: PendingTripParticipantResponse = {
+  userId: 'user-req',
+  username: 'req_user',
+  displayName: 'Request User',
+  avatarUrl: null,
+  status: TripParticipantStatus.PENDING_REQUEST,
+  initiatedAt: '2026-01-01T00:00:00.000Z',
+};
+
+const invited: PendingTripParticipantResponse = {
+  userId: 'user-inv',
+  username: 'inv_user',
+  displayName: 'Invited User',
+  avatarUrl: null,
+  status: TripParticipantStatus.INVITED,
+  initiatedAt: '2026-01-02T00:00:00.000Z',
+};
+
+describe('PendingParticipantsPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.mockPatch.mockResolvedValue({ data: {} });
+    mocks.mockDelete.mockResolvedValue({ data: {} });
+  });
+
+  describe('empty state', () => {
+    it('renders empty state when items is empty', () => {
+      render(
+        <PendingParticipantsPanel tripId={TRIP_ID} items={[]} onUpdate={mocks.mockOnUpdate} />,
+      );
+      expect(screen.getByText('participants.pending.noItems')).toBeInTheDocument();
+    });
+  });
+
+  describe('join request row', () => {
+    it('shows statusRequest badge for PENDING_REQUEST', () => {
+      render(
+        <PendingParticipantsPanel
+          tripId={TRIP_ID}
+          items={[joinRequest]}
+          onUpdate={mocks.mockOnUpdate}
+        />,
+      );
+      expect(screen.getByText('participants.pending.statusRequest')).toBeInTheDocument();
+    });
+
+    it('shows Accept and Reject buttons for PENDING_REQUEST', () => {
+      render(
+        <PendingParticipantsPanel
+          tripId={TRIP_ID}
+          items={[joinRequest]}
+          onUpdate={mocks.mockOnUpdate}
+        />,
+      );
+      expect(
+        screen.getByRole('button', { name: 'participants.pending.accept' }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: 'participants.pending.reject' }),
+      ).toBeInTheDocument();
+    });
+
+    it('calls PATCH accept and onUpdate when Accept clicked', async () => {
+      const user = userEvent.setup();
+      render(
+        <PendingParticipantsPanel
+          tripId={TRIP_ID}
+          items={[joinRequest]}
+          onUpdate={mocks.mockOnUpdate}
+        />,
+      );
+      await user.click(screen.getByRole('button', { name: 'participants.pending.accept' }));
+      await waitFor(() => {
+        expect(mocks.mockPatch).toHaveBeenCalledWith(
+          `/v1/trips/${TRIP_ID}/join-requests/${joinRequest.userId}/accept`,
+        );
+        expect(mocks.mockOnUpdate).toHaveBeenCalled();
+      });
+    });
+
+    it('calls PATCH reject and onUpdate when Reject clicked', async () => {
+      const user = userEvent.setup();
+      render(
+        <PendingParticipantsPanel
+          tripId={TRIP_ID}
+          items={[joinRequest]}
+          onUpdate={mocks.mockOnUpdate}
+        />,
+      );
+      await user.click(screen.getByRole('button', { name: 'participants.pending.reject' }));
+      await waitFor(() => {
+        expect(mocks.mockPatch).toHaveBeenCalledWith(
+          `/v1/trips/${TRIP_ID}/join-requests/${joinRequest.userId}/reject`,
+        );
+        expect(mocks.mockOnUpdate).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('invited row', () => {
+    it('shows statusInvited badge for INVITED', () => {
+      render(
+        <PendingParticipantsPanel
+          tripId={TRIP_ID}
+          items={[invited]}
+          onUpdate={mocks.mockOnUpdate}
+        />,
+      );
+      expect(screen.getByText('participants.pending.statusInvited')).toBeInTheDocument();
+    });
+
+    it('shows only Revoke button for INVITED', () => {
+      render(
+        <PendingParticipantsPanel
+          tripId={TRIP_ID}
+          items={[invited]}
+          onUpdate={mocks.mockOnUpdate}
+        />,
+      );
+      expect(
+        screen.getByRole('button', { name: 'participants.pending.revoke' }),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: 'participants.pending.accept' }),
+      ).not.toBeInTheDocument();
+    });
+
+    it('calls DELETE and onUpdate when Revoke clicked', async () => {
+      const user = userEvent.setup();
+      render(
+        <PendingParticipantsPanel
+          tripId={TRIP_ID}
+          items={[invited]}
+          onUpdate={mocks.mockOnUpdate}
+        />,
+      );
+      await user.click(screen.getByRole('button', { name: 'participants.pending.revoke' }));
+      await waitFor(() => {
+        expect(mocks.mockDelete).toHaveBeenCalledWith(
+          `/v1/trips/${TRIP_ID}/invitations/${invited.userId}`,
+        );
+        expect(mocks.mockOnUpdate).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('mixed items', () => {
+    it('renders both request and invited rows', () => {
+      render(
+        <PendingParticipantsPanel
+          tripId={TRIP_ID}
+          items={[joinRequest, invited]}
+          onUpdate={mocks.mockOnUpdate}
+        />,
+      );
+      expect(screen.getByText('Request User')).toBeInTheDocument();
+      expect(screen.getByText('Invited User')).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/src/components/trips/participants/PendingParticipantsPanel.tsx
+++ b/apps/web/src/components/trips/participants/PendingParticipantsPanel.tsx
@@ -1,0 +1,119 @@
+'use client';
+
+import { useTranslation } from 'react-i18next';
+import { TripParticipantStatus } from '@chamuco/shared-types';
+import { Avatar } from '@/components/ui/avatar';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  acceptJoinRequest,
+  rejectJoinRequest,
+  revokeTripInvitation,
+} from '@/services/trips.service';
+import type { PendingTripParticipantResponse } from '@/services/trips.types';
+
+interface PendingParticipantsPanelProps {
+  tripId: string;
+  items: PendingTripParticipantResponse[];
+  onUpdate: () => void;
+}
+
+export function PendingParticipantsPanel({
+  tripId,
+  items,
+  onUpdate,
+}: PendingParticipantsPanelProps) {
+  const { t } = useTranslation('trips');
+
+  const handleAccept = async (userId: string) => {
+    await acceptJoinRequest(tripId, userId);
+    onUpdate();
+  };
+
+  const handleReject = async (userId: string) => {
+    await rejectJoinRequest(tripId, userId);
+    onUpdate();
+  };
+
+  const handleRevoke = async (userId: string) => {
+    await revokeTripInvitation(tripId, userId);
+    onUpdate();
+  };
+
+  if (items.length === 0) {
+    return (
+      <div className="rounded-xl border border-border p-4">
+        <p className="text-sm font-semibold mb-3">
+          {t('participants.pending.title', { count: 0 })}
+        </p>
+        <p className="text-sm text-muted-foreground">{t('participants.pending.noItems')}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-xl border border-border p-4">
+      <p className="text-sm font-semibold mb-3">
+        {t('participants.pending.title', { count: items.length })}
+      </p>
+
+      <ul className="divide-y divide-border">
+        {items.map((item) => {
+          const initials = item.displayName
+            .split(' ')
+            .map((n) => n[0])
+            .join('')
+            .slice(0, 2)
+            .toUpperCase();
+
+          return (
+            <li key={item.userId} className="flex items-center gap-3 py-3">
+              <Avatar
+                src={item.avatarUrl ?? undefined}
+                alt={item.displayName}
+                fallback={initials}
+                size="sm"
+              />
+
+              <div className="min-w-0 flex-1">
+                <p className="truncate text-sm font-medium">{item.displayName}</p>
+                <p className="truncate text-xs text-muted-foreground">@{item.username}</p>
+              </div>
+
+              <Badge variant="outline" className="shrink-0">
+                {item.status === TripParticipantStatus.PENDING_REQUEST
+                  ? t('participants.pending.statusRequest')
+                  : t('participants.pending.statusInvited')}
+              </Badge>
+
+              <div className="flex shrink-0 gap-1.5">
+                {item.status === TripParticipantStatus.PENDING_REQUEST ? (
+                  <>
+                    <Button size="xs" onClick={() => void handleAccept(item.userId)}>
+                      {t('participants.pending.accept')}
+                    </Button>
+                    <Button
+                      size="xs"
+                      variant="destructive"
+                      onClick={() => void handleReject(item.userId)}
+                    >
+                      {t('participants.pending.reject')}
+                    </Button>
+                  </>
+                ) : (
+                  <Button
+                    size="xs"
+                    variant="destructive"
+                    onClick={() => void handleRevoke(item.userId)}
+                  >
+                    {t('participants.pending.revoke')}
+                  </Button>
+                )}
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/apps/web/src/components/trips/participants/PendingParticipantsPanel.tsx
+++ b/apps/web/src/components/trips/participants/PendingParticipantsPanel.tsx
@@ -1,10 +1,13 @@
 'use client';
 
 import { useTranslation } from 'react-i18next';
+import axios from 'axios';
 import { TripParticipantStatus } from '@chamuco/shared-types';
 import { Avatar } from '@/components/ui/avatar';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { toast } from '@/components/ui/toast';
+import { getInitials } from '@/lib/name-utils';
 import {
   acceptJoinRequest,
   rejectJoinRequest,
@@ -26,18 +29,34 @@ export function PendingParticipantsPanel({
   const { t } = useTranslation('trips');
 
   const handleAccept = async (userId: string) => {
-    await acceptJoinRequest(tripId, userId);
-    onUpdate();
+    try {
+      await acceptJoinRequest(tripId, userId);
+      onUpdate();
+    } catch (err) {
+      const message =
+        axios.isAxiosError(err) && err.response?.status === 409
+          ? t('participants.pending.capacityFull')
+          : t('participants.pending.acceptError');
+      toast.error(message);
+    }
   };
 
   const handleReject = async (userId: string) => {
-    await rejectJoinRequest(tripId, userId);
-    onUpdate();
+    try {
+      await rejectJoinRequest(tripId, userId);
+      onUpdate();
+    } catch {
+      toast.error(t('participants.pending.rejectError'));
+    }
   };
 
   const handleRevoke = async (userId: string) => {
-    await revokeTripInvitation(tripId, userId);
-    onUpdate();
+    try {
+      await revokeTripInvitation(tripId, userId);
+      onUpdate();
+    } catch {
+      toast.error(t('participants.pending.revokeError'));
+    }
   };
 
   if (items.length === 0) {
@@ -58,61 +77,52 @@ export function PendingParticipantsPanel({
       </p>
 
       <ul className="divide-y divide-border">
-        {items.map((item) => {
-          const initials = item.displayName
-            .split(' ')
-            .map((n) => n[0])
-            .join('')
-            .slice(0, 2)
-            .toUpperCase();
+        {items.map((item) => (
+          <li key={item.userId} className="flex items-center gap-3 py-3">
+            <Avatar
+              src={item.avatarUrl ?? undefined}
+              alt={item.displayName}
+              fallback={getInitials(item.displayName)}
+              size="sm"
+            />
 
-          return (
-            <li key={item.userId} className="flex items-center gap-3 py-3">
-              <Avatar
-                src={item.avatarUrl ?? undefined}
-                alt={item.displayName}
-                fallback={initials}
-                size="sm"
-              />
+            <div className="min-w-0 flex-1">
+              <p className="truncate text-sm font-medium">{item.displayName}</p>
+              <p className="truncate text-xs text-muted-foreground">@{item.username}</p>
+            </div>
 
-              <div className="min-w-0 flex-1">
-                <p className="truncate text-sm font-medium">{item.displayName}</p>
-                <p className="truncate text-xs text-muted-foreground">@{item.username}</p>
-              </div>
+            <Badge variant="outline" className="shrink-0">
+              {item.status === TripParticipantStatus.PENDING_REQUEST
+                ? t('participants.pending.statusRequest')
+                : t('participants.pending.statusInvited')}
+            </Badge>
 
-              <Badge variant="outline" className="shrink-0">
-                {item.status === TripParticipantStatus.PENDING_REQUEST
-                  ? t('participants.pending.statusRequest')
-                  : t('participants.pending.statusInvited')}
-              </Badge>
-
-              <div className="flex shrink-0 gap-1.5">
-                {item.status === TripParticipantStatus.PENDING_REQUEST ? (
-                  <>
-                    <Button size="xs" onClick={() => void handleAccept(item.userId)}>
-                      {t('participants.pending.accept')}
-                    </Button>
-                    <Button
-                      size="xs"
-                      variant="destructive"
-                      onClick={() => void handleReject(item.userId)}
-                    >
-                      {t('participants.pending.reject')}
-                    </Button>
-                  </>
-                ) : (
+            <div className="flex shrink-0 gap-1.5">
+              {item.status === TripParticipantStatus.PENDING_REQUEST ? (
+                <>
+                  <Button size="xs" onClick={() => void handleAccept(item.userId)}>
+                    {t('participants.pending.accept')}
+                  </Button>
                   <Button
                     size="xs"
                     variant="destructive"
-                    onClick={() => void handleRevoke(item.userId)}
+                    onClick={() => void handleReject(item.userId)}
                   >
-                    {t('participants.pending.revoke')}
+                    {t('participants.pending.reject')}
                   </Button>
-                )}
-              </div>
-            </li>
-          );
-        })}
+                </>
+              ) : (
+                <Button
+                  size="xs"
+                  variant="destructive"
+                  onClick={() => void handleRevoke(item.userId)}
+                >
+                  {t('participants.pending.revoke')}
+                </Button>
+              )}
+            </div>
+          </li>
+        ))}
       </ul>
     </div>
   );

--- a/apps/web/src/components/trips/participants/TripInvitationResponseButtons.test.tsx
+++ b/apps/web/src/components/trips/participants/TripInvitationResponseButtons.test.tsx
@@ -1,0 +1,99 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+const mocks = vi.hoisted(() => ({
+  mockPatch: vi.fn(),
+  mockOnSuccess: vi.fn(),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('@/services/api-client', () => ({
+  apiClient: { patch: mocks.mockPatch },
+}));
+
+import { TripInvitationResponseButtons } from './TripInvitationResponseButtons';
+
+describe('TripInvitationResponseButtons', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.mockPatch.mockResolvedValue({ data: {} });
+  });
+
+  it('renders accept and decline buttons', () => {
+    render(<TripInvitationResponseButtons tripId="t1" onSuccess={mocks.mockOnSuccess} />);
+    expect(screen.getByRole('button', { name: 'common:actions.accept' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'common:actions.decline' })).toBeInTheDocument();
+  });
+
+  it('shows received message by default', () => {
+    render(<TripInvitationResponseButtons tripId="t1" onSuccess={mocks.mockOnSuccess} />);
+    expect(screen.getByText('participants.invitation.received')).toBeInTheDocument();
+  });
+
+  it('hides received message when showMessage is false', () => {
+    render(
+      <TripInvitationResponseButtons
+        tripId="t1"
+        onSuccess={mocks.mockOnSuccess}
+        showMessage={false}
+      />,
+    );
+    expect(screen.queryByText('participants.invitation.received')).not.toBeInTheDocument();
+  });
+
+  it('calls PATCH accept and onSuccess when accept clicked', async () => {
+    const user = userEvent.setup();
+    render(<TripInvitationResponseButtons tripId="t1" onSuccess={mocks.mockOnSuccess} />);
+    await user.click(screen.getByRole('button', { name: 'common:actions.accept' }));
+    await waitFor(() => {
+      expect(mocks.mockPatch).toHaveBeenCalledWith('/v1/trips/t1/invitations/accept');
+      expect(mocks.mockOnSuccess).toHaveBeenCalled();
+    });
+  });
+
+  it('calls PATCH decline and onSuccess when decline clicked', async () => {
+    const user = userEvent.setup();
+    render(<TripInvitationResponseButtons tripId="t1" onSuccess={mocks.mockOnSuccess} />);
+    await user.click(screen.getByRole('button', { name: 'common:actions.decline' }));
+    await waitFor(() => {
+      expect(mocks.mockPatch).toHaveBeenCalledWith('/v1/trips/t1/invitations/decline');
+      expect(mocks.mockOnSuccess).toHaveBeenCalled();
+    });
+  });
+
+  it('shows acceptError on accept failure', async () => {
+    mocks.mockPatch.mockRejectedValueOnce(new Error('fail'));
+    const user = userEvent.setup();
+    render(<TripInvitationResponseButtons tripId="t1" onSuccess={mocks.mockOnSuccess} />);
+    await user.click(screen.getByRole('button', { name: 'common:actions.accept' }));
+    await waitFor(() => {
+      expect(screen.getByText('participants.invitation.acceptError')).toBeInTheDocument();
+    });
+  });
+
+  it('shows declineError on decline failure', async () => {
+    mocks.mockPatch.mockRejectedValueOnce(new Error('fail'));
+    const user = userEvent.setup();
+    render(<TripInvitationResponseButtons tripId="t1" onSuccess={mocks.mockOnSuccess} />);
+    await user.click(screen.getByRole('button', { name: 'common:actions.decline' }));
+    await waitFor(() => {
+      expect(screen.getByText('participants.invitation.declineError')).toBeInTheDocument();
+    });
+  });
+
+  it('disables both buttons while accepting', async () => {
+    let resolve!: () => void;
+    mocks.mockPatch.mockReturnValueOnce(new Promise<void>((r) => (resolve = r)));
+
+    const user = userEvent.setup();
+    render(<TripInvitationResponseButtons tripId="t1" onSuccess={mocks.mockOnSuccess} />);
+    await user.click(screen.getByRole('button', { name: 'common:actions.accept' }));
+
+    expect(screen.getByRole('button', { name: 'common:actions.accept' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'common:actions.decline' })).toBeDisabled();
+    resolve();
+  });
+});

--- a/apps/web/src/components/trips/participants/TripInvitationResponseButtons.tsx
+++ b/apps/web/src/components/trips/participants/TripInvitationResponseButtons.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { CheckIcon, XIcon } from '@phosphor-icons/react';
+import { acceptTripInvitation, declineTripInvitation } from '@/services/trips.service';
+import { Button } from '@/components/ui/button';
+
+interface TripInvitationResponseButtonsProps {
+  tripId: string;
+  onSuccess: () => void;
+  showMessage?: boolean;
+}
+
+export function TripInvitationResponseButtons({
+  tripId,
+  onSuccess,
+  showMessage = true,
+}: TripInvitationResponseButtonsProps) {
+  const { t } = useTranslation(['trips', 'common']);
+  const [isAccepting, setIsAccepting] = useState(false);
+  const [isDeclining, setIsDeclining] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const isBusy = isAccepting || isDeclining;
+
+  const handleAccept = async () => {
+    setIsAccepting(true);
+    setError(null);
+    try {
+      await acceptTripInvitation(tripId);
+      onSuccess();
+    } catch {
+      setError(t('participants.invitation.acceptError'));
+      setIsAccepting(false);
+    }
+  };
+
+  const handleDecline = async () => {
+    setIsDeclining(true);
+    setError(null);
+    try {
+      await declineTripInvitation(tripId);
+      onSuccess();
+    } catch {
+      setError(t('participants.invitation.declineError'));
+      setIsDeclining(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col items-end gap-2">
+      {showMessage && (
+        <p className="text-sm text-muted-foreground">{t('participants.invitation.received')}</p>
+      )}
+      <div className="flex gap-2">
+        <Button
+          size="icon"
+          onClick={handleAccept}
+          disabled={isBusy}
+          title={t('common:actions.accept')}
+          aria-label={t('common:actions.accept')}
+        >
+          <CheckIcon aria-hidden="true" />
+        </Button>
+        <Button
+          variant="outline"
+          size="icon"
+          onClick={handleDecline}
+          disabled={isBusy}
+          title={t('common:actions.decline')}
+          aria-label={t('common:actions.decline')}
+        >
+          <XIcon aria-hidden="true" />
+        </Button>
+      </div>
+      {error && <p className="text-xs text-destructive">{error}</p>}
+    </div>
+  );
+}

--- a/apps/web/src/locales/en/trips.json
+++ b/apps/web/src/locales/en/trips.json
@@ -74,9 +74,12 @@
       "remove": "Remove participant",
       "promote": "Promote to co-organizer",
       "demote": "Demote to participant",
+      "confirm": "Confirm attendance",
+      "unconfirm": "Mark as not confirmed",
       "removeError": "Failed to remove participant",
       "promoteError": "Failed to promote participant",
-      "demoteError": "Failed to demote participant"
+      "demoteError": "Failed to demote participant",
+      "confirmError": "Failed to update confirmation"
     },
     "role": {
       "ORGANIZER": "Organizer",
@@ -85,6 +88,10 @@
     },
     "traveler": "Traveling",
     "notTraveler": "Not traveling",
+    "sections": {
+      "confirmed": "Confirmed ({{count}})",
+      "pendingConfirmation": "Pending confirmation ({{count}})"
+    },
     "empty": "No participants yet",
     "loading": "Loading participants...",
     "loadError": "Failed to load participants"

--- a/apps/web/src/locales/en/trips.json
+++ b/apps/web/src/locales/en/trips.json
@@ -5,7 +5,85 @@
   "upcomingTrips": "Upcoming Trips",
   "pastTrips": "Past Trips",
   "tripDetails": "Trip Details",
-  "participants": "Participants",
+  "participants": {
+    "title": "Participants",
+    "capacity": "{{confirmed}} / {{total}} participants",
+    "invite": {
+      "button": "Invite",
+      "title": "Invite participants",
+      "usernamePlaceholder": "Search by name or @username",
+      "submit": "Send invitations",
+      "sending": "Sending...",
+      "cancel": "Cancel",
+      "success": "Invitation sent",
+      "error": "Failed to send invitation",
+      "noResults": "No users found",
+      "removeUser": "Remove {{username}}",
+      "alreadyExcluded": "This user is already a participant or has a pending invitation",
+      "maxUsers": "You can invite up to 20 users at once",
+      "done": "Done",
+      "results": { "title": "Invitation results" },
+      "result": {
+        "INVITED": "Invited successfully",
+        "ALREADY_MEMBER": "Already a participant",
+        "ALREADY_INVITED": "Already invited",
+        "HAS_PENDING_REQUEST": "Has a pending join request",
+        "NOT_FOUND": "User not found"
+      }
+    },
+    "joinRequest": {
+      "button": "Request to join",
+      "requesting": "Requesting...",
+      "success": "Join request sent",
+      "error": "Failed to send request",
+      "withdraw": "Withdraw request",
+      "withdrawing": "Withdrawing...",
+      "withdrawSuccess": "Request withdrawn",
+      "withdrawError": "Failed to withdraw request"
+    },
+    "leave": {
+      "button": "Leave trip",
+      "confirm": "Are you sure you want to leave this trip?",
+      "cancel": "Cancel",
+      "confirmButton": "Leave trip",
+      "leaving": "Leaving...",
+      "success": "You have left the trip",
+      "error": "Failed to leave trip",
+      "lastOrganizer": "You are the last organizer. Transfer the role before leaving."
+    },
+    "invitation": {
+      "received": "You have been invited to join this trip",
+      "acceptError": "Failed to accept invitation",
+      "declineError": "Failed to decline invitation"
+    },
+    "pending": {
+      "title": "Pending ({{count}})",
+      "noItems": "No pending requests or invitations",
+      "accept": "Accept",
+      "reject": "Reject",
+      "revoke": "Revoke",
+      "statusRequest": "Wants to join",
+      "statusInvited": "Invited"
+    },
+    "actions": {
+      "remove": "Remove participant",
+      "promote": "Promote to co-organizer",
+      "demote": "Demote to participant",
+      "removeError": "Failed to remove participant",
+      "promoteError": "Failed to promote participant",
+      "demoteError": "Failed to demote participant"
+    },
+    "role": {
+      "ORGANIZER": "Organizer",
+      "CO_ORGANIZER": "Co-organizer",
+      "PARTICIPANT": "Participant"
+    },
+    "traveler": "Traveling",
+    "notTraveler": "Not traveling",
+    "empty": "No participants yet",
+    "loading": "Loading participants...",
+    "loadError": "Failed to load participants"
+  },
   "itinerary": "Itinerary",
   "budget": "Budget",
   "expenses": "Expenses",
@@ -90,6 +168,9 @@
     "forbidden": "You don't have permission to perform this action.",
     "cannotMakePublic": "A private trip cannot be made public.",
     "coverUploadFailed": "Trip created. Cover upload failed — you can update it later."
+  },
+  "invitations": {
+    "titleWithCount": "Trip Invitations ({{count}})"
   },
   "announcements": "Announcements",
   "announcementsPublish": "Publish announcement",

--- a/apps/web/src/locales/en/trips.json
+++ b/apps/web/src/locales/en/trips.json
@@ -7,7 +7,7 @@
   "tripDetails": "Trip Details",
   "participants": {
     "title": "Participants",
-    "capacity": "{{confirmed}} / {{total}} participants",
+    "capacity": "{{active}} / {{total}} participants",
     "invite": {
       "button": "Invite",
       "title": "Invite participants",

--- a/apps/web/src/locales/en/trips.json
+++ b/apps/web/src/locales/en/trips.json
@@ -36,6 +36,7 @@
       "requesting": "Requesting...",
       "success": "Join request sent",
       "error": "Failed to send request",
+      "capacityFull": "Trip is at full capacity",
       "withdraw": "Withdraw request",
       "withdrawing": "Withdrawing...",
       "withdrawSuccess": "Request withdrawn",
@@ -63,7 +64,11 @@
       "reject": "Reject",
       "revoke": "Revoke",
       "statusRequest": "Wants to join",
-      "statusInvited": "Invited"
+      "statusInvited": "Invited",
+      "capacityFull": "Trip is at full capacity",
+      "acceptError": "Failed to accept request",
+      "rejectError": "Failed to reject request",
+      "revokeError": "Failed to revoke invitation"
     },
     "actions": {
       "remove": "Remove participant",

--- a/apps/web/src/locales/es/trips.json
+++ b/apps/web/src/locales/es/trips.json
@@ -74,9 +74,12 @@
       "remove": "Eliminar participante",
       "promote": "Promover a co-organizador",
       "demote": "Degradar a participante",
+      "confirm": "Confirmar asistencia",
+      "unconfirm": "Marcar como no confirmado",
       "removeError": "Error al eliminar al participante",
       "promoteError": "Error al promover al participante",
-      "demoteError": "Error al degradar al participante"
+      "demoteError": "Error al degradar al participante",
+      "confirmError": "Error al actualizar la confirmación"
     },
     "role": {
       "ORGANIZER": "Organizador",
@@ -85,6 +88,10 @@
     },
     "traveler": "Viajando",
     "notTraveler": "No viaja",
+    "sections": {
+      "confirmed": "Confirmados ({{count}})",
+      "pendingConfirmation": "Por confirmar ({{count}})"
+    },
     "empty": "Aún no hay participantes",
     "loading": "Cargando participantes...",
     "loadError": "Error al cargar los participantes"

--- a/apps/web/src/locales/es/trips.json
+++ b/apps/web/src/locales/es/trips.json
@@ -5,7 +5,85 @@
   "upcomingTrips": "Próximos Viajes",
   "pastTrips": "Viajes Pasados",
   "tripDetails": "Detalles del Viaje",
-  "participants": "Participantes",
+  "participants": {
+    "title": "Participantes",
+    "capacity": "{{confirmed}} / {{total}} participantes",
+    "invite": {
+      "button": "Invitar",
+      "title": "Invitar participantes",
+      "usernamePlaceholder": "Buscar por nombre o @usuario",
+      "submit": "Enviar invitaciones",
+      "sending": "Enviando...",
+      "cancel": "Cancelar",
+      "success": "Invitación enviada",
+      "error": "Error al enviar la invitación",
+      "noResults": "No se encontraron usuarios",
+      "removeUser": "Eliminar {{username}}",
+      "alreadyExcluded": "Este usuario ya es participante o tiene una invitación pendiente",
+      "maxUsers": "Puedes invitar hasta 20 usuarios a la vez",
+      "done": "Listo",
+      "results": { "title": "Resultados de invitación" },
+      "result": {
+        "INVITED": "Invitado exitosamente",
+        "ALREADY_MEMBER": "Ya es participante",
+        "ALREADY_INVITED": "Ya fue invitado",
+        "HAS_PENDING_REQUEST": "Tiene una solicitud pendiente",
+        "NOT_FOUND": "Usuario no encontrado"
+      }
+    },
+    "joinRequest": {
+      "button": "Solicitar unirse",
+      "requesting": "Solicitando...",
+      "success": "Solicitud enviada",
+      "error": "Error al enviar la solicitud",
+      "withdraw": "Retirar solicitud",
+      "withdrawing": "Retirando...",
+      "withdrawSuccess": "Solicitud retirada",
+      "withdrawError": "Error al retirar la solicitud"
+    },
+    "leave": {
+      "button": "Salir del viaje",
+      "confirm": "¿Estás seguro de que quieres salir de este viaje?",
+      "cancel": "Cancelar",
+      "confirmButton": "Salir del viaje",
+      "leaving": "Saliendo...",
+      "success": "Has salido del viaje",
+      "error": "Error al salir del viaje",
+      "lastOrganizer": "Eres el último organizador. Transfiere el rol antes de salir."
+    },
+    "invitation": {
+      "received": "Has sido invitado a unirte a este viaje",
+      "acceptError": "Error al aceptar la invitación",
+      "declineError": "Error al rechazar la invitación"
+    },
+    "pending": {
+      "title": "Pendientes ({{count}})",
+      "noItems": "No hay solicitudes ni invitaciones pendientes",
+      "accept": "Aceptar",
+      "reject": "Rechazar",
+      "revoke": "Revocar",
+      "statusRequest": "Quiere unirse",
+      "statusInvited": "Invitado"
+    },
+    "actions": {
+      "remove": "Eliminar participante",
+      "promote": "Promover a co-organizador",
+      "demote": "Degradar a participante",
+      "removeError": "Error al eliminar al participante",
+      "promoteError": "Error al promover al participante",
+      "demoteError": "Error al degradar al participante"
+    },
+    "role": {
+      "ORGANIZER": "Organizador",
+      "CO_ORGANIZER": "Co-organizador",
+      "PARTICIPANT": "Participante"
+    },
+    "traveler": "Viajando",
+    "notTraveler": "No viaja",
+    "empty": "Aún no hay participantes",
+    "loading": "Cargando participantes...",
+    "loadError": "Error al cargar los participantes"
+  },
   "itinerary": "Itinerario",
   "budget": "Presupuesto",
   "expenses": "Gastos",
@@ -90,6 +168,9 @@
     "forbidden": "No tienes permiso para realizar esta acción.",
     "cannotMakePublic": "Un viaje privado no puede hacerse público.",
     "coverUploadFailed": "Viaje creado. Error al subir la portada — puedes actualizarla más tarde."
+  },
+  "invitations": {
+    "titleWithCount": "Invitaciones a viajes ({{count}})"
   },
   "announcements": "Anuncios",
   "announcementsPublish": "Publicar anuncio",

--- a/apps/web/src/locales/es/trips.json
+++ b/apps/web/src/locales/es/trips.json
@@ -36,6 +36,7 @@
       "requesting": "Solicitando...",
       "success": "Solicitud enviada",
       "error": "Error al enviar la solicitud",
+      "capacityFull": "El viaje está al máximo de capacidad",
       "withdraw": "Retirar solicitud",
       "withdrawing": "Retirando...",
       "withdrawSuccess": "Solicitud retirada",
@@ -63,7 +64,11 @@
       "reject": "Rechazar",
       "revoke": "Revocar",
       "statusRequest": "Quiere unirse",
-      "statusInvited": "Invitado"
+      "statusInvited": "Invitado",
+      "capacityFull": "El viaje está al máximo de capacidad",
+      "acceptError": "Error al aceptar la solicitud",
+      "rejectError": "Error al rechazar la solicitud",
+      "revokeError": "Error al revocar la invitación"
     },
     "actions": {
       "remove": "Eliminar participante",

--- a/apps/web/src/locales/es/trips.json
+++ b/apps/web/src/locales/es/trips.json
@@ -7,7 +7,7 @@
   "tripDetails": "Detalles del Viaje",
   "participants": {
     "title": "Participantes",
-    "capacity": "{{confirmed}} / {{total}} participantes",
+    "capacity": "{{active}} / {{total}} participantes",
     "invite": {
       "button": "Invitar",
       "title": "Invitar participantes",

--- a/apps/web/src/services/trips.service.ts
+++ b/apps/web/src/services/trips.service.ts
@@ -1,18 +1,25 @@
+import type { BulkInvitationResponse } from '@chamuco/shared-types';
+
 import { apiClient } from '@/services/api-client';
 
 import type {
   AddTripGroupPayload,
   CreateDestinationPayload,
+  CreateTripInvitationPayload,
   CreateTripPayload,
   DestinationResponse,
   DestinationWriteResponse,
+  MyTripInvitationResponse,
   MyTripListItemResponse,
+  MyTripParticipationResponse,
+  PendingTripParticipantResponse,
   ReorderDestinationsPayload,
   TransitionTripStatusPayload,
   TripGroupResponse,
   TripParticipantResponse,
   TripResponse,
   UpdateDestinationPayload,
+  UpdateParticipantRolePayload,
   UpdateTripPayload,
 } from '@/services/trips.types';
 
@@ -52,8 +59,10 @@ export async function transitionTripStatus(
   return data;
 }
 
-export async function getTripParticipation(id: string): Promise<TripParticipantResponse> {
-  const { data } = await apiClient.get<TripParticipantResponse>(`/v1/trips/${id}/participants/me`);
+export async function getTripParticipation(id: string): Promise<MyTripParticipationResponse> {
+  const { data } = await apiClient.get<MyTripParticipationResponse>(
+    `/v1/trips/${id}/participants/me`,
+  );
   return data;
 }
 
@@ -100,6 +109,84 @@ export async function updateTripDestination(
 
 export async function deleteTripDestination(id: string, destId: string): Promise<void> {
   await apiClient.delete(`/v1/trips/${id}/destinations/${destId}`);
+}
+
+// ─── Participant methods ──────────────────────────────────────────────────────
+
+export async function getTripParticipants(id: string): Promise<TripParticipantResponse[]> {
+  const { data } = await apiClient.get<TripParticipantResponse[]>(`/v1/trips/${id}/participants`);
+  return data;
+}
+
+export async function getPendingTripParticipants(
+  id: string,
+): Promise<PendingTripParticipantResponse[]> {
+  const { data } = await apiClient.get<PendingTripParticipantResponse[]>(
+    `/v1/trips/${id}/participants/pending`,
+  );
+  return data;
+}
+
+export async function updateTripParticipantRole(
+  id: string,
+  userId: string,
+  payload: UpdateParticipantRolePayload,
+): Promise<void> {
+  await apiClient.patch(`/v1/trips/${id}/participants/${userId}/role`, payload);
+}
+
+export async function removeTripParticipant(id: string, userId: string): Promise<void> {
+  await apiClient.delete(`/v1/trips/${id}/participants/${userId}`);
+}
+
+// ─── Global invitation methods ────────────────────────────────────────────────
+
+export async function getMyTripInvitations(): Promise<MyTripInvitationResponse[]> {
+  const { data } = await apiClient.get<MyTripInvitationResponse[]>('/v1/trips/invitations');
+  return data;
+}
+
+// ─── Trip invitation methods ──────────────────────────────────────────────────
+
+export async function inviteTripParticipants(
+  id: string,
+  payload: CreateTripInvitationPayload,
+): Promise<BulkInvitationResponse> {
+  const { data } = await apiClient.post<BulkInvitationResponse>(
+    `/v1/trips/${id}/invitations`,
+    payload,
+  );
+  return data;
+}
+
+export async function acceptTripInvitation(id: string): Promise<void> {
+  await apiClient.patch(`/v1/trips/${id}/invitations/accept`);
+}
+
+export async function declineTripInvitation(id: string): Promise<void> {
+  await apiClient.patch(`/v1/trips/${id}/invitations/decline`);
+}
+
+export async function revokeTripInvitation(id: string, userId: string): Promise<void> {
+  await apiClient.delete(`/v1/trips/${id}/invitations/${userId}`);
+}
+
+// ─── Trip join request methods ────────────────────────────────────────────────
+
+export async function submitJoinRequest(id: string): Promise<void> {
+  await apiClient.post(`/v1/trips/${id}/join-request`);
+}
+
+export async function withdrawJoinRequest(id: string): Promise<void> {
+  await apiClient.delete(`/v1/trips/${id}/join-request`);
+}
+
+export async function acceptJoinRequest(id: string, userId: string): Promise<void> {
+  await apiClient.patch(`/v1/trips/${id}/join-requests/${userId}/accept`);
+}
+
+export async function rejectJoinRequest(id: string, userId: string): Promise<void> {
+  await apiClient.patch(`/v1/trips/${id}/join-requests/${userId}/reject`);
 }
 
 // ─── Group methods ────────────────────────────────────────────────────────────

--- a/apps/web/src/services/trips.service.ts
+++ b/apps/web/src/services/trips.service.ts
@@ -181,6 +181,10 @@ export async function withdrawJoinRequest(id: string): Promise<void> {
   await apiClient.delete(`/v1/trips/${id}/join-request`);
 }
 
+export async function toggleTripParticipantConfirmation(id: string, userId: string): Promise<void> {
+  await apiClient.patch(`/v1/trips/${id}/participants/${userId}/confirmation`);
+}
+
 export async function acceptJoinRequest(id: string, userId: string): Promise<void> {
   await apiClient.patch(`/v1/trips/${id}/join-requests/${userId}/accept`);
 }

--- a/apps/web/src/services/trips.types.ts
+++ b/apps/web/src/services/trips.types.ts
@@ -1,4 +1,9 @@
-import type { TripRole, TripStatus, TripVisibility } from '@chamuco/shared-types';
+import type {
+  TripParticipantStatus,
+  TripRole,
+  TripStatus,
+  TripVisibility,
+} from '@chamuco/shared-types';
 
 // Mirrors the NestJS DTOs in apps/api/src/modules/trips/dto/.
 // When the backend adds or removes fields, update this file to match.
@@ -130,4 +135,36 @@ export interface TripParticipantResponse {
   role: TripRole;
   isTraveler: boolean;
   confirmedAt: string | null;
+}
+
+export interface PendingTripParticipantResponse {
+  userId: string;
+  username: string;
+  displayName: string;
+  avatarUrl: string | null;
+  status: TripParticipantStatus.INVITED | TripParticipantStatus.PENDING_REQUEST;
+  initiatedAt: string;
+}
+
+export interface MyTripParticipationResponse {
+  status: TripParticipantStatus;
+  role: TripRole;
+  isTraveler: boolean;
+}
+
+export interface UpdateParticipantRolePayload {
+  role: TripRole;
+}
+
+export interface CreateTripInvitationPayload {
+  usernames: string[];
+}
+
+export interface MyTripInvitationResponse {
+  trip: {
+    id: string;
+    name: string;
+    coverUrl: string | null;
+  };
+  initiatedAt: string;
 }

--- a/apps/web/src/services/trips.types.ts
+++ b/apps/web/src/services/trips.types.ts
@@ -134,6 +134,7 @@ export interface TripParticipantResponse {
   avatarUrl: string | null;
   role: TripRole;
   isTraveler: boolean;
+  status: TripParticipantStatus.ACCEPTED | TripParticipantStatus.CONFIRMED;
   confirmedAt: string | null;
 }
 

--- a/apps/web/src/store/trip-invitations.test.tsx
+++ b/apps/web/src/store/trip-invitations.test.tsx
@@ -1,0 +1,120 @@
+import { type ReactNode } from 'react';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import type { User } from 'firebase/auth';
+import type { AuthContextValue } from '@/store/auth';
+
+const mocks = vi.hoisted(() => ({
+  mockApiGet: vi.fn(),
+}));
+
+vi.mock('@/hooks/useAuth', () => ({
+  useAuth: vi.fn(),
+}));
+
+vi.mock('@/services/api-client', () => ({
+  apiClient: { get: mocks.mockApiGet },
+}));
+
+import { useAuth } from '@/hooks/useAuth';
+import { TripInvitationsProvider, useTripInvitations } from './trip-invitations';
+import type { MyTripInvitationResponse } from '@/services/trips.types';
+
+function makeAuth(overrides: Partial<AuthContextValue> = {}): AuthContextValue {
+  return {
+    currentUser: null,
+    idToken: null,
+    isLoading: false,
+    getIdToken: vi.fn().mockResolvedValue(null),
+    signInWithGoogle: vi.fn(),
+    signInWithFacebook: vi.fn(),
+    signOut: vi.fn(),
+    ...overrides,
+  };
+}
+
+function makeFirebaseUser(overrides: Partial<User> = {}): User {
+  return { uid: 'uid-123', displayName: 'Test', email: 'test@example.com', ...overrides } as User;
+}
+
+function wrapper({ children }: { children: ReactNode }) {
+  return <TripInvitationsProvider>{children}</TripInvitationsProvider>;
+}
+
+const mockInvitation: MyTripInvitationResponse = {
+  trip: {
+    id: 'trip-uuid',
+    name: 'Cancún 2026',
+    coverUrl: 'https://cdn.example.com/cover.jpg',
+  },
+  initiatedAt: '2026-01-01T00:00:00.000Z',
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('TripInvitationsProvider', () => {
+  it('stays loading while auth is still loading', () => {
+    vi.mocked(useAuth).mockReturnValue(makeAuth({ isLoading: true }));
+
+    const { result } = renderHook(() => useTripInvitations(), { wrapper });
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.invitations).toEqual([]);
+  });
+
+  it('returns empty list when user is not authenticated', async () => {
+    vi.mocked(useAuth).mockReturnValue(makeAuth({ currentUser: null }));
+
+    const { result } = renderHook(() => useTripInvitations(), { wrapper });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.invitations).toEqual([]);
+    expect(result.current.count).toBe(0);
+    expect(mocks.mockApiGet).not.toHaveBeenCalled();
+  });
+
+  it('fetches and exposes invitations when authenticated', async () => {
+    vi.mocked(useAuth).mockReturnValue(makeAuth({ currentUser: makeFirebaseUser() }));
+    mocks.mockApiGet.mockResolvedValue({ data: [mockInvitation] });
+
+    const { result } = renderHook(() => useTripInvitations(), { wrapper });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.invitations).toEqual([mockInvitation]);
+    expect(result.current.count).toBe(1);
+  });
+
+  it('returns empty list on API error', async () => {
+    vi.mocked(useAuth).mockReturnValue(makeAuth({ currentUser: makeFirebaseUser() }));
+    mocks.mockApiGet.mockRejectedValue(new Error('Network error'));
+
+    const { result } = renderHook(() => useTripInvitations(), { wrapper });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.invitations).toEqual([]);
+    expect(result.current.count).toBe(0);
+  });
+
+  it('refresh re-fetches invitations', async () => {
+    vi.mocked(useAuth).mockReturnValue(makeAuth({ currentUser: makeFirebaseUser() }));
+    mocks.mockApiGet.mockResolvedValueOnce({ data: [mockInvitation] });
+
+    const { result } = renderHook(() => useTripInvitations(), { wrapper });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    mocks.mockApiGet.mockResolvedValueOnce({ data: [] });
+    await act(() => result.current.refresh());
+
+    expect(result.current.invitations).toEqual([]);
+    expect(result.current.count).toBe(0);
+  });
+});
+
+describe('useTripInvitations outside provider', () => {
+  it('throws when used outside TripInvitationsProvider', () => {
+    expect(() => renderHook(() => useTripInvitations())).toThrow(
+      'useTripInvitations must be used within a TripInvitationsProvider',
+    );
+  });
+});

--- a/apps/web/src/store/trip-invitations.tsx
+++ b/apps/web/src/store/trip-invitations.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import type { ReactNode } from 'react';
+
+import { useAuth } from '@/hooks/useAuth';
+import { getMyTripInvitations } from '@/services/trips.service';
+import type { MyTripInvitationResponse } from '@/services/trips.types';
+
+export interface TripInvitationsContextValue {
+  invitations: MyTripInvitationResponse[];
+  count: number;
+  isLoading: boolean;
+  refresh: () => Promise<void>;
+}
+
+export const TripInvitationsContext = createContext<TripInvitationsContextValue | null>(null);
+
+export function TripInvitationsProvider({ children }: { children: ReactNode }) {
+  const { currentUser, isLoading: authLoading } = useAuth();
+  const [invitations, setInvitations] = useState<MyTripInvitationResponse[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const fetchInvitations = useCallback(async () => {
+    try {
+      const data = await getMyTripInvitations();
+      setInvitations(data);
+    } catch {
+      setInvitations([]);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  // TODO: once FCM is active, trigger refresh() from incoming trip-invitation
+  // push notifications so the badge updates in real time without a page reload.
+  useEffect(() => {
+    if (authLoading) return;
+
+    if (!currentUser) {
+      setInvitations([]);
+      setIsLoading(false);
+      return;
+    }
+
+    void fetchInvitations();
+  }, [authLoading, currentUser, fetchInvitations]);
+
+  const value = useMemo<TripInvitationsContextValue>(
+    () => ({
+      invitations,
+      count: invitations.length,
+      isLoading,
+      refresh: fetchInvitations,
+    }),
+    [invitations, isLoading, fetchInvitations],
+  );
+
+  return (
+    <TripInvitationsContext.Provider value={value}>{children}</TripInvitationsContext.Provider>
+  );
+}
+
+export function useTripInvitations(): TripInvitationsContextValue {
+  const context = useContext(TripInvitationsContext);
+  if (!context) {
+    throw new Error('useTripInvitations must be used within a TripInvitationsProvider');
+  }
+  return context;
+}


### PR DESCRIPTION
## Summary

- **Participants admin view** (`/trips/[id]/participants`): confirmed list with capacity indicator, pending requests/invitations panel (organizer only), role management (promote/demote co-organizer), leave trip with last-organizer 409 guard, and non-participant states (invited accept/decline, pending request withdraw, public join request)
- **Confirmation toggle** (`PATCH /v1/trips/:id/participants/:userId/confirmation`): organizer/co-organizer can toggle participant status ACCEPTED ↔ CONFIRMED; check icon is orange when pending, green when confirmed. Only shown for non-ORGANIZER targets.
- **Participant list split** into two sections: Confirmed and Pending confirmation, with capacity counter counting both ACCEPTED and CONFIRMED participants.
- **isTraveler badge** now only shown for ORGANIZER and CO_ORGANIZER roles (PARTICIPANT always travels — badge was noise).
- **Bug fix** (`acceptJoinRequest`, `acceptInvitation`): both were incorrectly setting `confirmedAt` on the ACCEPTED status transition. Fixed — `confirmedAt` is only set/cleared by `toggleParticipantConfirmation`. Existing DB anomaly cleaned up.
- **Global invitations section** on `/trips` list page: pending trip invitations visible before entering the trip, accept/decline refreshes the trip list immediately
- **`TripInvitationsProvider`** added to `AppShell` (mirrors `GroupInvitationsProvider`)
- **Notification routing fix**: `TRIP_INVITATION` notifications now navigate to `/trips` (general view) instead of the specific trip URL
- **Backend routing fix** (`apps/api`): moved `TripParticipantsController` before `TripsController` in `TripsModule` so `GET /v1/trips/invitations` resolves correctly and is not swallowed by the `/:id` param route

## Changes

**New API endpoint**
- `PATCH /v1/trips/:id/participants/:userId/confirmation` — toggles ACCEPTED ↔ CONFIRMED, only for organizer/co-organizer

**Bug fixes**
- `acceptJoinRequest` and `acceptInvitation` no longer set `confirmedAt` on ACCEPTED status
- `ParticipantResponseDto` now includes `status` field (source of truth for confirmation state)

**Frontend — participant list UI**
- Split confirmed/pending-confirmation sections with section headers and counts
- Confirmation toggle button on each row (orange = pending, green = confirmed); hidden for ORGANIZER targets and non-organizer viewers
- isTraveler badge restricted to ORGANIZER and CO_ORGANIZER roles
- Capacity counter counts all active participants (ACCEPTED + CONFIRMED)

## Test plan

- [ ] Log in as a user with a pending trip invitation — invitation card appears on `/trips`
- [ ] Accept invitation — card disappears, trip appears in upcoming list immediately
- [ ] Decline invitation — card disappears, trip does not appear
- [ ] Click a `TRIP_INVITATION` notification — navigates to `/trips`, not the trip detail
- [ ] Navigate to `/trips/[id]/participants` as organizer — see confirmed and pending-confirmation sections
- [ ] Toggle confirmation on ACCEPTED participant → becomes CONFIRMED (green check)
- [ ] Toggle again → reverts to ACCEPTED (orange question mark)
- [ ] Confirmation toggle not visible on ORGANIZER row, not visible when viewing as PARTICIPANT
- [ ] isTraveler badge shows on ORGANIZER/CO_ORGANIZER when isTraveler=true; never on PARTICIPANT row
- [ ] Capacity counter reflects both ACCEPTED and CONFIRMED participants
- [ ] Promote/demote/remove participant as organizer
- [ ] Leave trip as last organizer — shows "transfer role first" error
- [ ] Navigate as non-participant to `/trips/[id]/participants` — see invite/join state

🤖 Generated with [Claude Code](https://claude.com/claude-code)