### PR TITLE
feat(trips): move departure/landing from header to destinations section

### DIFF
--- a/apps/web/src/app/trips/[id]/page.tsx
+++ b/apps/web/src/app/trips/[id]/page.tsx
@@ -11,7 +11,6 @@ import {
   UsersThreeIcon,
   AirplaneTakeoffIcon,
   AirplaneLandingIcon,
-  MapPinIcon,
   UsersIcon,
   NavigationArrowIcon,
   PencilSimpleIcon,
@@ -166,13 +165,6 @@ export default function TripDetailPage({ params }: TripDetailPageProps) {
           </div>
 
           <div className="mt-1 flex items-center gap-1 text-sm text-muted-foreground">
-            <MapPinIcon className="size-3.5 shrink-0" aria-hidden="true" />
-            <span>{trip.departureCity}</span>
-            <span>→</span>
-            <span>{trip.landingCity}</span>
-          </div>
-
-          <div className="mt-1 flex items-center gap-1 text-sm text-muted-foreground">
             <UsersIcon className="size-3.5 shrink-0" aria-hidden="true" />
             <span>
               {t('detail.capacity')}: {trip.participantCapacity}
@@ -202,7 +194,15 @@ export default function TripDetailPage({ params }: TripDetailPageProps) {
           <h2 className="text-sm font-semibold">{t('detail.destinations')}</h2>
         </div>
 
-        <DestinationList tripId={id} initialDestinations={destinations} isOrganizer={isOrganizer} />
+        <DestinationList
+          tripId={id}
+          initialDestinations={destinations}
+          isOrganizer={isOrganizer}
+          departureCity={trip.departureCity}
+          departureCountry={trip.departureCountry}
+          landingCity={trip.landingCity}
+          landingCountry={trip.landingCountry}
+        />
       </section>
 
       {/* Quick stats — only rendered when at least one field has a value */}

--- a/apps/web/src/components/trips/DestinationList.test.tsx
+++ b/apps/web/src/components/trips/DestinationList.test.tsx
@@ -126,6 +126,70 @@ beforeEach(() => {
 });
 
 describe('DestinationList', () => {
+  describe('fixed departure and landing items', () => {
+    it('renders departure city in both modes', () => {
+      render(
+        <DestinationList
+          tripId="trip-1"
+          initialDestinations={[]}
+          isOrganizer={false}
+          departureCity="Mexico City"
+          departureCountry="MX"
+          landingCity="Bogota"
+          landingCountry="CO"
+        />,
+      );
+      expect(screen.getByText(/Mexico City/)).toBeInTheDocument();
+    });
+
+    it('renders landing city in both modes', () => {
+      render(
+        <DestinationList
+          tripId="trip-1"
+          initialDestinations={[]}
+          isOrganizer={false}
+          departureCity="Mexico City"
+          departureCountry="MX"
+          landingCity="Bogota"
+          landingCountry="CO"
+        />,
+      );
+      expect(screen.getByText(/Bogota/)).toBeInTheDocument();
+    });
+
+    it('renders departure and landing labels', () => {
+      render(
+        <DestinationList
+          tripId="trip-1"
+          initialDestinations={[]}
+          isOrganizer={false}
+          departureCity="Mexico City"
+          departureCountry="MX"
+          landingCity="Bogota"
+          landingCountry="CO"
+        />,
+      );
+      expect(screen.getByText('form.departureLocation')).toBeInTheDocument();
+      expect(screen.getByText('form.landingLocation')).toBeInTheDocument();
+    });
+
+    it('renders departure and landing in organizer mode', () => {
+      render(
+        <DestinationList
+          tripId="trip-1"
+          initialDestinations={[]}
+          isOrganizer={true}
+          departureCity="Mexico City"
+          departureCountry="MX"
+          landingCity="Bogota"
+          landingCountry="CO"
+        />,
+      );
+      expect(screen.getByText(/Mexico City/)).toBeInTheDocument();
+      expect(screen.getByText(/Bogota/)).toBeInTheDocument();
+    });
+  });
+
   describe('read-only (participant) mode', () => {
     it('renders ordered destination list', () => {
       render(
@@ -133,6 +197,10 @@ describe('DestinationList', () => {
           tripId="trip-1"
           initialDestinations={[destA, destB]}
           isOrganizer={false}
+          departureCity="Bogota"
+          departureCountry="CO"
+          landingCity="Bogota"
+          landingCountry="CO"
         />,
       );
       expect(screen.getByText(/Cancun/)).toBeInTheDocument();
@@ -145,6 +213,10 @@ describe('DestinationList', () => {
           tripId="trip-1"
           initialDestinations={[destA, destB]}
           isOrganizer={false}
+          departureCity="Bogota"
+          departureCountry="CO"
+          landingCity="Bogota"
+          landingCountry="CO"
         />,
       );
       expect(screen.getByText('1.')).toBeInTheDocument();
@@ -153,22 +225,62 @@ describe('DestinationList', () => {
 
     it('renders label when present', () => {
       const dest = makeDestination({ label: 'Beach stop' });
-      render(<DestinationList tripId="trip-1" initialDestinations={[dest]} isOrganizer={false} />);
+      render(
+        <DestinationList
+          tripId="trip-1"
+          initialDestinations={[dest]}
+          isOrganizer={false}
+          departureCity="Bogota"
+          departureCountry="CO"
+          landingCity="Bogota"
+          landingCountry="CO"
+        />,
+      );
       expect(screen.getByText(/Beach stop/)).toBeInTheDocument();
     });
 
     it('shows empty state when no destinations', () => {
-      render(<DestinationList tripId="trip-1" initialDestinations={[]} isOrganizer={false} />);
+      render(
+        <DestinationList
+          tripId="trip-1"
+          initialDestinations={[]}
+          isOrganizer={false}
+          departureCity="Bogota"
+          departureCountry="CO"
+          landingCity="Bogota"
+          landingCountry="CO"
+        />,
+      );
       expect(screen.getByText('detail.noDestinations')).toBeInTheDocument();
     });
 
     it('does not show add button', () => {
-      render(<DestinationList tripId="trip-1" initialDestinations={[destA]} isOrganizer={false} />);
+      render(
+        <DestinationList
+          tripId="trip-1"
+          initialDestinations={[destA]}
+          isOrganizer={false}
+          departureCity="Bogota"
+          departureCountry="CO"
+          landingCity="Bogota"
+          landingCountry="CO"
+        />,
+      );
       expect(screen.queryByLabelText('destinations.addButton')).not.toBeInTheDocument();
     });
 
     it('does not show edit/delete actions', () => {
-      render(<DestinationList tripId="trip-1" initialDestinations={[destA]} isOrganizer={false} />);
+      render(
+        <DestinationList
+          tripId="trip-1"
+          initialDestinations={[destA]}
+          isOrganizer={false}
+          departureCity="Bogota"
+          departureCountry="CO"
+          landingCity="Bogota"
+          landingCountry="CO"
+        />,
+      );
       expect(screen.queryByLabelText('actions.edit')).not.toBeInTheDocument();
       expect(screen.queryByLabelText('actions.delete')).not.toBeInTheDocument();
     });
@@ -176,12 +288,32 @@ describe('DestinationList', () => {
 
   describe('organizer mode', () => {
     it('shows add button', () => {
-      render(<DestinationList tripId="trip-1" initialDestinations={[]} isOrganizer={true} />);
+      render(
+        <DestinationList
+          tripId="trip-1"
+          initialDestinations={[]}
+          isOrganizer={true}
+          departureCity="Bogota"
+          departureCountry="CO"
+          landingCity="Bogota"
+          landingCountry="CO"
+        />,
+      );
       expect(screen.getByLabelText('destinations.addButton')).toBeInTheDocument();
     });
 
     it('shows edit and delete actions per item', () => {
-      render(<DestinationList tripId="trip-1" initialDestinations={[destA]} isOrganizer={true} />);
+      render(
+        <DestinationList
+          tripId="trip-1"
+          initialDestinations={[destA]}
+          isOrganizer={true}
+          departureCity="Bogota"
+          departureCountry="CO"
+          landingCity="Bogota"
+          landingCountry="CO"
+        />,
+      );
       expect(screen.getByTitle('actions.edit')).toBeInTheDocument();
       expect(screen.getByTitle('actions.delete')).toBeInTheDocument();
     });
@@ -189,7 +321,17 @@ describe('DestinationList', () => {
     describe('add flow', () => {
       it('opens add dialog on button click', async () => {
         const user = userEvent.setup();
-        render(<DestinationList tripId="trip-1" initialDestinations={[]} isOrganizer={true} />);
+        render(
+          <DestinationList
+            tripId="trip-1"
+            initialDestinations={[]}
+            isOrganizer={true}
+            departureCity="Bogota"
+            departureCountry="CO"
+            landingCity="Bogota"
+            landingCountry="CO"
+          />,
+        );
         await user.click(screen.getByLabelText('destinations.addButton'));
         expect(screen.getByText('destinations.addTitle')).toBeInTheDocument();
       });
@@ -199,7 +341,17 @@ describe('DestinationList', () => {
         const newDest = makeDestination({ id: 'dest-new', city: 'Oaxaca', countryCode: 'MX' });
         mocks.addTripDestination.mockResolvedValueOnce(writeResponse(newDest));
 
-        render(<DestinationList tripId="trip-1" initialDestinations={[]} isOrganizer={true} />);
+        render(
+          <DestinationList
+            tripId="trip-1"
+            initialDestinations={[]}
+            isOrganizer={true}
+            departureCity="Bogota"
+            departureCountry="CO"
+            landingCity="Bogota"
+            landingCountry="CO"
+          />,
+        );
 
         await user.click(screen.getByLabelText('destinations.addButton'));
         await user.selectOptions(screen.getByTestId('country-combobox'), 'MX');
@@ -222,7 +374,17 @@ describe('DestinationList', () => {
         const user = userEvent.setup();
         mocks.addTripDestination.mockRejectedValueOnce(new Error('network'));
 
-        render(<DestinationList tripId="trip-1" initialDestinations={[]} isOrganizer={true} />);
+        render(
+          <DestinationList
+            tripId="trip-1"
+            initialDestinations={[]}
+            isOrganizer={true}
+            departureCity="Bogota"
+            departureCountry="CO"
+            landingCity="Bogota"
+            landingCountry="CO"
+          />,
+        );
 
         await user.click(screen.getByLabelText('destinations.addButton'));
         await user.selectOptions(screen.getByTestId('country-combobox'), 'MX');
@@ -239,7 +401,15 @@ describe('DestinationList', () => {
       it('opens edit dialog pre-filled with destination data', async () => {
         const user = userEvent.setup();
         render(
-          <DestinationList tripId="trip-1" initialDestinations={[destA]} isOrganizer={true} />,
+          <DestinationList
+            tripId="trip-1"
+            initialDestinations={[destA]}
+            isOrganizer={true}
+            departureCity="Bogota"
+            departureCountry="CO"
+            landingCity="Bogota"
+            landingCountry="CO"
+          />,
         );
         await user.click(screen.getByTitle('actions.edit'));
         expect(screen.getByText('destinations.editTitle')).toBeInTheDocument();
@@ -253,7 +423,15 @@ describe('DestinationList', () => {
         mocks.updateTripDestination.mockResolvedValueOnce(writeResponse(updated));
 
         render(
-          <DestinationList tripId="trip-1" initialDestinations={[destA]} isOrganizer={true} />,
+          <DestinationList
+            tripId="trip-1"
+            initialDestinations={[destA]}
+            isOrganizer={true}
+            departureCity="Bogota"
+            departureCountry="CO"
+            landingCity="Bogota"
+            landingCountry="CO"
+          />,
         );
 
         await user.click(screen.getByTitle('actions.edit'));
@@ -283,6 +461,10 @@ describe('DestinationList', () => {
             tripId="trip-1"
             initialDestinations={[destA, destB]}
             isOrganizer={true}
+            departureCity="Bogota"
+            departureCountry="CO"
+            landingCity="Bogota"
+            landingCountry="CO"
           />,
         );
 
@@ -302,7 +484,15 @@ describe('DestinationList', () => {
         mocks.deleteTripDestination.mockRejectedValueOnce(new Error('network'));
 
         render(
-          <DestinationList tripId="trip-1" initialDestinations={[destA]} isOrganizer={true} />,
+          <DestinationList
+            tripId="trip-1"
+            initialDestinations={[destA]}
+            isOrganizer={true}
+            departureCity="Bogota"
+            departureCountry="CO"
+            landingCity="Bogota"
+            landingCountry="CO"
+          />,
         );
 
         const deleteButton = screen.getByTitle('actions.delete');
@@ -330,6 +520,10 @@ describe('DestinationList', () => {
             tripId="trip-1"
             initialDestinations={[destA, destB]}
             isOrganizer={true}
+            departureCity="Bogota"
+            departureCountry="CO"
+            landingCity="Bogota"
+            landingCountry="CO"
           />,
         );
 
@@ -352,6 +546,10 @@ describe('DestinationList', () => {
             tripId="trip-1"
             initialDestinations={[destA, destB]}
             isOrganizer={true}
+            departureCity="Bogota"
+            departureCountry="CO"
+            landingCity="Bogota"
+            landingCountry="CO"
           />,
         );
 
@@ -371,6 +569,10 @@ describe('DestinationList', () => {
             tripId="trip-1"
             initialDestinations={[destA, destB]}
             isOrganizer={true}
+            departureCity="Bogota"
+            departureCountry="CO"
+            landingCity="Bogota"
+            landingCountry="CO"
           />,
         );
 
@@ -384,6 +586,10 @@ describe('DestinationList', () => {
             tripId="trip-1"
             initialDestinations={[destA, destB]}
             isOrganizer={true}
+            departureCity="Bogota"
+            departureCountry="CO"
+            landingCity="Bogota"
+            landingCountry="CO"
           />,
         );
 

--- a/apps/web/src/components/trips/DestinationList.test.tsx
+++ b/apps/web/src/components/trips/DestinationList.test.tsx
@@ -127,7 +127,7 @@ beforeEach(() => {
 
 describe('DestinationList', () => {
   describe('fixed departure and landing items', () => {
-    it('renders departure city in both modes', () => {
+    it('renders departure city in participant mode', () => {
       render(
         <DestinationList
           tripId="trip-1"
@@ -142,7 +142,7 @@ describe('DestinationList', () => {
       expect(screen.getByText(/Mexico City/)).toBeInTheDocument();
     });
 
-    it('renders landing city in both modes', () => {
+    it('renders landing city in participant mode', () => {
       render(
         <DestinationList
           tripId="trip-1"

--- a/apps/web/src/components/trips/DestinationList.tsx
+++ b/apps/web/src/components/trips/DestinationList.tsx
@@ -388,43 +388,51 @@ export function DestinationList({
 
   return (
     <div>
-      <div className="flex items-center gap-2 px-2 py-1.5 text-sm">
-        <AirplaneTakeoffIcon className="size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
-        <span className="flex-1">
-          {departureCity}, {departureCountry}
-        </span>
-        <span className="text-xs text-muted-foreground">{t('form.departureLocation')}</span>
-      </div>
+      <div className="space-y-1">
+        <div className="flex items-center gap-2 px-2 py-1.5 text-sm">
+          <AirplaneTakeoffIcon
+            className="size-4 shrink-0 text-muted-foreground"
+            aria-hidden="true"
+          />
+          <span className="flex-1">
+            {departureCity}, {departureCountry}
+          </span>
+          <span className="text-xs text-muted-foreground">{t('form.departureLocation')}</span>
+        </div>
 
-      <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
-        <SortableContext
-          items={destinations.map((d) => d.id)}
-          strategy={verticalListSortingStrategy}
-        >
-          {destinations.length === 0 ? (
-            <p className="px-2 text-sm text-muted-foreground">{t('detail.noDestinations')}</p>
-          ) : (
-            <ol className="space-y-1">
-              {destinations.map((dest) => (
-                <SortableItem
-                  key={dest.id}
-                  dest={dest}
-                  isSaving={isSaving}
-                  onEdit={openEdit}
-                  onDelete={handleDelete}
-                />
-              ))}
-            </ol>
-          )}
-        </SortableContext>
-      </DndContext>
+        <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+          <SortableContext
+            items={destinations.map((d) => d.id)}
+            strategy={verticalListSortingStrategy}
+          >
+            {destinations.length === 0 ? (
+              <p className="px-2 text-sm text-muted-foreground">{t('detail.noDestinations')}</p>
+            ) : (
+              <ol className="space-y-1">
+                {destinations.map((dest) => (
+                  <SortableItem
+                    key={dest.id}
+                    dest={dest}
+                    isSaving={isSaving}
+                    onEdit={openEdit}
+                    onDelete={handleDelete}
+                  />
+                ))}
+              </ol>
+            )}
+          </SortableContext>
+        </DndContext>
 
-      <div className="flex items-center gap-2 px-2 py-1.5 text-sm">
-        <AirplaneLandingIcon className="size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
-        <span className="flex-1">
-          {landingCity}, {landingCountry}
-        </span>
-        <span className="text-xs text-muted-foreground">{t('form.landingLocation')}</span>
+        <div className="flex items-center gap-2 px-2 py-1.5 text-sm">
+          <AirplaneLandingIcon
+            className="size-4 shrink-0 text-muted-foreground"
+            aria-hidden="true"
+          />
+          <span className="flex-1">
+            {landingCity}, {landingCountry}
+          </span>
+          <span className="text-xs text-muted-foreground">{t('form.landingLocation')}</span>
+        </div>
       </div>
 
       <Button

--- a/apps/web/src/components/trips/DestinationList.tsx
+++ b/apps/web/src/components/trips/DestinationList.tsx
@@ -19,7 +19,12 @@ import {
   arrayMove,
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import { DotsSixVerticalIcon, PlusIcon } from '@phosphor-icons/react';
+import {
+  AirplaneLandingIcon,
+  AirplaneTakeoffIcon,
+  DotsSixVerticalIcon,
+  PlusIcon,
+} from '@phosphor-icons/react';
 
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -50,6 +55,10 @@ interface DestinationListProps {
   tripId: string;
   initialDestinations: DestinationResponse[];
   isOrganizer: boolean;
+  departureCity: string;
+  departureCountry: string;
+  landingCity: string;
+  landingCountry: string;
 }
 
 type FormMode = 'add' | 'edit';
@@ -258,6 +267,10 @@ export function DestinationList({
   tripId,
   initialDestinations,
   isOrganizer,
+  departureCity,
+  departureCountry,
+  landingCity,
+  landingCountry,
 }: DestinationListProps) {
   const { t } = useTranslation('trips');
   const [destinations, setDestinations] = useState<DestinationResponse[]>(initialDestinations);
@@ -329,17 +342,28 @@ export function DestinationList({
 
   if (!isOrganizer) {
     return (
-      <div>
+      <div className="space-y-1">
+        <div className="flex items-center gap-2 px-2 py-1.5 text-sm">
+          <AirplaneTakeoffIcon
+            className="size-4 shrink-0 text-muted-foreground"
+            aria-hidden="true"
+          />
+          <span className="flex-1">
+            {departureCity}, {departureCountry}
+          </span>
+          <span className="text-xs text-muted-foreground">{t('form.departureLocation')}</span>
+        </div>
+
         {destinations.length === 0 ? (
-          <p className="text-sm text-muted-foreground">{t('detail.noDestinations')}</p>
+          <p className="px-2 text-sm text-muted-foreground">{t('detail.noDestinations')}</p>
         ) : (
-          <ol className="space-y-2">
+          <ol className="space-y-1">
             {destinations.map((dest) => (
-              <li key={dest.id} className="flex items-center gap-2 text-sm">
+              <li key={dest.id} className="flex items-center gap-2 px-2 py-1.5 text-sm">
                 <span className="text-muted-foreground tabular-nums w-5 shrink-0 text-right">
                   {dest.position}.
                 </span>
-                <span>
+                <span className="flex-1">
                   {dest.city}, {dest.countryCode}
                   {dest.label && <span className="ml-1 text-muted-foreground">— {dest.label}</span>}
                 </span>
@@ -347,19 +371,38 @@ export function DestinationList({
             ))}
           </ol>
         )}
+
+        <div className="flex items-center gap-2 px-2 py-1.5 text-sm">
+          <AirplaneLandingIcon
+            className="size-4 shrink-0 text-muted-foreground"
+            aria-hidden="true"
+          />
+          <span className="flex-1">
+            {landingCity}, {landingCountry}
+          </span>
+          <span className="text-xs text-muted-foreground">{t('form.landingLocation')}</span>
+        </div>
       </div>
     );
   }
 
   return (
     <div>
+      <div className="flex items-center gap-2 px-2 py-1.5 text-sm">
+        <AirplaneTakeoffIcon className="size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+        <span className="flex-1">
+          {departureCity}, {departureCountry}
+        </span>
+        <span className="text-xs text-muted-foreground">{t('form.departureLocation')}</span>
+      </div>
+
       <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
         <SortableContext
           items={destinations.map((d) => d.id)}
           strategy={verticalListSortingStrategy}
         >
           {destinations.length === 0 ? (
-            <p className="text-sm text-muted-foreground">{t('detail.noDestinations')}</p>
+            <p className="px-2 text-sm text-muted-foreground">{t('detail.noDestinations')}</p>
           ) : (
             <ol className="space-y-1">
               {destinations.map((dest) => (
@@ -375,6 +418,14 @@ export function DestinationList({
           )}
         </SortableContext>
       </DndContext>
+
+      <div className="flex items-center gap-2 px-2 py-1.5 text-sm">
+        <AirplaneLandingIcon className="size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+        <span className="flex-1">
+          {landingCity}, {landingCountry}
+        </span>
+        <span className="text-xs text-muted-foreground">{t('form.landingLocation')}</span>
+      </div>
 
       <Button
         type="button"

--- a/apps/web/src/locales/en/trips.json
+++ b/apps/web/src/locales/en/trips.json
@@ -145,7 +145,7 @@
     "participantCapacity": "Participant capacity",
     "isTravelingParticipant": "I'm traveling with the group",
     "departureLocation": "Departure",
-    "landingLocation": "Return location",
+    "landingLocation": "Return",
     "country": "Country",
     "city": "City",
     "cityDisabled": "Select a country first",

--- a/apps/web/src/locales/es/trips.json
+++ b/apps/web/src/locales/es/trips.json
@@ -145,7 +145,7 @@
     "participantCapacity": "Capacidad de participantes",
     "isTravelingParticipant": "Voy a viajar con el grupo",
     "departureLocation": "Salida",
-    "landingLocation": "Lugar de regreso",
+    "landingLocation": "Regreso",
     "country": "País",
     "city": "Ciudad",
     "cityDisabled": "Selecciona un país primero",


### PR DESCRIPTION
## Summary

Departure and landing cities previously appeared in the trip header as a single `city → city` metadata row. Because these locations define the start and end of the route, they belong visually alongside the destinations list rather than in the header. This PR relocates them as fixed, non-sortable items that bookend the sortable `DestinationList`.

## Changes

**DestinationList component**
- Added `departureCity`, `departureCountry`, `landingCity`, `landingCountry` props
- Renders a fixed departure row (✈↑) before the sortable list and a fixed landing row (✈↓) after it
- Formatted as `city, countryCode` to match sortable destination items
- Label tag (`Departure` / `Return`) aligned right in muted text — uses existing `form.departureLocation` / `form.landingLocation` i18n keys

**Trip detail page**
- Removed `MapPinIcon` header row (`departureCity → landingCity`)
- Passes `departureCountry` and `landingCountry` (already in `TripResponse`) to `DestinationList`

**i18n**
- Shortened `landingLocation` label: `"Return location"` → `"Return"` / `"Lugar de regreso"` → `"Regreso"` for compact display in the label badge

**Tests**
- Added 4 new tests covering the fixed departure/landing items in both participant and organizer modes
- Updated all existing `DestinationList` render calls with the new required props

## Testing

- [ ] Participant view: departure and landing appear as first/last items, no drag handle, no edit/delete actions
- [ ] Organizer view: same fixed items, sortable destinations in between, "Add destination" button still visible
- [ ] Empty destinations state: departure → "No destinations added yet." → landing
- [ ] Header no longer shows the `city → city` row
- [ ] Labels display in both English and Spanish

Closes #435