### PR TITLE
feat(trips): enforce status-based lifecycle rules

### DIFF
--- a/apps/api/src/modules/trips/announcements/trip-announcements.service.spec.ts
+++ b/apps/api/src/modules/trips/announcements/trip-announcements.service.spec.ts
@@ -1,4 +1,4 @@
-import { ForbiddenException, NotFoundException } from '@nestjs/common';
+import { BadRequestException, ForbiddenException, NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import {
   NotificationChannel,
@@ -244,9 +244,22 @@ describe('TripAnnouncementsService', () => {
       );
     });
 
+    it('throws BadRequestException when trip is DRAFT', async () => {
+      mockTripsFindFirst
+        .mockResolvedValueOnce(mockTrip)
+        .mockResolvedValueOnce({ ...mockTrip, status: TripStatus.DRAFT });
+
+      await expect(service.create(TRIP_ID, ORGANIZER_ID, ORGANIZER_USERNAME, dto)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
     it('uses empty string for tripName when trip lookup returns undefined', async () => {
-      // First call: assertTripExists; second call: name lookup after insert
-      mockTripsFindFirst.mockResolvedValueOnce(mockTrip).mockResolvedValueOnce(undefined);
+      // 1. assertTripExists; 2. status check; 3. name lookup after insert
+      mockTripsFindFirst
+        .mockResolvedValueOnce(mockTrip)
+        .mockResolvedValueOnce(mockTrip)
+        .mockResolvedValueOnce(undefined);
 
       await service.create(TRIP_ID, ORGANIZER_ID, ORGANIZER_USERNAME, dto);
 

--- a/apps/api/src/modules/trips/announcements/trip-announcements.service.ts
+++ b/apps/api/src/modules/trips/announcements/trip-announcements.service.ts
@@ -1,4 +1,11 @@
-import { ForbiddenException, Inject, Injectable, Logger, NotFoundException } from '@nestjs/common';
+import {
+  BadRequestException,
+  ForbiddenException,
+  Inject,
+  Injectable,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
 import { and, count, desc, eq, inArray } from 'drizzle-orm';
 
 import {
@@ -6,6 +13,7 @@ import {
   NotificationType,
   TripParticipantStatus,
   TripRole,
+  TripStatus,
 } from '@chamuco/shared-types';
 import { DRIZZLE_CLIENT, DrizzleClient } from '@/database/drizzle.provider';
 import { users } from '@/modules/users/schema/users.schema';
@@ -37,6 +45,14 @@ export class TripAnnouncementsService {
     dto: CreateTripAnnouncementDto,
   ): Promise<TripAnnouncementResponseDto> {
     await this.assertTripOrganizer(tripId, callerId);
+
+    const tripStatus = await this.db.query.trips.findFirst({
+      where: eq(trips.id, tripId),
+      columns: { status: true },
+    });
+    if (tripStatus?.status === TripStatus.DRAFT) {
+      throw new BadRequestException('Announcements are not allowed on DRAFT trips');
+    }
 
     const [inserted] = await this.db
       .insert(tripAnnouncements)

--- a/apps/api/src/modules/trips/groups/dto/trip-linked-group.dto.ts
+++ b/apps/api/src/modules/trips/groups/dto/trip-linked-group.dto.ts
@@ -8,8 +8,10 @@ export class TripLinkedGroupDto {
   name!: string;
 
   @ApiProperty({
-    description: 'Ready-to-use URL for the group cover image or emoji (Twemoji CDN).',
+    description:
+      'Ready-to-use URL for the group cover image or emoji (Twemoji CDN). Null when the group has no cover.',
     example: 'https://cdn.jsdelivr.net/npm/twemoji/2/svg/1f3d4.svg',
+    nullable: true,
   })
-  coverUrl!: string;
+  coverUrl!: string | null;
 }

--- a/apps/api/src/modules/trips/groups/dto/trip-linked-group.dto.ts
+++ b/apps/api/src/modules/trips/groups/dto/trip-linked-group.dto.ts
@@ -1,0 +1,15 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class TripLinkedGroupDto {
+  @ApiProperty({ example: '550e8400-e29b-41d4-a716-446655440001' })
+  id!: string;
+
+  @ApiProperty({ example: 'Mountain Crew' })
+  name!: string;
+
+  @ApiProperty({
+    description: 'Ready-to-use URL for the group cover image or emoji (Twemoji CDN).',
+    example: 'https://cdn.jsdelivr.net/npm/twemoji/2/svg/1f3d4.svg',
+  })
+  coverUrl!: string;
+}

--- a/apps/api/src/modules/trips/groups/trips-groups.controller.ts
+++ b/apps/api/src/modules/trips/groups/trips-groups.controller.ts
@@ -23,6 +23,7 @@ import { CurrentUser } from '@/common/decorators/current-user.decorator';
 import type { AuthenticatedUser } from '@/types/express';
 import { TripsGroupsService } from './trips-groups.service';
 import { TripGroupResponseDto } from './dto/trip-group-response.dto';
+import { TripLinkedGroupDto } from './dto/trip-linked-group.dto';
 import { AddTripGroupDto } from './dto/add-trip-group.dto';
 
 @ApiTags('trip-groups')
@@ -30,6 +31,20 @@ import { AddTripGroupDto } from './dto/add-trip-group.dto';
 @Controller('v1/trips')
 export class TripsGroupsController {
   constructor(private readonly tripsGroupsService: TripsGroupsService) {}
+
+  @Get(':id/linked-groups')
+  @ApiOperation({
+    summary: 'List linked groups with full details',
+    description:
+      'Returns id, name, and coverUrl for every group associated with the trip. ' +
+      'Accessible to any authenticated user.',
+  })
+  @ApiParam({ name: 'id', type: String, description: 'Trip UUID' })
+  @ApiResponse({ status: 200, type: [TripLinkedGroupDto] })
+  @ApiNotFoundResponse({ description: 'Trip not found or a group cover asset is missing.' })
+  async listLinkedGroups(@Param('id', ParseUUIDPipe) id: string): Promise<TripLinkedGroupDto[]> {
+    return this.tripsGroupsService.listLinkedGroups(id);
+  }
 
   @Get(':id/groups')
   @ApiOperation({

--- a/apps/api/src/modules/trips/groups/trips-groups.controller.ts
+++ b/apps/api/src/modules/trips/groups/trips-groups.controller.ts
@@ -41,7 +41,7 @@ export class TripsGroupsController {
   })
   @ApiParam({ name: 'id', type: String, description: 'Trip UUID' })
   @ApiResponse({ status: 200, type: [TripLinkedGroupDto] })
-  @ApiNotFoundResponse({ description: 'Trip not found or a group cover asset is missing.' })
+  @ApiNotFoundResponse({ description: 'Trip not found.' })
   async listLinkedGroups(@Param('id', ParseUUIDPipe) id: string): Promise<TripLinkedGroupDto[]> {
     return this.tripsGroupsService.listLinkedGroups(id);
   }

--- a/apps/api/src/modules/trips/groups/trips-groups.service.spec.ts
+++ b/apps/api/src/modules/trips/groups/trips-groups.service.spec.ts
@@ -171,10 +171,22 @@ describe('TripsGroupsService', () => {
       expect(result).toEqual([]);
     });
 
-    it('throws NotFoundException when a group cover asset is missing', async () => {
+    it('returns null coverUrl when group cover asset is orphaned', async () => {
       mockAssetsFindMany.mockResolvedValue([]);
 
-      await expect(service.listLinkedGroups('trip-uuid')).rejects.toThrow(NotFoundException);
+      const result = await service.listLinkedGroups('trip-uuid');
+
+      expect(result).toHaveLength(1);
+      expect(result.at(0)?.coverUrl).toBeNull();
+    });
+
+    it('returns null coverUrl when group has no cover', async () => {
+      mockGroupsFindMany.mockResolvedValue([{ ...mockGroupRow, cover: null }]);
+
+      const result = await service.listLinkedGroups('trip-uuid');
+
+      expect(result).toHaveLength(1);
+      expect(result.at(0)?.coverUrl).toBeNull();
     });
   });
 

--- a/apps/api/src/modules/trips/groups/trips-groups.service.spec.ts
+++ b/apps/api/src/modules/trips/groups/trips-groups.service.spec.ts
@@ -7,6 +7,7 @@ import {
   TripVisibility,
 } from '@chamuco/shared-types';
 import { DRIZZLE_CLIENT } from '@/database/drizzle.provider';
+import { AssetResolverService } from '@/modules/assets/asset-resolver.service';
 import { TripsGroupsService } from './trips-groups.service';
 import { TripsService } from '@/modules/trips/trips.service';
 import type { AuthenticatedUser } from '@/types/express';
@@ -64,7 +65,9 @@ describe('TripsGroupsService', () => {
   let service: TripsGroupsService;
   let mockTripsFindFirst: jest.Mock;
   let mockGroupsFindFirst: jest.Mock;
+  let mockGroupsFindMany: jest.Mock;
   let mockGroupTripsFindFirst: jest.Mock;
+  let mockAssetsFindMany: jest.Mock;
   let mockSelectWhere: jest.Mock;
   let mockSelectFrom: jest.Mock;
   let mockSelect: jest.Mock;
@@ -74,11 +77,25 @@ describe('TripsGroupsService', () => {
   let mockInsertValues: jest.Mock;
   let mockInsert: jest.Mock;
   let mockAssertOrganizerRole: jest.Mock;
+  let mockAssetResolve: jest.Mock;
+
+  const mockAssetRow = {
+    id: 'asset-uuid',
+    type: 'EMOJI' as const,
+    source: 'emoji',
+    target: '🏔️',
+    fileSize: null,
+    isPublic: true,
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+  };
 
   beforeEach(async () => {
     mockTripsFindFirst = jest.fn().mockResolvedValue(mockTripRow);
     mockGroupsFindFirst = jest.fn().mockResolvedValue(mockGroupRow);
+    mockGroupsFindMany = jest.fn().mockResolvedValue([{ ...mockGroupRow, cover: 'asset-uuid' }]);
     mockGroupTripsFindFirst = jest.fn().mockResolvedValue(mockGroupTripRow);
+    mockAssetsFindMany = jest.fn().mockResolvedValue([mockAssetRow]);
+    mockAssetResolve = jest.fn().mockResolvedValue({ url: 'https://cdn/emoji.svg' });
 
     mockSelectWhere = jest.fn().mockResolvedValue([mockGroupTripRow]);
     mockSelectFrom = jest.fn().mockReturnValue({ where: mockSelectWhere });
@@ -103,8 +120,9 @@ describe('TripsGroupsService', () => {
           useValue: {
             query: {
               trips: { findFirst: mockTripsFindFirst },
-              groups: { findFirst: mockGroupsFindFirst },
+              groups: { findFirst: mockGroupsFindFirst, findMany: mockGroupsFindMany },
               groupTrips: { findFirst: mockGroupTripsFindFirst },
+              assets: { findMany: mockAssetsFindMany },
             },
             select: mockSelect,
             insert: mockInsert,
@@ -115,10 +133,49 @@ describe('TripsGroupsService', () => {
           provide: TripsService,
           useValue: { assertOrganizerRole: mockAssertOrganizerRole },
         },
+        {
+          provide: AssetResolverService,
+          useValue: { resolve: mockAssetResolve },
+        },
       ],
     }).compile();
 
     service = module.get<TripsGroupsService>(TripsGroupsService);
+  });
+
+  describe('listLinkedGroups', () => {
+    it('returns groups with id, name, and coverUrl', async () => {
+      const result = await service.listLinkedGroups('trip-uuid');
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual({
+        id: 'group-uuid',
+        name: 'Aventureros MX',
+        coverUrl: 'https://cdn/emoji.svg',
+      });
+    });
+
+    it('returns empty array when no groups are linked', async () => {
+      mockSelectWhere.mockResolvedValue([]);
+
+      const result = await service.listLinkedGroups('trip-uuid');
+
+      expect(result).toEqual([]);
+    });
+
+    it('returns empty array when all linked groups are soft-deleted', async () => {
+      mockGroupsFindMany.mockResolvedValue([]);
+
+      const result = await service.listLinkedGroups('trip-uuid');
+
+      expect(result).toEqual([]);
+    });
+
+    it('throws NotFoundException when a group cover asset is missing', async () => {
+      mockAssetsFindMany.mockResolvedValue([]);
+
+      await expect(service.listLinkedGroups('trip-uuid')).rejects.toThrow(NotFoundException);
+    });
   });
 
   describe('listTripGroups', () => {

--- a/apps/api/src/modules/trips/groups/trips-groups.service.spec.ts
+++ b/apps/api/src/modules/trips/groups/trips-groups.service.spec.ts
@@ -144,6 +144,12 @@ describe('TripsGroupsService', () => {
   });
 
   describe('listLinkedGroups', () => {
+    it('throws NotFoundException when trip does not exist', async () => {
+      mockTripsFindFirst.mockResolvedValueOnce(null);
+
+      await expect(service.listLinkedGroups('trip-uuid')).rejects.toThrow(NotFoundException);
+    });
+
     it('returns groups with id, name, and coverUrl', async () => {
       const result = await service.listLinkedGroups('trip-uuid');
 

--- a/apps/api/src/modules/trips/groups/trips-groups.service.ts
+++ b/apps/api/src/modules/trips/groups/trips-groups.service.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable, NotFoundException } from '@nestjs/common';
+import { Inject, Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { and, eq, inArray, isNull } from 'drizzle-orm';
 
 import { DRIZZLE_CLIENT, DrizzleClient } from '@/database/drizzle.provider';
@@ -16,6 +16,8 @@ import type { AddTripGroupDto } from './dto/add-trip-group.dto';
 
 @Injectable()
 export class TripsGroupsService {
+  private readonly logger = new Logger(TripsGroupsService.name);
+
   constructor(
     @Inject(DRIZZLE_CLIENT) private readonly db: DrizzleClient,
     private readonly tripsService: TripsService,
@@ -43,11 +45,17 @@ export class TripsGroupsService {
 
     return Promise.all(
       groupRows.map(async (group) => {
-        if (!group.cover) throw new NotFoundException('Group cover asset not found');
+        if (!group.cover) return { id: group.id, name: group.name, coverUrl: null };
         const coverRow = assetMap.get(group.cover);
-        if (!coverRow) throw new NotFoundException('Group cover asset not found');
+        if (!coverRow) {
+          this.logger.warn(`Orphaned cover asset ${group.cover} on group ${group.id}`);
+          return { id: group.id, name: group.name, coverUrl: null };
+        }
         const resolved = await this.assetResolver.resolve(assetRowToAsset(coverRow));
-        if (!resolved) throw new NotFoundException('Failed to resolve group cover');
+        if (!resolved) {
+          this.logger.warn(`Failed to resolve cover asset ${group.cover} on group ${group.id}`);
+          return { id: group.id, name: group.name, coverUrl: null };
+        }
         return { id: group.id, name: group.name, coverUrl: resolved.url };
       }),
     );

--- a/apps/api/src/modules/trips/groups/trips-groups.service.ts
+++ b/apps/api/src/modules/trips/groups/trips-groups.service.ts
@@ -1,13 +1,17 @@
 import { Inject, Injectable, NotFoundException } from '@nestjs/common';
-import { and, eq, isNull } from 'drizzle-orm';
+import { and, eq, inArray, isNull } from 'drizzle-orm';
 
 import { DRIZZLE_CLIENT, DrizzleClient } from '@/database/drizzle.provider';
 import type { AuthenticatedUser } from '@/types/express';
+import { assets } from '@/modules/assets/schema/assets.schema';
+import { AssetResolverService } from '@/modules/assets/asset-resolver.service';
+import { assetRowToAsset } from '@/modules/assets/asset.utils';
 import { groups } from '@/modules/groups/schema/groups.schema';
 import { groupTrips } from '@/modules/trips/schema/group-trips.schema';
 import { trips } from '@/modules/trips/schema/trips.schema';
 import { TripsService } from '@/modules/trips/trips.service';
 import type { TripGroupResponseDto } from './dto/trip-group-response.dto';
+import type { TripLinkedGroupDto } from './dto/trip-linked-group.dto';
 import type { AddTripGroupDto } from './dto/add-trip-group.dto';
 
 @Injectable()
@@ -15,7 +19,39 @@ export class TripsGroupsService {
   constructor(
     @Inject(DRIZZLE_CLIENT) private readonly db: DrizzleClient,
     private readonly tripsService: TripsService,
+    private readonly assetResolver: AssetResolverService,
   ) {}
+
+  async listLinkedGroups(tripId: string): Promise<TripLinkedGroupDto[]> {
+    const links = await this.db.select().from(groupTrips).where(eq(groupTrips.tripId, tripId));
+
+    if (links.length === 0) return [];
+
+    const groupIds = links.map((l) => l.groupId);
+    const groupRows = await this.db.query.groups.findMany({
+      where: and(inArray(groups.id, groupIds), isNull(groups.deletedAt)),
+    });
+
+    if (groupRows.length === 0) return [];
+
+    const coverIds = groupRows.map((g) => g.cover).filter((id): id is string => id !== null);
+    const coverAssets =
+      coverIds.length > 0
+        ? await this.db.query.assets.findMany({ where: inArray(assets.id, coverIds) })
+        : [];
+    const assetMap = new Map(coverAssets.map((a) => [a.id, a]));
+
+    return Promise.all(
+      groupRows.map(async (group) => {
+        if (!group.cover) throw new NotFoundException('Group cover asset not found');
+        const coverRow = assetMap.get(group.cover);
+        if (!coverRow) throw new NotFoundException('Group cover asset not found');
+        const resolved = await this.assetResolver.resolve(assetRowToAsset(coverRow));
+        if (!resolved) throw new NotFoundException('Failed to resolve group cover');
+        return { id: group.id, name: group.name, coverUrl: resolved.url };
+      }),
+    );
+  }
 
   async listTripGroups(user: AuthenticatedUser, tripId: string): Promise<TripGroupResponseDto[]> {
     const trip = await this.db.query.trips.findFirst({ where: eq(trips.id, tripId) });

--- a/apps/api/src/modules/trips/groups/trips-groups.service.ts
+++ b/apps/api/src/modules/trips/groups/trips-groups.service.ts
@@ -25,6 +25,9 @@ export class TripsGroupsService {
   ) {}
 
   async listLinkedGroups(tripId: string): Promise<TripLinkedGroupDto[]> {
+    const trip = await this.db.query.trips.findFirst({ where: eq(trips.id, tripId) });
+    if (!trip) throw new NotFoundException('Trip not found');
+
     const links = await this.db.select().from(groupTrips).where(eq(groupTrips.tripId, tripId));
 
     if (links.length === 0) return [];

--- a/apps/api/src/modules/trips/invitations/trip-invitations.service.spec.ts
+++ b/apps/api/src/modules/trips/invitations/trip-invitations.service.spec.ts
@@ -1,4 +1,9 @@
-import { ConflictException, ForbiddenException, NotFoundException } from '@nestjs/common';
+import {
+  BadRequestException,
+  ConflictException,
+  ForbiddenException,
+  NotFoundException,
+} from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 
 jest.mock('@google-cloud/storage', () => ({
@@ -9,6 +14,7 @@ import {
   NotificationType,
   TripParticipantStatus,
   TripRole,
+  TripStatus,
 } from '@chamuco/shared-types';
 import { DRIZZLE_CLIENT } from '@/database/drizzle.provider';
 import { TripInvitationsService } from './trip-invitations.service';
@@ -82,7 +88,9 @@ describe('TripInvitationsService', () => {
   let mockFindParticipantOrThrow: jest.Mock;
 
   beforeEach(async () => {
-    mockTripsFindFirst = jest.fn().mockResolvedValue({ name: 'Alps Adventure' });
+    mockTripsFindFirst = jest
+      .fn()
+      .mockResolvedValue({ name: 'Alps Adventure', status: TripStatus.OPEN });
     mockTripParticipantsFindMany = jest.fn().mockResolvedValue([]);
     mockUsersFindMany = jest.fn().mockResolvedValue([]);
     mockUsersFindFirst = jest.fn().mockResolvedValue(mockOrganizerUser);
@@ -161,6 +169,17 @@ describe('TripInvitationsService', () => {
         NotificationType.TRIP_INVITATION,
         { tripId: TRIP_ID, tripName: 'Alps Adventure' },
         [NotificationChannel.PUSH],
+      );
+    });
+
+    it('throws BadRequestException when trip is DRAFT', async () => {
+      mockTripsFindFirst.mockResolvedValueOnce({
+        name: 'Alps Adventure',
+        status: TripStatus.DRAFT,
+      });
+
+      await expect(service.sendInvitations(TRIP_ID, dto, ORGANIZER_ID)).rejects.toThrow(
+        BadRequestException,
       );
     });
 

--- a/apps/api/src/modules/trips/invitations/trip-invitations.service.ts
+++ b/apps/api/src/modules/trips/invitations/trip-invitations.service.ts
@@ -1,4 +1,4 @@
-import { ConflictException, Inject, Injectable, Logger } from '@nestjs/common';
+import { BadRequestException, ConflictException, Inject, Injectable, Logger } from '@nestjs/common';
 import { and, count, eq, inArray } from 'drizzle-orm';
 
 import {
@@ -6,6 +6,7 @@ import {
   NotificationType,
   TripParticipantStatus,
   TripRole,
+  TripStatus,
 } from '@chamuco/shared-types';
 import { DRIZZLE_CLIENT, DrizzleClient } from '@/database/drizzle.provider';
 import { isUniqueViolation } from '@/database/db-errors';
@@ -42,8 +43,12 @@ export class TripInvitationsService {
 
     const trip = await this.db.query.trips.findFirst({
       where: eq(trips.id, tripId),
-      columns: { name: true },
+      columns: { name: true, status: true },
     });
+
+    if (trip?.status === TripStatus.DRAFT) {
+      throw new BadRequestException('Invitations are not allowed on DRAFT trips');
+    }
 
     const targetUsers = await this.db.query.users.findMany({
       where: inArray(users.username, dto.usernames),

--- a/apps/api/src/modules/trips/trips.service.spec.ts
+++ b/apps/api/src/modules/trips/trips.service.spec.ts
@@ -2,6 +2,8 @@ import { BadRequestException, ForbiddenException, NotFoundException } from '@nes
 import { Test, TestingModule } from '@nestjs/testing';
 import {
   AuthProvider,
+  NotificationChannel,
+  NotificationType,
   PlatformRole,
   ProfileVisibility,
   TripParticipantStatus,
@@ -12,6 +14,7 @@ import {
 import { DRIZZLE_CLIENT } from '@/database/drizzle.provider';
 import { AssetResolverService } from '@/modules/assets/asset-resolver.service';
 import { CloudStorageService } from '@/modules/cloud-storage/cloud-storage.service';
+import { NotificationsService } from '@/modules/notifications/notifications.service';
 import { TripsService } from './trips.service';
 import type { CreateTripDto } from './dto/create-trip.dto';
 import type { UpdateTripDto } from './dto/update-trip.dto';
@@ -108,6 +111,7 @@ describe('TripsService', () => {
   let mockInsert: jest.Mock;
   let mockTransaction: jest.Mock;
   let mockCloudStorage: { makePublic: jest.Mock; deleteObject: jest.Mock };
+  let mockNotificationsService: { notifyMany: jest.Mock };
 
   beforeEach(async () => {
     mockTripsFindFirst = jest.fn().mockResolvedValue(mockTripRow);
@@ -126,7 +130,10 @@ describe('TripsService', () => {
     mockDelete = jest.fn().mockReturnValue({ where: mockDeleteWhere });
 
     mockInsertReturning = jest.fn().mockResolvedValue([mockTripRow]);
-    mockInsertValues = jest.fn().mockReturnValue({ returning: mockInsertReturning });
+    mockInsertValues = jest.fn().mockReturnValue({
+      returning: mockInsertReturning,
+      onConflictDoNothing: jest.fn().mockResolvedValue([]),
+    });
     mockInsert = jest.fn().mockReturnValue({ values: mockInsertValues });
 
     mockTransaction = jest
@@ -143,6 +150,10 @@ describe('TripsService', () => {
     mockCloudStorage = {
       makePublic: jest.fn().mockResolvedValue(undefined),
       deleteObject: jest.fn().mockResolvedValue(undefined),
+    };
+
+    mockNotificationsService = {
+      notifyMany: jest.fn().mockResolvedValue(undefined),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -170,6 +181,10 @@ describe('TripsService', () => {
         {
           provide: CloudStorageService,
           useValue: mockCloudStorage,
+        },
+        {
+          provide: NotificationsService,
+          useValue: mockNotificationsService,
         },
       ],
     }).compile();
@@ -504,6 +519,80 @@ describe('TripsService', () => {
         new Date('2026-12-08').getTime(),
       );
     });
+
+    it('invites active group members when transitioning DRAFT→OPEN', async () => {
+      // 1. destinations count
+      mockSelectWhere.mockResolvedValueOnce([{ total: 1 }]);
+      // 2. linked groups query
+      mockSelectWhere.mockResolvedValueOnce([{ groupId: 'group-uuid' }]);
+      // 3. active group members
+      mockSelectWhere.mockResolvedValueOnce([{ userId: 'member-uuid' }]);
+      // 4. existing trip participants (none)
+      mockSelectWhere.mockResolvedValueOnce([]);
+      const dto: TransitionTripStatusDto = { status: TripStatus.OPEN };
+
+      await service.transitionStatus(mockUser, 'trip-uuid', dto);
+
+      expect(mockInsertValues).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({
+            tripId: 'trip-uuid',
+            userId: 'member-uuid',
+            role: TripRole.PARTICIPANT,
+            status: TripParticipantStatus.INVITED,
+          }),
+        ]),
+      );
+      expect(mockNotificationsService.notifyMany).toHaveBeenCalledWith(
+        ['member-uuid'],
+        NotificationType.TRIP_INVITATION,
+        { tripId: 'trip-uuid', tripName: 'Cancún 2026' },
+        [NotificationChannel.PUSH],
+      );
+    });
+
+    it('skips invitations when trip has no linked groups on DRAFT→OPEN', async () => {
+      // 1. destinations count
+      mockSelectWhere.mockResolvedValueOnce([{ total: 1 }]);
+      // 2. no linked groups
+      mockSelectWhere.mockResolvedValueOnce([]);
+      const dto: TransitionTripStatusDto = { status: TripStatus.OPEN };
+
+      await service.transitionStatus(mockUser, 'trip-uuid', dto);
+
+      expect(mockNotificationsService.notifyMany).not.toHaveBeenCalled();
+    });
+
+    it('does not re-invite users already participating when DRAFT→OPEN', async () => {
+      // 1. destinations count
+      mockSelectWhere.mockResolvedValueOnce([{ total: 1 }]);
+      // 2. linked groups
+      mockSelectWhere.mockResolvedValueOnce([{ groupId: 'group-uuid' }]);
+      // 3. active members
+      mockSelectWhere.mockResolvedValueOnce([{ userId: 'member-uuid' }]);
+      // 4. member already a participant
+      mockSelectWhere.mockResolvedValueOnce([{ userId: 'member-uuid' }]);
+      const dto: TransitionTripStatusDto = { status: TripStatus.OPEN };
+
+      await service.transitionStatus(mockUser, 'trip-uuid', dto);
+
+      // insert should not be called for the invite (newInviteeIds is empty)
+      expect(mockNotificationsService.notifyMany).not.toHaveBeenCalled();
+    });
+
+    it('excludes organizer from group member invitations on DRAFT→OPEN', async () => {
+      // 1. destinations count
+      mockSelectWhere.mockResolvedValueOnce([{ total: 1 }]);
+      // 2. linked groups
+      mockSelectWhere.mockResolvedValueOnce([{ groupId: 'group-uuid' }]);
+      // 3. active members: only the organizer
+      mockSelectWhere.mockResolvedValueOnce([{ userId: mockUser.id }]);
+      const dto: TransitionTripStatusDto = { status: TripStatus.OPEN };
+
+      await service.transitionStatus(mockUser, 'trip-uuid', dto);
+
+      expect(mockNotificationsService.notifyMany).not.toHaveBeenCalled();
+    });
   });
 
   describe('getMyTrips', () => {
@@ -556,6 +645,10 @@ describe('TripsService', () => {
           {
             provide: CloudStorageService,
             useValue: { makePublic: jest.fn(), deleteObject: jest.fn() },
+          },
+          {
+            provide: NotificationsService,
+            useValue: { notifyMany: jest.fn().mockResolvedValue(undefined) },
           },
         ],
       }).compile();

--- a/apps/api/src/modules/trips/trips.service.ts
+++ b/apps/api/src/modules/trips/trips.service.ts
@@ -359,7 +359,11 @@ export class TripsService {
     await this.db.update(trips).set({ status: dto.status }).where(eq(trips.id, id));
 
     if (trip.status === TripStatus.DRAFT && dto.status === TripStatus.OPEN) {
-      await this.inviteLinkedGroupMembers(id, user.id, trip.name);
+      try {
+        await this.inviteLinkedGroupMembers(id, user.id, trip.name);
+      } catch (err: unknown) {
+        this.logger.error('Failed to invite linked group members after DRAFT→OPEN', err);
+      }
     }
 
     return this.fetchAndMapTrip(id);

--- a/apps/api/src/modules/trips/trips.service.ts
+++ b/apps/api/src/modules/trips/trips.service.ts
@@ -3,18 +3,25 @@ import {
   ForbiddenException,
   Inject,
   Injectable,
+  Logger,
   NotFoundException,
 } from '@nestjs/common';
 import { and, count, eq, inArray } from 'drizzle-orm';
 
 import {
+  GroupMemberStatus,
+  NotificationChannel,
+  NotificationType,
   PlatformRole,
   TripParticipantStatus,
   TripRole,
   TripStatus,
   TripVisibility,
 } from '@chamuco/shared-types';
+import { groupMembers } from '@/modules/groups/schema/group-members.schema';
+import { NotificationsService } from '@/modules/notifications/notifications.service';
 import { tripAnnouncements } from '@/modules/trips/schema/trip-announcements.schema';
+import { groupTrips } from '@/modules/trips/schema/group-trips.schema';
 import { DRIZZLE_CLIENT, DrizzleClient } from '@/database/drizzle.provider';
 import { assets } from '@/modules/assets/schema/assets.schema';
 import { AssetResolverService } from '@/modules/assets/asset-resolver.service';
@@ -43,10 +50,13 @@ const VALID_TRANSITIONS: Partial<Record<TripStatus, TripStatus[]>> = {
 
 @Injectable()
 export class TripsService {
+  private readonly logger = new Logger(TripsService.name);
+
   constructor(
     @Inject(DRIZZLE_CLIENT) private readonly db: DrizzleClient,
     private readonly assetResolver: AssetResolverService,
     private readonly cloudStorage: CloudStorageService,
+    private readonly notifications: NotificationsService,
   ) {}
 
   async getMyTrips(user: AuthenticatedUser): Promise<MyTripListItemResponseDto[]> {
@@ -348,7 +358,74 @@ export class TripsService {
 
     await this.db.update(trips).set({ status: dto.status }).where(eq(trips.id, id));
 
+    if (trip.status === TripStatus.DRAFT && dto.status === TripStatus.OPEN) {
+      await this.inviteLinkedGroupMembers(id, user.id, trip.name);
+    }
+
     return this.fetchAndMapTrip(id);
+  }
+
+  private async inviteLinkedGroupMembers(
+    tripId: string,
+    organizerUserId: string,
+    tripName: string,
+  ): Promise<void> {
+    const linkedGroups = await this.db
+      .select({ groupId: groupTrips.groupId })
+      .from(groupTrips)
+      .where(eq(groupTrips.tripId, tripId));
+
+    if (linkedGroups.length === 0) return;
+
+    const groupIds = linkedGroups.map((r) => r.groupId);
+
+    const activeMembers = await this.db
+      .select({ userId: groupMembers.userId })
+      .from(groupMembers)
+      .where(
+        and(
+          inArray(groupMembers.groupId, groupIds),
+          eq(groupMembers.status, GroupMemberStatus.ACTIVE),
+        ),
+      );
+
+    const candidateIds = [
+      ...new Set(activeMembers.map((m) => m.userId).filter((id) => id !== organizerUserId)),
+    ];
+    if (candidateIds.length === 0) return;
+
+    const existing = await this.db
+      .select({ userId: tripParticipants.userId })
+      .from(tripParticipants)
+      .where(
+        and(eq(tripParticipants.tripId, tripId), inArray(tripParticipants.userId, candidateIds)),
+      );
+
+    const existingIds = new Set(existing.map((r) => r.userId));
+    const newInviteeIds = candidateIds.filter((id) => !existingIds.has(id));
+    if (newInviteeIds.length === 0) return;
+
+    await this.db
+      .insert(tripParticipants)
+      .values(
+        newInviteeIds.map((userId) => ({
+          tripId,
+          userId,
+          role: TripRole.PARTICIPANT,
+          status: TripParticipantStatus.INVITED,
+          isTraveler: true,
+          initiatedBy: organizerUserId,
+        })),
+      )
+      .onConflictDoNothing();
+
+    this.notifications
+      .notifyMany(newInviteeIds, NotificationType.TRIP_INVITATION, { tripId, tripName }, [
+        NotificationChannel.PUSH,
+      ])
+      .catch((err: unknown) => {
+        this.logger.error('Failed to send TRIP_INVITATION notifications after DRAFT→OPEN', err);
+      });
   }
 
   async assertOrganizerRole(

--- a/apps/web/src/app/trips/[id]/page.tsx
+++ b/apps/web/src/app/trips/[id]/page.tsx
@@ -99,6 +99,9 @@ export default function TripDetailPage({ params }: TripDetailPageProps) {
   }
 
   const isOrganizer = callerRole !== null && ORGANIZER_ROLES.includes(callerRole);
+  const isTerminal = trip.status === TripStatus.COMPLETED || trip.status === TripStatus.CANCELLED;
+  const isDestinationEditable =
+    isOrganizer && (trip.status === TripStatus.DRAFT || trip.status === TripStatus.OPEN);
 
   return (
     <div className="p-8 max-w-2xl">
@@ -134,17 +137,11 @@ export default function TripDetailPage({ params }: TripDetailPageProps) {
           )}
           {isOrganizer && (
             <Link
-              href={
-                trip.status !== TripStatus.COMPLETED && trip.status !== TripStatus.CANCELLED
-                  ? `/trips/${trip.id}/settings`
-                  : '#'
-              }
-              className={`inline-flex items-center justify-center rounded-lg border border-border bg-background p-2 transition-colors hover:bg-muted${trip.status === TripStatus.COMPLETED || trip.status === TripStatus.CANCELLED ? ' pointer-events-none opacity-50' : ''}`}
+              href={!isTerminal ? `/trips/${trip.id}/settings` : '#'}
+              className={`inline-flex items-center justify-center rounded-lg border border-border bg-background p-2 transition-colors hover:bg-muted${isTerminal ? ' pointer-events-none opacity-50' : ''}`}
               title={t('actions.editSettings')}
               aria-label={t('actions.editSettings')}
-              aria-disabled={
-                trip.status === TripStatus.COMPLETED || trip.status === TripStatus.CANCELLED
-              }
+              aria-disabled={isTerminal}
             >
               <GearSixIcon className="size-5" aria-hidden="true" />
             </Link>
@@ -217,9 +214,7 @@ export default function TripDetailPage({ params }: TripDetailPageProps) {
         <DestinationList
           tripId={id}
           initialDestinations={destinations}
-          isOrganizer={
-            isOrganizer && (trip.status === TripStatus.DRAFT || trip.status === TripStatus.OPEN)
-          }
+          isOrganizer={isDestinationEditable}
           departureCity={trip.departureCity}
           departureCountry={trip.departureCountry}
           landingCity={trip.landingCity}
@@ -282,23 +277,20 @@ export default function TripDetailPage({ params }: TripDetailPageProps) {
       <section>
         <div className="flex items-center justify-between mb-2">
           <h2 className="text-sm font-semibold">{t('detail.itineraryNotes')}</h2>
-          {isOrganizer &&
-            !isEditingNotes &&
-            trip.status !== TripStatus.COMPLETED &&
-            trip.status !== TripStatus.CANCELLED && (
-              <button
-                type="button"
-                onClick={() => {
-                  setDraftNotes(trip.itineraryNotes ?? '');
-                  setIsEditingNotes(true);
-                }}
-                className="inline-flex items-center justify-center rounded p-1.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-                title={t('detail.editItineraryNotes')}
-                aria-label={t('detail.editItineraryNotes')}
-              >
-                <PencilSimpleIcon className="size-4" aria-hidden="true" />
-              </button>
-            )}
+          {isOrganizer && !isEditingNotes && !isTerminal && (
+            <button
+              type="button"
+              onClick={() => {
+                setDraftNotes(trip.itineraryNotes ?? '');
+                setIsEditingNotes(true);
+              }}
+              className="inline-flex items-center justify-center rounded p-1.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+              title={t('detail.editItineraryNotes')}
+              aria-label={t('detail.editItineraryNotes')}
+            >
+              <PencilSimpleIcon className="size-4" aria-hidden="true" />
+            </button>
+          )}
         </div>
 
         {isEditingNotes ? (

--- a/apps/web/src/app/trips/[id]/page.tsx
+++ b/apps/web/src/app/trips/[id]/page.tsx
@@ -99,6 +99,7 @@ export default function TripDetailPage({ params }: TripDetailPageProps) {
   }
 
   const isOrganizer = callerRole !== null && ORGANIZER_ROLES.includes(callerRole);
+  const isDraft = trip.status === TripStatus.DRAFT;
   const isTerminal = trip.status === TripStatus.COMPLETED || trip.status === TripStatus.CANCELLED;
   const isDestinationEditable =
     isOrganizer && (trip.status === TripStatus.DRAFT || trip.status === TripStatus.OPEN);
@@ -126,11 +127,11 @@ export default function TripDetailPage({ params }: TripDetailPageProps) {
           </Link>
           {isOrganizer && (
             <Link
-              href={trip.status !== TripStatus.DRAFT ? `/trips/${trip.id}/announcements/new` : '#'}
-              className={`inline-flex items-center justify-center rounded-lg border border-border bg-background p-2 transition-colors hover:bg-muted${trip.status === TripStatus.DRAFT ? ' pointer-events-none opacity-50' : ''}`}
+              href={!isDraft ? `/trips/${trip.id}/announcements/new` : '#'}
+              className={`inline-flex items-center justify-center rounded-lg border border-border bg-background p-2 transition-colors hover:bg-muted${isDraft ? ' pointer-events-none opacity-50' : ''}`}
               title={t('announcementsPublish')}
               aria-label={t('announcementsPublish')}
-              aria-disabled={trip.status === TripStatus.DRAFT}
+              aria-disabled={isDraft}
             >
               <MegaphoneIcon className="size-5" aria-hidden="true" />
             </Link>

--- a/apps/web/src/app/trips/[id]/page.tsx
+++ b/apps/web/src/app/trips/[id]/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState, use } from 'react';
 import Link from 'next/link';
 import { useTranslation } from 'react-i18next';
-import { TripRole, TripVisibility } from '@chamuco/shared-types';
+import { TripRole, TripStatus, TripVisibility } from '@chamuco/shared-types';
 import {
   ArrowLeftIcon,
   GearSixIcon,
@@ -14,12 +14,14 @@ import {
   UsersIcon,
   NavigationArrowIcon,
   PencilSimpleIcon,
+  LinkIcon,
 } from '@phosphor-icons/react';
 
 import { toast } from '@/components/ui/toast';
 import {
   getTrip,
   getTripDestinations,
+  getTripLinkedGroups,
   getTripParticipation,
   updateTrip,
 } from '@/services/trips.service';
@@ -29,7 +31,7 @@ import { TripStatusTransition } from '@/components/trips/TripStatusTransition';
 import { DestinationList } from '@/components/trips/DestinationList';
 import { MarkdownContent } from '@/components/ui/markdown-content';
 import { RichTextEditor } from '@/components/ui/rich-text-editor';
-import type { TripResponse, DestinationResponse } from '@/services/trips.types';
+import type { TripResponse, DestinationResponse, TripLinkedGroup } from '@/services/trips.types';
 
 interface TripDetailPageProps {
   params: Promise<{ id: string }>;
@@ -43,6 +45,8 @@ export default function TripDetailPage({ params }: TripDetailPageProps) {
   const { isLoading: isAuthLoading } = useAuth();
   const [trip, setTrip] = useState<TripResponse | null>(null);
   const [destinations, setDestinations] = useState<DestinationResponse[]>([]);
+  const [destinationCount, setDestinationCount] = useState(0);
+  const [linkedGroups, setLinkedGroups] = useState<TripLinkedGroup[]>([]);
   const [callerRole, setCallerRole] = useState<TripRole | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [notFound, setNotFound] = useState(false);
@@ -57,11 +61,14 @@ export default function TripDetailPage({ params }: TripDetailPageProps) {
       getTrip(id),
       getTripDestinations(id).catch(() => []),
       getTripParticipation(id).catch(() => null),
+      getTripLinkedGroups(id).catch(() => []),
     ])
-      .then(([tripData, destinationsData, participation]) => {
+      .then(([tripData, destinationsData, participation, linkedGroupsData]) => {
         setTrip(tripData);
         setDestinations(destinationsData);
+        setDestinationCount(destinationsData.length);
         setCallerRole(participation?.role ?? null);
+        setLinkedGroups(linkedGroupsData);
       })
       .catch(() => setNotFound(true))
       .finally(() => setIsLoading(false));
@@ -116,20 +123,28 @@ export default function TripDetailPage({ params }: TripDetailPageProps) {
           </Link>
           {isOrganizer && (
             <Link
-              href={`/trips/${trip.id}/announcements/new`}
-              className="inline-flex items-center justify-center rounded-lg border border-border bg-background p-2 transition-colors hover:bg-muted"
+              href={trip.status !== TripStatus.DRAFT ? `/trips/${trip.id}/announcements/new` : '#'}
+              className={`inline-flex items-center justify-center rounded-lg border border-border bg-background p-2 transition-colors hover:bg-muted${trip.status === TripStatus.DRAFT ? ' pointer-events-none opacity-50' : ''}`}
               title={t('announcementsPublish')}
               aria-label={t('announcementsPublish')}
+              aria-disabled={trip.status === TripStatus.DRAFT}
             >
               <MegaphoneIcon className="size-5" aria-hidden="true" />
             </Link>
           )}
           {isOrganizer && (
             <Link
-              href={`/trips/${trip.id}/settings`}
-              className="inline-flex items-center justify-center rounded-lg border border-border bg-background p-2 transition-colors hover:bg-muted"
+              href={
+                trip.status !== TripStatus.COMPLETED && trip.status !== TripStatus.CANCELLED
+                  ? `/trips/${trip.id}/settings`
+                  : '#'
+              }
+              className={`inline-flex items-center justify-center rounded-lg border border-border bg-background p-2 transition-colors hover:bg-muted${trip.status === TripStatus.COMPLETED || trip.status === TripStatus.CANCELLED ? ' pointer-events-none opacity-50' : ''}`}
               title={t('actions.editSettings')}
               aria-label={t('actions.editSettings')}
+              aria-disabled={
+                trip.status === TripStatus.COMPLETED || trip.status === TripStatus.CANCELLED
+              }
             >
               <GearSixIcon className="size-5" aria-hidden="true" />
             </Link>
@@ -183,7 +198,12 @@ export default function TripDetailPage({ params }: TripDetailPageProps) {
       {/* Organizer status transitions */}
       {isOrganizer && (
         <section className="mb-6">
-          <TripStatusTransition tripId={id} currentStatus={trip.status} onTransitioned={setTrip} />
+          <TripStatusTransition
+            tripId={id}
+            currentStatus={trip.status}
+            onTransitioned={setTrip}
+            disabledTargets={destinationCount === 0 ? [TripStatus.OPEN] : []}
+          />
         </section>
       )}
 
@@ -197,11 +217,14 @@ export default function TripDetailPage({ params }: TripDetailPageProps) {
         <DestinationList
           tripId={id}
           initialDestinations={destinations}
-          isOrganizer={isOrganizer}
+          isOrganizer={
+            isOrganizer && (trip.status === TripStatus.DRAFT || trip.status === TripStatus.OPEN)
+          }
           departureCity={trip.departureCity}
           departureCountry={trip.departureCountry}
           landingCity={trip.landingCity}
           landingCountry={trip.landingCountry}
+          onCountChange={setDestinationCount}
         />
       </section>
 
@@ -225,24 +248,57 @@ export default function TripDetailPage({ params }: TripDetailPageProps) {
         </section>
       )}
 
+      {/* Linked groups */}
+      {linkedGroups.length > 0 && (
+        <section className="mb-6">
+          <div className="flex items-center gap-2 mb-3">
+            <LinkIcon className="size-4 text-muted-foreground" aria-hidden="true" />
+            <h2 className="text-sm font-semibold">{t('detail.linkedGroups')}</h2>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {linkedGroups.map((group) => (
+              <div
+                key={group.id}
+                className="flex items-center gap-2 rounded-full border border-border bg-background px-3 py-1.5 text-sm"
+              >
+                <div className="size-5 shrink-0 overflow-hidden rounded-sm bg-muted">
+                  {group.coverUrl && (
+                    <img
+                      src={group.coverUrl}
+                      alt=""
+                      className="size-full object-cover"
+                      aria-hidden="true"
+                    />
+                  )}
+                </div>
+                <span className="font-medium">{group.name}</span>
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+
       {/* Itinerary notes */}
       <section>
         <div className="flex items-center justify-between mb-2">
           <h2 className="text-sm font-semibold">{t('detail.itineraryNotes')}</h2>
-          {isOrganizer && !isEditingNotes && (
-            <button
-              type="button"
-              onClick={() => {
-                setDraftNotes(trip.itineraryNotes ?? '');
-                setIsEditingNotes(true);
-              }}
-              className="inline-flex items-center justify-center rounded p-1.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-              title={t('detail.editItineraryNotes')}
-              aria-label={t('detail.editItineraryNotes')}
-            >
-              <PencilSimpleIcon className="size-4" aria-hidden="true" />
-            </button>
-          )}
+          {isOrganizer &&
+            !isEditingNotes &&
+            trip.status !== TripStatus.COMPLETED &&
+            trip.status !== TripStatus.CANCELLED && (
+              <button
+                type="button"
+                onClick={() => {
+                  setDraftNotes(trip.itineraryNotes ?? '');
+                  setIsEditingNotes(true);
+                }}
+                className="inline-flex items-center justify-center rounded p-1.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                title={t('detail.editItineraryNotes')}
+                aria-label={t('detail.editItineraryNotes')}
+              >
+                <PencilSimpleIcon className="size-4" aria-hidden="true" />
+              </button>
+            )}
         </div>
 
         {isEditingNotes ? (

--- a/apps/web/src/app/trips/[id]/participants/page.tsx
+++ b/apps/web/src/app/trips/[id]/participants/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState, use } from 'react';
 import Link from 'next/link';
 import { useTranslation } from 'react-i18next';
-import { TripParticipantStatus, TripRole, TripVisibility } from '@chamuco/shared-types';
+import { TripParticipantStatus, TripRole, TripStatus, TripVisibility } from '@chamuco/shared-types';
 import { ArrowLeftIcon } from '@phosphor-icons/react';
 import {
   getTrip,
@@ -157,6 +157,7 @@ export default function TripParticipantsPage({ params }: ParticipantsPageProps) 
             capacity={trip.participantCapacity}
             currentUserId={appUser?.id ?? null}
             callerRole={callerRole}
+            canInvite={trip.status !== TripStatus.DRAFT}
             onInviteSuccess={() => void loadData()}
             onParticipantAction={() => void loadData()}
             excludedIds={excludedIds}

--- a/apps/web/src/app/trips/[id]/settings/page.test.tsx
+++ b/apps/web/src/app/trips/[id]/settings/page.test.tsx
@@ -6,6 +6,7 @@ import type { TripResponse } from '@/services/trips.types';
 const mocks = vi.hoisted(() => ({
   mockApiGet: vi.fn(),
   mockApiPatch: vi.fn(),
+  mockApiDelete: vi.fn(),
   mockUseAuth: vi.fn(),
   mockRouterReplace: vi.fn(),
   mockToastSuccess: vi.fn(),
@@ -46,6 +47,7 @@ vi.mock('@/services/api-client', () => ({
   apiClient: {
     get: mocks.mockApiGet,
     patch: mocks.mockApiPatch,
+    delete: mocks.mockApiDelete,
   },
 }));
 
@@ -76,6 +78,10 @@ vi.mock('@/components/trips/TripForm', () => ({
       </button>
     </div>
   ),
+}));
+
+vi.mock('@/components/trips/TripLinkedGroupsEditor', () => ({
+  TripLinkedGroupsEditor: () => <div data-testid="linked-groups-editor" />,
 }));
 
 vi.mock('@/components/ui/toast', () => ({
@@ -237,12 +243,13 @@ describe('TripSettingsPage', () => {
     });
   });
 
-  it('shows danger zone for DRAFT trip', async () => {
+  it('shows delete button (not cancel) for DRAFT trip', async () => {
     setupMocks({ tripStatus: TripStatus.DRAFT });
     render(<TripSettingsPage params={Promise.resolve({ id: 'trip-id' })} />);
 
     await waitFor(() => {
-      expect(screen.getByTestId('cancel-trip-btn')).toBeInTheDocument();
+      expect(screen.getByTestId('delete-trip-btn')).toBeInTheDocument();
+      expect(screen.queryByTestId('cancel-trip-btn')).not.toBeInTheDocument();
     });
   });
 
@@ -261,24 +268,25 @@ describe('TripSettingsPage', () => {
 
     await waitFor(() => {
       expect(screen.queryByTestId('cancel-trip-btn')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('delete-trip-btn')).not.toBeInTheDocument();
     });
   });
 
-  it('hides danger zone for CANCELLED trip', async () => {
+  it('redirects to trip detail for CANCELLED trip', async () => {
     setupMocks({ tripStatus: TripStatus.CANCELLED });
     render(<TripSettingsPage params={Promise.resolve({ id: 'trip-id' })} />);
 
     await waitFor(() => {
-      expect(screen.queryByTestId('cancel-trip-btn')).not.toBeInTheDocument();
+      expect(mocks.mockRouterReplace).toHaveBeenCalledWith('/trips/trip-id');
     });
   });
 
-  it('hides danger zone for COMPLETED trip', async () => {
+  it('redirects to trip detail for COMPLETED trip', async () => {
     setupMocks({ tripStatus: TripStatus.COMPLETED });
     render(<TripSettingsPage params={Promise.resolve({ id: 'trip-id' })} />);
 
     await waitFor(() => {
-      expect(screen.queryByTestId('cancel-trip-btn')).not.toBeInTheDocument();
+      expect(mocks.mockRouterReplace).toHaveBeenCalledWith('/trips/trip-id');
     });
   });
 
@@ -363,6 +371,67 @@ describe('TripSettingsPage', () => {
 
     await waitFor(() => {
       expect(screen.queryByTestId('cancel-trip-confirm-btn')).not.toBeInTheDocument();
+    });
+  });
+
+  it('opens delete dialog when delete button clicked', async () => {
+    setupMocks({ tripStatus: TripStatus.DRAFT });
+    render(<TripSettingsPage params={Promise.resolve({ id: 'trip-id' })} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('delete-trip-btn')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('delete-trip-btn'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('delete-trip-confirm-btn')).toBeInTheDocument();
+    });
+  });
+
+  it('calls deleteTrip and redirects to /trips on confirm', async () => {
+    mocks.mockApiDelete.mockResolvedValue({});
+    setupMocks({ tripStatus: TripStatus.DRAFT });
+    render(<TripSettingsPage params={Promise.resolve({ id: 'trip-id' })} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('delete-trip-btn')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('delete-trip-btn'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('delete-trip-confirm-btn')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('delete-trip-confirm-btn'));
+
+    await waitFor(() => {
+      expect(mocks.mockApiDelete).toHaveBeenCalledWith('/v1/trips/trip-id');
+      expect(mocks.mockToastSuccess).toHaveBeenCalledWith('settings.deleteSuccess');
+      expect(mocks.mockRouterReplace).toHaveBeenCalledWith('/trips');
+    });
+  });
+
+  it('shows error toast when delete fails', async () => {
+    mocks.mockApiDelete.mockRejectedValue(new Error('Server error'));
+    setupMocks({ tripStatus: TripStatus.DRAFT });
+    render(<TripSettingsPage params={Promise.resolve({ id: 'trip-id' })} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('delete-trip-btn')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('delete-trip-btn'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('delete-trip-confirm-btn')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('delete-trip-confirm-btn'));
+
+    await waitFor(() => {
+      expect(mocks.mockToastError).toHaveBeenCalledWith('settings.deleteFailed');
     });
   });
 

--- a/apps/web/src/app/trips/[id]/settings/page.tsx
+++ b/apps/web/src/app/trips/[id]/settings/page.tsx
@@ -7,10 +7,16 @@ import { useTranslation } from 'react-i18next';
 import { TripRole, TripStatus } from '@chamuco/shared-types';
 import { ArrowLeftIcon } from '@phosphor-icons/react';
 
-import { getTrip, getTripParticipation, transitionTripStatus } from '@/services/trips.service';
+import {
+  deleteTrip,
+  getTrip,
+  getTripParticipation,
+  transitionTripStatus,
+} from '@/services/trips.service';
 import { useAuth } from '@/hooks/useAuth';
 import { TripCoverEditor } from '@/components/trips/TripCoverEditor';
 import { TripForm } from '@/components/trips/TripForm';
+import { TripLinkedGroupsEditor } from '@/components/trips/TripLinkedGroupsEditor';
 import { toast } from '@/components/ui/toast';
 import { Button } from '@/components/ui/button';
 import {
@@ -44,6 +50,8 @@ export default function TripSettingsPage({ params }: TripSettingsPageProps) {
   const [isLoading, setIsLoading] = useState(true);
   const [showCancelDialog, setShowCancelDialog] = useState(false);
   const [isCancelling, setIsCancelling] = useState(false);
+  const [showDeleteDialog, setShowDeleteDialog] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
 
   const fetchTrip = useCallback(() => {
     if (isAuthLoading) return;
@@ -51,6 +59,10 @@ export default function TripSettingsPage({ params }: TripSettingsPageProps) {
       .then(([tripData, participation]) => {
         const role = participation?.role ?? null;
         if (role === null || !ORGANIZER_ROLES.includes(role)) {
+          router.replace(`/trips/${id}`);
+          return;
+        }
+        if (tripData.status === TripStatus.COMPLETED || tripData.status === TripStatus.CANCELLED) {
           router.replace(`/trips/${id}`);
           return;
         }
@@ -78,9 +90,24 @@ export default function TripSettingsPage({ params }: TripSettingsPageProps) {
     }
   }
 
+  async function handleDelete() {
+    setIsDeleting(true);
+    try {
+      await deleteTrip(id);
+      setShowDeleteDialog(false);
+      toast.success(t('settings.deleteSuccess'));
+      router.replace('/trips');
+    } catch {
+      toast.error(t('settings.deleteFailed'));
+    } finally {
+      setIsDeleting(false);
+    }
+  }
+
   if (isLoading || !trip) return null;
 
-  const canCancel = CANCELLABLE_STATUSES.includes(trip.status);
+  const isDraft = trip.status === TripStatus.DRAFT;
+  const canCancel = CANCELLABLE_STATUSES.includes(trip.status) && !isDraft;
 
   return (
     <div className="p-8 max-w-xl">
@@ -99,6 +126,10 @@ export default function TripSettingsPage({ params }: TripSettingsPageProps) {
       <div className="mb-8">
         <p className="text-sm font-medium mb-3">{t('cover.label')}</p>
         <TripCoverEditor trip={trip} onUpdate={fetchTrip} />
+      </div>
+
+      <div className="mb-8">
+        <TripLinkedGroupsEditor tripId={id} />
       </div>
 
       <TripForm
@@ -123,6 +154,62 @@ export default function TripSettingsPage({ params }: TripSettingsPageProps) {
           toast.success(t('settings.editSuccess'));
         }}
       />
+
+      {isDraft && (
+        <>
+          <div className="mt-10 rounded-xl border border-destructive/50 p-6">
+            <h2 className="text-base font-semibold text-destructive mb-3">
+              {t('settings.dangerZone')}
+            </h2>
+            <div className="flex items-center justify-between gap-4">
+              <p className="text-sm text-muted-foreground">{t('settings.deleteTripDescription')}</p>
+              <Button
+                type="button"
+                variant="destructive"
+                size="sm"
+                onClick={() => setShowDeleteDialog(true)}
+                data-testid="delete-trip-btn"
+              >
+                {t('settings.deleteTrip')}
+              </Button>
+            </div>
+          </div>
+
+          <Dialog
+            open={showDeleteDialog}
+            onOpenChange={(open) => !isDeleting && setShowDeleteDialog(open)}
+          >
+            <DialogPopup>
+              <DialogClose />
+              <DialogHeader>
+                <DialogTitle>{t('settings.deleteDialogTitle')}</DialogTitle>
+                <DialogDescription>{t('settings.deleteDialogDescription')}</DialogDescription>
+              </DialogHeader>
+              <DialogFooter className="mt-4">
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setShowDeleteDialog(false)}
+                  disabled={isDeleting}
+                >
+                  {t('transitions.cancelButton')}
+                </Button>
+                <Button
+                  type="button"
+                  variant="destructive"
+                  size="sm"
+                  onClick={() => void handleDelete()}
+                  disabled={isDeleting}
+                  data-testid="delete-trip-confirm-btn"
+                >
+                  {t('transitions.confirmButton')}
+                </Button>
+              </DialogFooter>
+            </DialogPopup>
+          </Dialog>
+        </>
+      )}
 
       {canCancel && (
         <>

--- a/apps/web/src/components/trips/DestinationList.tsx
+++ b/apps/web/src/components/trips/DestinationList.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, type SubmitEvent } from 'react';
+import { useEffect, useState, type SubmitEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   DndContext,
@@ -61,6 +61,7 @@ interface DestinationListProps {
   departureCountry: string;
   landingCity: string;
   landingCountry: string;
+  onCountChange?: (count: number) => void;
 }
 
 type FormMode = 'add' | 'edit';
@@ -273,11 +274,16 @@ export function DestinationList({
   departureCountry,
   landingCity,
   landingCountry,
+  onCountChange,
 }: DestinationListProps) {
   const { t } = useTranslation('trips');
   const [destinations, setDestinations] = useState<DestinationResponse[]>(initialDestinations);
   const [isSaving, setIsSaving] = useState(false);
   const [formState, setFormState] = useState<FormState | null>(null);
+
+  useEffect(() => {
+    onCountChange?.(destinations.length);
+  }, [destinations.length, onCountChange]);
 
   const sensors = useSensors(
     useSensor(PointerSensor),

--- a/apps/web/src/components/trips/TripForm.test.tsx
+++ b/apps/web/src/components/trips/TripForm.test.tsx
@@ -125,6 +125,10 @@ vi.mock('@/components/ui/timezone-combobox', () => ({
   ),
 }));
 
+vi.mock('@/components/ui/group-autocomplete', () => ({
+  GroupAutocomplete: () => <input data-testid="group-autocomplete" readOnly />,
+}));
+
 import { TripForm } from './TripForm';
 
 const mockTrip = {

--- a/apps/web/src/components/trips/TripForm.tsx
+++ b/apps/web/src/components/trips/TripForm.tsx
@@ -14,9 +14,10 @@ import { CountryCombobox } from '@/components/ui/country-combobox';
 import { CityCombobox } from '@/components/ui/city-combobox';
 import { TimezoneCombobox } from '@/components/ui/timezone-combobox';
 import { CropModal } from '@/components/ui/crop-modal';
-import { createTrip, updateTrip } from '@/services/trips.service';
+import { createTrip, updateTrip, addTripGroup } from '@/services/trips.service';
 import { getSignedUrl } from '@/services/uploads.service';
 import { uploadToGcs } from '@/services/gcs-upload';
+import { GroupAutocomplete, type GroupPickerItem } from '@/components/ui/group-autocomplete';
 import { AVATAR_EMOJIS } from '@/lib/avatar-emojis';
 import type { TripResponse } from '@/services/trips.types';
 
@@ -76,6 +77,9 @@ export function TripForm({ mode, tripId, initialValues, onSuccess }: TripFormPro
   const [defaultCurrency, setDefaultCurrency] = useState(initialValues?.defaultCurrency ?? '');
   const [showOptional, setShowOptional] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
+
+  const [linkedGroups, setLinkedGroups] = useState<GroupPickerItem[]>([]);
+  const [groupSearchInput, setGroupSearchInput] = useState('');
 
   const [coverTab, setCoverTab] = useState<CoverTab>('emoji');
   const [selectedEmoji, setSelectedEmoji] = useState(AVATAR_EMOJIS[0] ?? '😀');
@@ -161,6 +165,14 @@ export function TripForm({ mode, tripId, initialValues, onSuccess }: TripFormPro
             toast.error(t('errors.coverUploadFailed'));
             onSuccess(trip);
             return;
+          }
+        }
+
+        for (const group of linkedGroups) {
+          try {
+            await addTripGroup(trip.id, { groupId: group.id });
+          } catch {
+            // best-effort: group linking failure does not block trip creation
           }
         }
 
@@ -379,6 +391,53 @@ export function TripForm({ mode, tripId, initialValues, onSuccess }: TripFormPro
               />
             </div>
           </div>
+        </div>
+      )}
+
+      {/* Linked groups (create only) */}
+      {mode === 'create' && (
+        <div className="space-y-2">
+          <Label>{t('form.linkedGroups')}</Label>
+          {linkedGroups.length > 0 && (
+            <div className="flex flex-wrap gap-2">
+              {linkedGroups.map((g) => (
+                <span
+                  key={g.id}
+                  className="flex items-center gap-1.5 rounded-full bg-muted px-3 py-1 text-sm"
+                >
+                  {g.coverUrl && (
+                    <img
+                      src={g.coverUrl}
+                      alt=""
+                      className="size-4 rounded-sm object-cover"
+                      aria-hidden="true"
+                    />
+                  )}
+                  {g.name}
+                  <button
+                    type="button"
+                    onClick={() => setLinkedGroups((prev) => prev.filter((x) => x.id !== g.id))}
+                    className="ml-0.5 rounded-full hover:text-destructive"
+                    aria-label={t('form.linkedGroupsRemove', { name: g.name })}
+                  >
+                    ×
+                  </button>
+                </span>
+              ))}
+            </div>
+          )}
+          <GroupAutocomplete
+            value={groupSearchInput}
+            onChange={setGroupSearchInput}
+            onSelect={(group) => {
+              setLinkedGroups((prev) =>
+                prev.some((g) => g.id === group.id) ? prev : [...prev, group],
+              );
+            }}
+            excludedIds={linkedGroups.map((g) => g.id)}
+            placeholder={t('form.linkedGroupsPlaceholder')}
+            disabled={isSaving}
+          />
         </div>
       )}
 

--- a/apps/web/src/components/trips/TripLinkedGroupsEditor.test.tsx
+++ b/apps/web/src/components/trips/TripLinkedGroupsEditor.test.tsx
@@ -1,0 +1,145 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+const mocks = vi.hoisted(() => ({
+  mockGetTripLinkedGroups: vi.fn(),
+  mockAddTripGroup: vi.fn(),
+  mockRemoveTripGroup: vi.fn(),
+  mockToastError: vi.fn(),
+}));
+
+vi.mock('@/services/trips.service', () => ({
+  getTripLinkedGroups: mocks.mockGetTripLinkedGroups,
+  addTripGroup: mocks.mockAddTripGroup,
+  removeTripGroup: mocks.mockRemoveTripGroup,
+}));
+
+vi.mock('@/components/ui/toast', () => ({
+  toast: { error: mocks.mockToastError },
+}));
+
+vi.mock('@/components/ui/group-autocomplete', () => ({
+  GroupAutocomplete: ({
+    onSelect,
+    onChange,
+  }: {
+    onSelect: (g: { id: string; name: string; coverUrl: string }) => void;
+    onChange: (v: string) => void;
+  }) => (
+    <button
+      data-testid="group-autocomplete"
+      onClick={() => {
+        onSelect({ id: 'group-2', name: 'Beach Crew', coverUrl: 'https://cdn/emoji2.svg' });
+        onChange('');
+      }}
+    >
+      add-group
+    </button>
+  ),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, unknown>) => {
+      if (opts?.name) return `${key}:${String(opts.name)}`;
+      return key;
+    },
+  }),
+}));
+
+vi.mock('@phosphor-icons/react', () => ({
+  XIcon: () => <span>x</span>,
+}));
+
+import { TripLinkedGroupsEditor } from './TripLinkedGroupsEditor';
+
+const existingGroup = { id: 'group-1', name: 'Mountain Crew', coverUrl: 'https://cdn/emoji.svg' };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.mockGetTripLinkedGroups.mockResolvedValue([existingGroup]);
+  mocks.mockAddTripGroup.mockResolvedValue({});
+  mocks.mockRemoveTripGroup.mockResolvedValue(undefined);
+});
+
+describe('TripLinkedGroupsEditor', () => {
+  it('loads and displays linked groups', async () => {
+    render(<TripLinkedGroupsEditor tripId="trip-1" />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Mountain Crew')).toBeInTheDocument();
+    });
+  });
+
+  it('removes a group on remove button click', async () => {
+    const user = userEvent.setup();
+    render(<TripLinkedGroupsEditor tripId="trip-1" />);
+
+    await waitFor(() => screen.getByText('Mountain Crew'));
+
+    await user.click(screen.getByRole('button', { name: /linkedGroupRemove/ }));
+
+    await waitFor(() => {
+      expect(mocks.mockRemoveTripGroup).toHaveBeenCalledWith('trip-1', 'group-1');
+      expect(screen.queryByText('Mountain Crew')).not.toBeInTheDocument();
+    });
+  });
+
+  it('adds a group via autocomplete', async () => {
+    const user = userEvent.setup();
+    render(<TripLinkedGroupsEditor tripId="trip-1" />);
+
+    await waitFor(() => screen.getByText('Mountain Crew'));
+
+    await user.click(screen.getByTestId('group-autocomplete'));
+
+    await waitFor(() => {
+      expect(mocks.mockAddTripGroup).toHaveBeenCalledWith('trip-1', { groupId: 'group-2' });
+      expect(screen.getByText('Beach Crew')).toBeInTheDocument();
+    });
+  });
+
+  it('shows error toast when remove fails', async () => {
+    mocks.mockRemoveTripGroup.mockRejectedValue(new Error('fail'));
+    const user = userEvent.setup();
+    render(<TripLinkedGroupsEditor tripId="trip-1" />);
+
+    await waitFor(() => screen.getByText('Mountain Crew'));
+
+    await user.click(screen.getByRole('button', { name: /linkedGroupRemove/ }));
+
+    await waitFor(() => {
+      expect(mocks.mockToastError).toHaveBeenCalledWith('settings.linkedGroupRemoveFailed');
+    });
+  });
+
+  it('shows error toast when add fails', async () => {
+    mocks.mockAddTripGroup.mockRejectedValue(new Error('fail'));
+    const user = userEvent.setup();
+    render(<TripLinkedGroupsEditor tripId="trip-1" />);
+
+    await waitFor(() => screen.getByText('Mountain Crew'));
+
+    await user.click(screen.getByTestId('group-autocomplete'));
+
+    await waitFor(() => {
+      expect(mocks.mockToastError).toHaveBeenCalledWith('settings.linkedGroupAddFailed');
+    });
+  });
+
+  it('does not add a group that is already linked', async () => {
+    mocks.mockGetTripLinkedGroups.mockResolvedValue([
+      { id: 'group-2', name: 'Beach Crew', coverUrl: 'https://cdn/emoji2.svg' },
+    ]);
+    const user = userEvent.setup();
+    render(<TripLinkedGroupsEditor tripId="trip-1" />);
+
+    await waitFor(() => screen.getByText('Beach Crew'));
+
+    await user.click(screen.getByTestId('group-autocomplete'));
+
+    await waitFor(() => {
+      expect(mocks.mockAddTripGroup).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/web/src/components/trips/TripLinkedGroupsEditor.tsx
+++ b/apps/web/src/components/trips/TripLinkedGroupsEditor.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { XIcon } from '@phosphor-icons/react';
+
+import { toast } from '@/components/ui/toast';
+import { GroupAutocomplete, type GroupPickerItem } from '@/components/ui/group-autocomplete';
+import { getTripLinkedGroups, addTripGroup, removeTripGroup } from '@/services/trips.service';
+import type { TripLinkedGroup } from '@/services/trips.types';
+
+interface TripLinkedGroupsEditorProps {
+  tripId: string;
+}
+
+export function TripLinkedGroupsEditor({ tripId }: TripLinkedGroupsEditorProps) {
+  const { t } = useTranslation('trips');
+  const [groups, setGroups] = useState<TripLinkedGroup[]>([]);
+  const [groupSearchInput, setGroupSearchInput] = useState('');
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    getTripLinkedGroups(tripId)
+      .then(setGroups)
+      .catch(() => {})
+      .finally(() => setIsLoading(false));
+  }, [tripId]);
+
+  async function handleAdd(group: GroupPickerItem) {
+    if (groups.some((g) => g.id === group.id)) return;
+    try {
+      await addTripGroup(tripId, { groupId: group.id });
+      setGroups((prev) => [...prev, { id: group.id, name: group.name, coverUrl: group.coverUrl }]);
+    } catch {
+      toast.error(t('settings.linkedGroupAddFailed'));
+    }
+  }
+
+  async function handleRemove(groupId: string) {
+    try {
+      await removeTripGroup(tripId, groupId);
+      setGroups((prev) => prev.filter((g) => g.id !== groupId));
+    } catch {
+      toast.error(t('settings.linkedGroupRemoveFailed'));
+    }
+  }
+
+  if (isLoading) return null;
+
+  return (
+    <div className="space-y-3">
+      <p className="text-sm font-medium">{t('settings.linkedGroups')}</p>
+
+      {groups.length > 0 && (
+        <ul className="space-y-2">
+          {groups.map((group) => (
+            <li
+              key={group.id}
+              className="flex items-center gap-3 rounded-lg border border-border bg-background px-3 py-2"
+            >
+              <div className="size-8 shrink-0 overflow-hidden rounded-md bg-muted">
+                {group.coverUrl && (
+                  <img
+                    src={group.coverUrl}
+                    alt=""
+                    className="size-full object-cover"
+                    aria-hidden="true"
+                  />
+                )}
+              </div>
+              <span className="flex-1 truncate text-sm font-medium">{group.name}</span>
+              <button
+                type="button"
+                onClick={() => void handleRemove(group.id)}
+                className="shrink-0 rounded p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-destructive"
+                title={t('settings.linkedGroupRemove', { name: group.name })}
+                aria-label={t('settings.linkedGroupRemove', { name: group.name })}
+              >
+                <XIcon className="size-4" aria-hidden="true" />
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <GroupAutocomplete
+        value={groupSearchInput}
+        onChange={setGroupSearchInput}
+        onSelect={(group) => {
+          void handleAdd(group);
+          setGroupSearchInput('');
+        }}
+        excludedIds={groups.map((g) => g.id)}
+        placeholder={t('form.linkedGroupsPlaceholder')}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/components/trips/TripStatusTransition.tsx
+++ b/apps/web/src/components/trips/TripStatusTransition.tsx
@@ -29,12 +29,14 @@ interface TripStatusTransitionProps {
   tripId: string;
   currentStatus: TripStatus;
   onTransitioned: (trip: TripResponse) => void;
+  disabledTargets?: TripStatus[];
 }
 
 export function TripStatusTransition({
   tripId,
   currentStatus,
   onTransitioned,
+  disabledTargets = [],
 }: TripStatusTransitionProps) {
   const { t } = useTranslation('trips');
   const [pendingTransition, setPendingTransition] = useState<TripStatus | null>(null);
@@ -78,6 +80,7 @@ export function TripStatusTransition({
             variant={target === TripStatus.CANCELLED ? 'destructive' : 'outline'}
             size="sm"
             onClick={() => handleButtonClick(target)}
+            disabled={disabledTargets.includes(target)}
             data-testid={`transition-btn-${target}`}
           >
             {t(`transitions.${target}`)}

--- a/apps/web/src/components/trips/participants/InviteParticipantModal.tsx
+++ b/apps/web/src/components/trips/participants/InviteParticipantModal.tsx
@@ -21,12 +21,14 @@ interface InviteParticipantModalProps {
   tripId: string;
   onSuccess: () => void;
   excludedIds?: string[];
+  disabled?: boolean;
 }
 
 export function InviteParticipantModal({
   tripId,
   onSuccess,
   excludedIds,
+  disabled = false,
 }: InviteParticipantModalProps) {
   const { t } = useTranslation('trips');
   const [open, setOpen] = useState(false);
@@ -95,7 +97,7 @@ export function InviteParticipantModal({
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogTrigger
         render={
-          <Button variant="outline" size="sm">
+          <Button variant="outline" size="sm" disabled={disabled}>
             <UserPlusIcon />
             {t('participants.invite.button')}
           </Button>

--- a/apps/web/src/components/trips/participants/ParticipantList.tsx
+++ b/apps/web/src/components/trips/participants/ParticipantList.tsx
@@ -12,6 +12,7 @@ interface ParticipantListProps {
   capacity: number;
   currentUserId: string | null;
   callerRole: TripRole | null;
+  canInvite?: boolean;
   onInviteSuccess: () => void;
   onParticipantAction: () => void;
   excludedIds?: string[];
@@ -62,6 +63,7 @@ export function ParticipantList({
   capacity,
   currentUserId,
   callerRole,
+  canInvite = true,
   onInviteSuccess,
   onParticipantAction,
   excludedIds,
@@ -85,6 +87,7 @@ export function ParticipantList({
             tripId={tripId}
             onSuccess={onInviteSuccess}
             excludedIds={excludedIds}
+            disabled={!canInvite}
           />
         )}
       </div>

--- a/apps/web/src/components/ui/group-autocomplete.test.tsx
+++ b/apps/web/src/components/ui/group-autocomplete.test.tsx
@@ -1,0 +1,162 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+const mocks = vi.hoisted(() => ({
+  mockUseGroupPickerSearch: vi.fn(),
+}));
+
+vi.mock('@/hooks/useGroupPickerSearch', () => ({
+  useGroupPickerSearch: mocks.mockUseGroupPickerSearch,
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+import { GroupAutocomplete } from './group-autocomplete';
+import type { Group, GroupSearchResult } from '@/types/group';
+import { GroupVisibility, MembershipStatus } from '@chamuco/shared-types';
+
+const myGroup: Group = {
+  id: 'group-1',
+  name: 'Mountain Crew',
+  description: null,
+  coverUrl: 'https://cdn/emoji.svg',
+  visibility: GroupVisibility.PUBLIC,
+  createdBy: 'user-1',
+  createdAt: '2026-01-01T00:00:00Z',
+  updatedAt: '2026-01-01T00:00:00Z',
+};
+
+const publicGroup: GroupSearchResult = {
+  ...myGroup,
+  id: 'group-2',
+  name: 'Beach Explorers',
+  memberCount: 5,
+  membershipStatus: 'none' as MembershipStatus,
+};
+
+function setup(value = '', onSelect = vi.fn(), onChange = vi.fn()) {
+  const user = userEvent.setup();
+  render(
+    <GroupAutocomplete
+      value={value}
+      onChange={onChange}
+      onSelect={onSelect}
+      placeholder="Search groups"
+      data-testid="group-autocomplete"
+    />,
+  );
+  return { user, onSelect, onChange };
+}
+
+beforeEach(() => {
+  mocks.mockUseGroupPickerSearch.mockReturnValue({
+    myGroups: [],
+    publicGroups: [],
+    isLoading: false,
+  });
+});
+
+describe('GroupAutocomplete', () => {
+  it('renders input', () => {
+    setup();
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
+  });
+
+  it('does not show dropdown when value is empty', () => {
+    setup('');
+    expect(screen.queryByRole('list')).not.toBeInTheDocument();
+  });
+
+  it('shows spinner when loading', async () => {
+    mocks.mockUseGroupPickerSearch.mockReturnValue({
+      myGroups: [],
+      publicGroups: [],
+      isLoading: true,
+    });
+    const { user } = setup('mountain');
+    await user.click(screen.getByRole('textbox'));
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
+  });
+
+  it('shows empty state when no results', async () => {
+    const { user } = setup('zzz');
+    await user.click(screen.getByRole('textbox'));
+    await waitFor(() => {
+      expect(screen.getByText('form.linkedGroupsNoResults')).toBeInTheDocument();
+    });
+  });
+
+  it('shows my groups section when there are own groups', async () => {
+    mocks.mockUseGroupPickerSearch.mockReturnValue({
+      myGroups: [myGroup],
+      publicGroups: [],
+      isLoading: false,
+    });
+    const { user } = setup('mountain');
+    await user.click(screen.getByRole('textbox'));
+    await waitFor(() => {
+      expect(screen.getByText('form.linkedGroupsMyGroups')).toBeInTheDocument();
+      expect(screen.getByText('Mountain Crew')).toBeInTheDocument();
+    });
+  });
+
+  it('shows public groups section when there are public groups', async () => {
+    mocks.mockUseGroupPickerSearch.mockReturnValue({
+      myGroups: [],
+      publicGroups: [publicGroup],
+      isLoading: false,
+    });
+    const { user } = setup('beach');
+    await user.click(screen.getByRole('textbox'));
+    await waitFor(() => {
+      expect(screen.getByText('form.linkedGroupsPublicGroups')).toBeInTheDocument();
+      expect(screen.getByText('Beach Explorers')).toBeInTheDocument();
+    });
+  });
+
+  it('calls onSelect with the group and isMyGroup flag when a my-group item is clicked', async () => {
+    mocks.mockUseGroupPickerSearch.mockReturnValue({
+      myGroups: [myGroup],
+      publicGroups: [],
+      isLoading: false,
+    });
+    const onSelect = vi.fn();
+    const { user } = setup('mountain', onSelect);
+    await user.click(screen.getByRole('textbox'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Mountain Crew')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByText('Mountain Crew'));
+
+    expect(onSelect).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'group-1', isMyGroup: true }),
+    );
+  });
+
+  it('excludes already-selected groups', async () => {
+    mocks.mockUseGroupPickerSearch.mockReturnValue({
+      myGroups: [myGroup],
+      publicGroups: [],
+      isLoading: false,
+    });
+    const { user } = setup('mountain');
+    render(
+      <GroupAutocomplete
+        value="mountain"
+        onChange={vi.fn()}
+        onSelect={vi.fn()}
+        excludedIds={['group-1']}
+        placeholder="Search"
+      />,
+    );
+    const inputs = screen.getAllByRole('textbox');
+    await user.click(inputs[inputs.length - 1]!);
+    await waitFor(() => {
+      expect(screen.queryByText('Mountain Crew')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/src/components/ui/group-autocomplete.tsx
+++ b/apps/web/src/components/ui/group-autocomplete.tsx
@@ -1,0 +1,196 @@
+'use client';
+
+import { useState, type KeyboardEvent } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { cn } from '@/lib/utils';
+import { Input } from '@/components/ui/input';
+import { Spinner } from '@/components/ui/spinner';
+import { useGroupPickerSearch } from '@/hooks/useGroupPickerSearch';
+import type { Group, GroupSearchResult } from '@/types/group';
+
+export type GroupPickerItem = (Group | GroupSearchResult) & { isMyGroup: boolean };
+
+interface GroupAutocompleteProps {
+  value: string;
+  onChange: (val: string) => void;
+  onSelect: (group: GroupPickerItem) => void;
+  excludedIds?: string[];
+  placeholder?: string;
+  className?: string;
+  disabled?: boolean;
+  'data-testid'?: string;
+}
+
+function GroupAutocomplete({
+  value,
+  onChange,
+  onSelect,
+  excludedIds,
+  placeholder,
+  className,
+  disabled,
+  'data-testid': testId,
+}: GroupAutocompleteProps) {
+  const { t } = useTranslation('trips');
+  const [open, setOpen] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(-1);
+  const { myGroups, publicGroups, isLoading } = useGroupPickerSearch(value);
+
+  const filteredMyGroups = myGroups.filter((g) => !excludedIds?.includes(g.id));
+  const filteredPublicGroups = publicGroups.filter((g) => !excludedIds?.includes(g.id));
+
+  const hasMyGroups = filteredMyGroups.length > 0;
+  const hasPublicGroups = filteredPublicGroups.length > 0;
+  const hasResults = hasMyGroups || hasPublicGroups;
+
+  const flatItems: GroupPickerItem[] = [
+    ...filteredMyGroups.map((g) => ({ ...g, isMyGroup: true as const })),
+    ...filteredPublicGroups.map((g) => ({ ...g, isMyGroup: false as const })),
+  ];
+
+  const showDropdown = open && value.length >= 1 && (isLoading || hasResults);
+  const showEmpty = open && value.length >= 1 && !isLoading && !hasResults;
+
+  function handleSelect(item: GroupPickerItem) {
+    onChange('');
+    onSelect(item);
+    setOpen(false);
+    setActiveIndex(-1);
+  }
+
+  function handleKeyDown(e: KeyboardEvent<HTMLInputElement>) {
+    if (!open) return;
+
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setActiveIndex((i) => Math.min(i + 1, flatItems.length - 1));
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setActiveIndex((i) => Math.max(i - 1, 0));
+    } else if (e.key === 'Enter' && activeIndex >= 0 && flatItems[activeIndex]) {
+      e.preventDefault();
+      handleSelect(flatItems[activeIndex]);
+    } else if (e.key === 'Escape') {
+      setOpen(false);
+      setActiveIndex(-1);
+    }
+  }
+
+  let itemOffset = 0;
+
+  return (
+    <div className="relative">
+      <Input
+        type="text"
+        value={value}
+        onChange={(e) => {
+          onChange(e.target.value);
+          setActiveIndex(-1);
+          setOpen(e.target.value.length >= 1);
+        }}
+        onFocus={() => {
+          if (value.length >= 1) setOpen(true);
+        }}
+        onBlur={() => setTimeout(() => setOpen(false), 150)}
+        onKeyDown={handleKeyDown}
+        placeholder={placeholder}
+        disabled={disabled}
+        data-testid={testId}
+        autoComplete="off"
+        spellCheck={false}
+        className={cn(className)}
+      />
+
+      {(showDropdown || showEmpty) && (
+        <div className="absolute top-full z-50 mt-1 w-full rounded-md border bg-popover text-popover-foreground shadow-md">
+          {isLoading ? (
+            <div className="flex items-center justify-center p-3">
+              <Spinner size="sm" />
+            </div>
+          ) : showEmpty ? (
+            <p className="px-3 py-2 text-sm text-muted-foreground">
+              {t('form.linkedGroupsNoResults')}
+            </p>
+          ) : (
+            <ul className="max-h-60 overflow-auto py-1">
+              {hasMyGroups && (
+                <>
+                  <li className="px-3 py-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                    {t('form.linkedGroupsMyGroups')}
+                  </li>
+                  {filteredMyGroups.map((group) => {
+                    const idx = itemOffset++;
+                    return (
+                      <GroupItem
+                        key={group.id}
+                        group={{ ...group, isMyGroup: true }}
+                        isActive={idx === activeIndex}
+                        onMouseDown={() => handleSelect({ ...group, isMyGroup: true })}
+                      />
+                    );
+                  })}
+                </>
+              )}
+              {hasPublicGroups && (
+                <>
+                  <li className="px-3 py-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                    {t('form.linkedGroupsPublicGroups')}
+                  </li>
+                  {filteredPublicGroups.map((group) => {
+                    const idx = itemOffset++;
+                    return (
+                      <GroupItem
+                        key={group.id}
+                        group={{ ...group, isMyGroup: false }}
+                        isActive={idx === activeIndex}
+                        onMouseDown={() => handleSelect({ ...group, isMyGroup: false })}
+                      />
+                    );
+                  })}
+                </>
+              )}
+            </ul>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface GroupItemProps {
+  group: GroupPickerItem;
+  isActive: boolean;
+  onMouseDown: () => void;
+}
+
+function GroupItem({ group, isActive, onMouseDown }: GroupItemProps) {
+  return (
+    <li>
+      <button
+        type="button"
+        data-active={isActive}
+        className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm hover:bg-muted data-[active=true]:bg-muted"
+        onMouseDown={(e) => {
+          e.preventDefault();
+          onMouseDown();
+        }}
+      >
+        <div className="size-7 shrink-0 overflow-hidden rounded-md bg-muted">
+          {group.coverUrl && (
+            <img
+              src={group.coverUrl}
+              alt=""
+              className="size-full object-cover"
+              aria-hidden="true"
+            />
+          )}
+        </div>
+        <span className="truncate font-medium">{group.name}</span>
+      </button>
+    </li>
+  );
+}
+
+export { GroupAutocomplete };
+export type { GroupAutocompleteProps };

--- a/apps/web/src/hooks/useGroupPickerSearch.ts
+++ b/apps/web/src/hooks/useGroupPickerSearch.ts
@@ -1,0 +1,58 @@
+import axios from 'axios';
+import { useEffect, useRef, useState } from 'react';
+
+import { getGroups, searchGroups } from '@/services/groups.service';
+import type { Group, GroupSearchResult } from '@/types/group';
+
+export interface GroupPickerSearchResults {
+  myGroups: Group[];
+  publicGroups: GroupSearchResult[];
+  isLoading: boolean;
+}
+
+export function useGroupPickerSearch(query: string, limit = 8): GroupPickerSearchResults {
+  const [myGroupsCache, setMyGroupsCache] = useState<Group[]>([]);
+  const [publicGroups, setPublicGroups] = useState<GroupSearchResult[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const fetchedMyGroups = useRef(false);
+
+  useEffect(() => {
+    if (fetchedMyGroups.current) return;
+    fetchedMyGroups.current = true;
+    getGroups()
+      .then(setMyGroupsCache)
+      .catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    const controller = new AbortController();
+
+    if (!query.trim()) {
+      setPublicGroups([]);
+      setIsLoading(false);
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      setIsLoading(true);
+      searchGroups({ q: query, limit }, controller.signal)
+        .then((res) => setPublicGroups(res.data))
+        .catch((err: unknown) => {
+          if (!axios.isCancel(err)) setPublicGroups([]);
+        })
+        .finally(() => setIsLoading(false));
+    }, 300);
+
+    return () => {
+      clearTimeout(timer);
+      controller.abort();
+    };
+  }, [query, limit]);
+
+  const lowerQuery = query.trim().toLowerCase();
+  const myGroups = lowerQuery
+    ? myGroupsCache.filter((g) => g.name.toLowerCase().includes(lowerQuery))
+    : [];
+
+  return { myGroups, publicGroups, isLoading };
+}

--- a/apps/web/src/locales/en/trips.json
+++ b/apps/web/src/locales/en/trips.json
@@ -22,7 +22,9 @@
       "alreadyExcluded": "This user is already a participant or has a pending invitation",
       "maxUsers": "You can invite up to 20 users at once",
       "done": "Done",
-      "results": { "title": "Invitation results" },
+      "results": {
+        "title": "Invitation results"
+      },
       "result": {
         "INVITED": "Invited successfully",
         "ALREADY_MEMBER": "Already a participant",
@@ -115,7 +117,8 @@
     "timezone": "Timezone",
     "itineraryNotes": "Itinerary notes",
     "noItineraryNotes": "No itinerary notes yet.",
-    "editItineraryNotes": "Edit itinerary notes"
+    "editItineraryNotes": "Edit itinerary notes",
+    "linkedGroups": "Linked groups"
   },
   "role": {
     "organizer": "Organizer",
@@ -164,7 +167,13 @@
       "cropTitle": "Crop cover photo",
       "usePhoto": "Use this photo",
       "editButton": "Change photo"
-    }
+    },
+    "linkedGroups": "Linked groups",
+    "linkedGroupsPlaceholder": "Search groups...",
+    "linkedGroupsMyGroups": "My groups",
+    "linkedGroupsPublicGroups": "Public groups",
+    "linkedGroupsNoResults": "No groups found",
+    "linkedGroupsRemove": "Remove {{name}}"
   },
   "visibility": {
     "label": "Visibility",
@@ -213,7 +222,18 @@
     "cancelDialogTitle": "Cancel this trip?",
     "cancelDialogDescription": "Are you sure you want to cancel this trip? All confirmed participants will be notified.",
     "cancelSuccess": "Trip cancelled.",
-    "cancelFailed": "Failed to cancel trip. Please try again."
+    "cancelFailed": "Failed to cancel trip. Please try again.",
+    "deleteTrip": "Delete trip",
+    "deleteTripDescription": "Permanently delete this draft. This action cannot be undone.",
+    "deleteDialogTitle": "Delete this trip?",
+    "deleteDialogDescription": "Are you sure you want to permanently delete this trip? This action cannot be undone.",
+    "deleteSuccess": "Trip deleted.",
+    "deleteFailed": "Failed to delete trip. Please try again.",
+    "saveFailed": "Failed to save trip settings.",
+    "linkedGroups": "Linked Groups",
+    "linkedGroupRemoveFailed": "Failed to remove group.",
+    "linkedGroupAddFailed": "Failed to add group.",
+    "linkedGroupRemove": "Remove {{name}} from this trip"
   },
   "card": {
     "capacityOf": "of"

--- a/apps/web/src/locales/es/trips.json
+++ b/apps/web/src/locales/es/trips.json
@@ -22,7 +22,9 @@
       "alreadyExcluded": "Este usuario ya es participante o tiene una invitación pendiente",
       "maxUsers": "Puedes invitar hasta 20 usuarios a la vez",
       "done": "Listo",
-      "results": { "title": "Resultados de invitación" },
+      "results": {
+        "title": "Resultados de invitación"
+      },
       "result": {
         "INVITED": "Invitado exitosamente",
         "ALREADY_MEMBER": "Ya es participante",
@@ -115,7 +117,8 @@
     "timezone": "Zona horaria",
     "itineraryNotes": "Notas de itinerario",
     "noItineraryNotes": "Sin notas de itinerario aún.",
-    "editItineraryNotes": "Editar notas de itinerario"
+    "editItineraryNotes": "Editar notas de itinerario",
+    "linkedGroups": "Grupos vinculados"
   },
   "role": {
     "organizer": "Organizador",
@@ -164,7 +167,13 @@
       "cropTitle": "Recortar foto de portada",
       "usePhoto": "Usar esta foto",
       "editButton": "Cambiar foto"
-    }
+    },
+    "linkedGroups": "Grupos vinculados",
+    "linkedGroupsPlaceholder": "Buscar grupos...",
+    "linkedGroupsMyGroups": "Mis grupos",
+    "linkedGroupsPublicGroups": "Grupos públicos",
+    "linkedGroupsNoResults": "No se encontraron grupos",
+    "linkedGroupsRemove": "Quitar {{name}}"
   },
   "visibility": {
     "label": "Visibilidad",
@@ -213,7 +222,18 @@
     "cancelDialogTitle": "¿Cancelar este viaje?",
     "cancelDialogDescription": "¿Estás seguro de que deseas cancelar este viaje? Todos los participantes confirmados serán notificados.",
     "cancelSuccess": "Viaje cancelado.",
-    "cancelFailed": "Error al cancelar el viaje. Por favor intenta de nuevo."
+    "cancelFailed": "Error al cancelar el viaje. Por favor intenta de nuevo.",
+    "deleteTrip": "Eliminar viaje",
+    "deleteTripDescription": "Elimina permanentemente este borrador. Esta acción no se puede deshacer.",
+    "deleteDialogTitle": "¿Eliminar este viaje?",
+    "deleteDialogDescription": "¿Estás seguro de que deseas eliminar permanentemente este viaje? Esta acción no se puede deshacer.",
+    "deleteSuccess": "Viaje eliminado.",
+    "deleteFailed": "Error al eliminar el viaje. Por favor intenta de nuevo.",
+    "saveFailed": "Error al guardar la configuración del viaje.",
+    "linkedGroups": "Grupos Vinculados",
+    "linkedGroupRemoveFailed": "Error al quitar el grupo.",
+    "linkedGroupAddFailed": "Error al agregar el grupo.",
+    "linkedGroupRemove": "Quitar {{name}} de este viaje"
   },
   "card": {
     "capacityOf": "de"

--- a/apps/web/src/services/trips.service.ts
+++ b/apps/web/src/services/trips.service.ts
@@ -16,6 +16,7 @@ import type {
   ReorderDestinationsPayload,
   TransitionTripStatusPayload,
   TripGroupResponse,
+  TripLinkedGroup,
   TripParticipantResponse,
   TripResponse,
   UpdateDestinationPayload,
@@ -197,6 +198,11 @@ export async function rejectJoinRequest(id: string, userId: string): Promise<voi
 
 export async function getTripGroups(id: string): Promise<TripGroupResponse[]> {
   const { data } = await apiClient.get<TripGroupResponse[]>(`/v1/trips/${id}/groups`);
+  return data;
+}
+
+export async function getTripLinkedGroups(id: string): Promise<TripLinkedGroup[]> {
+  const { data } = await apiClient.get<TripLinkedGroup[]>(`/v1/trips/${id}/linked-groups`);
   return data;
 }
 

--- a/apps/web/src/services/trips.types.ts
+++ b/apps/web/src/services/trips.types.ts
@@ -130,7 +130,7 @@ export interface TripGroupResponse {
 export interface TripLinkedGroup {
   id: string;
   name: string;
-  coverUrl: string;
+  coverUrl: string | null;
 }
 
 export interface TripParticipantResponse {

--- a/apps/web/src/services/trips.types.ts
+++ b/apps/web/src/services/trips.types.ts
@@ -127,6 +127,12 @@ export interface TripGroupResponse {
   addedAt: string;
 }
 
+export interface TripLinkedGroup {
+  id: string;
+  name: string;
+  coverUrl: string;
+}
+
 export interface TripParticipantResponse {
   userId: string;
   username: string;


### PR DESCRIPTION
## Summary

- **DRAFT→OPEN bulk invite**: when transitioning from DRAFT to OPEN, all active members of linked groups receive trip invitations (backend)
- **Block on DRAFT**: invitations and announcements throw `BadRequestException` when trip is DRAFT; megaphone icon and invite button disabled in UI
- **Destination requirement**: OPEN transition button disabled when trip has no destinations; `DestinationList` notifies parent via `onCountChange` callback
- **DRAFT delete**: settings page shows Delete (not Cancel) for DRAFT trips
- **Terminal status guards**: settings page redirects to trip detail for COMPLETED/CANCELLED; gear icon disabled; destination list read-only for CONFIRMED+; itinerary notes edit button hidden for COMPLETED/CANCELLED

## Test plan

- [ ] Backend: `trips.service.spec.ts` — DRAFT→OPEN bulk invite, organizer excluded, no re-invite, skips when no groups
- [ ] Backend: `trip-invitations.service.spec.ts` — DRAFT throws BadRequestException
- [ ] Backend: `trip-announcements.service.spec.ts` — DRAFT throws BadRequestException
- [ ] Frontend: `settings/page.test.tsx` — delete dialog for DRAFT, redirect for COMPLETED/CANCELLED
- [ ] All pre-commit checks pass (lint, typecheck, unit tests, 90% coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)