### PR TITLE
fix(trips): fix destination delete position compaction and last-destination error

### DIFF
--- a/apps/api/src/modules/trips/destinations/trips-destinations.service.spec.ts
+++ b/apps/api/src/modules/trips/destinations/trips-destinations.service.spec.ts
@@ -375,22 +375,18 @@ describe('TripsDestinationsService', () => {
   });
 
   describe('deleteDestination', () => {
-    it('deletes destination when count is > 1', async () => {
+    it('deletes destination and compacts positions in a single transaction', async () => {
       mockSelectWhere.mockResolvedValue([{ total: 2 }]);
 
       await expect(
         service.deleteDestination(mockUser, 'trip-uuid', 'dest-uuid'),
       ).resolves.toBeUndefined();
 
+      expect(mockTransaction).toHaveBeenCalledTimes(1);
       expect(mockDeleteWhere).toHaveBeenCalled();
-    });
-
-    it('compacts positions of remaining destinations after delete', async () => {
-      mockSelectWhere.mockResolvedValue([{ total: 2 }]);
-
-      await service.deleteDestination(mockUser, 'trip-uuid', 'dest-uuid');
-
-      expect(mockUpdateWhere).toHaveBeenCalled();
+      expect(mockUpdateSet).toHaveBeenCalledWith(
+        expect.objectContaining({ position: expect.anything() }),
+      );
     });
 
     it('throws UnprocessableEntityException when deleting the last destination', async () => {

--- a/apps/api/src/modules/trips/destinations/trips-destinations.service.spec.ts
+++ b/apps/api/src/modules/trips/destinations/trips-destinations.service.spec.ts
@@ -385,6 +385,14 @@ describe('TripsDestinationsService', () => {
       expect(mockDeleteWhere).toHaveBeenCalled();
     });
 
+    it('compacts positions of remaining destinations after delete', async () => {
+      mockSelectWhere.mockResolvedValue([{ total: 2 }]);
+
+      await service.deleteDestination(mockUser, 'trip-uuid', 'dest-uuid');
+
+      expect(mockUpdateWhere).toHaveBeenCalled();
+    });
+
     it('throws UnprocessableEntityException when deleting the last destination', async () => {
       mockSelectWhere.mockResolvedValue([{ total: 1 }]);
 

--- a/apps/api/src/modules/trips/destinations/trips-destinations.service.ts
+++ b/apps/api/src/modules/trips/destinations/trips-destinations.service.ts
@@ -6,7 +6,7 @@ import {
   NotFoundException,
   UnprocessableEntityException,
 } from '@nestjs/common';
-import { and, asc, count, eq, inArray, max, sql } from 'drizzle-orm';
+import { and, asc, count, eq, gt, inArray, max, sql } from 'drizzle-orm';
 
 import { TripStatus } from '@chamuco/shared-types';
 import { DRIZZLE_CLIENT, DrizzleClient } from '@/database/drizzle.provider';
@@ -124,6 +124,13 @@ export class TripsDestinationsService {
     }
 
     await this.db.delete(tripDestinations).where(eq(tripDestinations.id, destId));
+
+    await this.db
+      .update(tripDestinations)
+      .set({ position: sql`${tripDestinations.position} - 1` })
+      .where(
+        and(eq(tripDestinations.tripId, tripId), gt(tripDestinations.position, dest.position)),
+      );
   }
 
   async reorderDestinations(

--- a/apps/api/src/modules/trips/destinations/trips-destinations.service.ts
+++ b/apps/api/src/modules/trips/destinations/trips-destinations.service.ts
@@ -123,14 +123,16 @@ export class TripsDestinationsService {
       );
     }
 
-    await this.db.delete(tripDestinations).where(eq(tripDestinations.id, destId));
+    await this.db.transaction(async (trx) => {
+      await trx.delete(tripDestinations).where(eq(tripDestinations.id, destId));
 
-    await this.db
-      .update(tripDestinations)
-      .set({ position: sql`${tripDestinations.position} - 1` })
-      .where(
-        and(eq(tripDestinations.tripId, tripId), gt(tripDestinations.position, dest.position)),
-      );
+      await trx
+        .update(tripDestinations)
+        .set({ position: sql`${tripDestinations.position} - 1` })
+        .where(
+          and(eq(tripDestinations.tripId, tripId), gt(tripDestinations.position, dest.position)),
+        );
+    });
   }
 
   async reorderDestinations(

--- a/apps/web/src/components/trips/DestinationList.test.tsx
+++ b/apps/web/src/components/trips/DestinationList.test.tsx
@@ -486,6 +486,32 @@ describe('DestinationList', () => {
         render(
           <DestinationList
             tripId="trip-1"
+            initialDestinations={[destA, destB]}
+            isOrganizer={true}
+            departureCity="Bogota"
+            departureCountry="CO"
+            landingCity="Bogota"
+            landingCountry="CO"
+          />,
+        );
+
+        const deleteButtons = screen.getAllByTitle('actions.delete');
+        await user.click(deleteButtons[0]!);
+        await user.click(screen.getByText('actions.deleteConfirm'));
+
+        await waitFor(() => {
+          expect(mocks.toastError).toHaveBeenCalledWith('destinations.deleteError');
+        });
+
+        expect(screen.getByText(/Cancun/)).toBeInTheDocument();
+      });
+
+      it('shows deleteLastError toast when only one destination remains', async () => {
+        const user = userEvent.setup();
+
+        render(
+          <DestinationList
+            tripId="trip-1"
             initialDestinations={[destA]}
             isOrganizer={true}
             departureCity="Bogota"
@@ -500,9 +526,10 @@ describe('DestinationList', () => {
         await user.click(screen.getByText('actions.deleteConfirm'));
 
         await waitFor(() => {
-          expect(mocks.toastError).toHaveBeenCalledWith('destinations.deleteError');
+          expect(mocks.toastError).toHaveBeenCalledWith('destinations.deleteLastError');
         });
 
+        expect(mocks.deleteTripDestination).not.toHaveBeenCalled();
         expect(screen.getByText(/Cancun/)).toBeInTheDocument();
       });
     });

--- a/apps/web/src/components/trips/DestinationList.tsx
+++ b/apps/web/src/components/trips/DestinationList.tsx
@@ -305,8 +305,15 @@ export function DestinationList({
   }
 
   async function handleDelete(dest: DestinationResponse) {
+    if (destinations.length <= 1) {
+      toast.error(t('destinations.deleteLastError'));
+      return;
+    }
+
     const prev = destinations;
-    setDestinations((d) => d.filter((x) => x.id !== dest.id));
+    setDestinations((d) =>
+      d.filter((x) => x.id !== dest.id).map((x, i) => ({ ...x, position: i + 1 })),
+    );
     try {
       await deleteTripDestination(tripId, dest.id);
     } catch {

--- a/apps/web/src/components/trips/DestinationList.tsx
+++ b/apps/web/src/components/trips/DestinationList.tsx
@@ -26,6 +26,8 @@ import {
   PlusIcon,
 } from '@phosphor-icons/react';
 
+import axios from 'axios';
+
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -316,9 +318,12 @@ export function DestinationList({
     );
     try {
       await deleteTripDestination(tripId, dest.id);
-    } catch {
+    } catch (err) {
       setDestinations(prev);
-      toast.error(t('destinations.deleteError'));
+      const isLastDestinationError = axios.isAxiosError(err) && err.response?.status === 422;
+      toast.error(
+        t(isLastDestinationError ? 'destinations.deleteLastError' : 'destinations.deleteError'),
+      );
     }
   }
 

--- a/apps/web/src/locales/en/trips.json
+++ b/apps/web/src/locales/en/trips.json
@@ -241,6 +241,7 @@
     "labelPlaceholder": "e.g. Beach stop",
     "saveError": "Failed to save destination.",
     "deleteError": "Failed to delete destination.",
+    "deleteLastError": "Trips must have at least one destination.",
     "reorderError": "Failed to reorder destinations."
   }
 }

--- a/apps/web/src/locales/es/trips.json
+++ b/apps/web/src/locales/es/trips.json
@@ -241,6 +241,7 @@
     "labelPlaceholder": "ej. Parada en la playa",
     "saveError": "Error al guardar el destino.",
     "deleteError": "Error al eliminar el destino.",
+    "deleteLastError": "Los viajes deben tener al menos un destino.",
     "reorderError": "Error al reordenar los destinos."
   }
 }


### PR DESCRIPTION
## Summary

Two bugs in the trip destinations delete flow: remaining destinations kept gaps in their position numbers after a delete, and trying to delete the last destination showed a generic error toast with no context.

## Changes

**API — position compaction after delete**
- After deleting a destination, runs `UPDATE … SET position = position - 1 WHERE position > deleted.position` to close the gap in the sequence.

**Frontend — last-destination guard**
- `handleDelete` now checks `destinations.length <= 1` before making the API call. Shows a specific `destinations.deleteLastError` toast and returns early — no flash of empty state, no wasted request.
- Optimistic update now remaps positions (`map((x, i) => ({ ...x, position: i + 1 }))`) so displayed numbers update immediately after delete.
- Added `deleteLastError` i18n key in `en/trips.json` and `es/trips.json`.

## Testing

- [x] Delete second-to-last destination → remaining destination shows position 1
- [x] Delete middle destination from a list of 3 → positions compact to 1, 2
- [x] Attempt to delete the last remaining destination → specific error toast, no API call made
- [x] Network error on delete → state reverts, generic error toast shown
- [x] All existing + new unit tests pass (24 frontend, 36 backend)