### PR TITLE
fix(trips): enforce CO_ORGANIZER permissions across trip actions

### DIFF
--- a/apps/api/src/database/seeds/seed-dev.ts
+++ b/apps/api/src/database/seeds/seed-dev.ts
@@ -32,28 +32,28 @@ import {
 // Fixed UUIDs — deterministic so the script is idempotent
 // ---------------------------------------------------------------------------
 
-// Avatar assets: a0-<index>
+// Avatar assets: a0-<index>  (version=4, variant=8 → valid RFC 4122)
 const AVATAR_ASSET_IDS = Array.from(
   { length: 10 },
-  (_, i) => `a0000000-0000-0000-0000-${String(i + 1).padStart(12, '0')}`,
+  (_, i) => `a0000000-0000-4000-8000-${String(i + 1).padStart(12, '0')}`,
 );
 
 // Cover assets: c0-<index>
 const COVER_ASSET_IDS = Array.from(
   { length: 10 },
-  (_, i) => `c0000000-0000-0000-0000-${String(i + 1).padStart(12, '0')}`,
+  (_, i) => `c0000000-0000-4000-8000-${String(i + 1).padStart(12, '0')}`,
 );
 
 // User IDs: b0-<index>
 const USER_IDS = Array.from(
   { length: 10 },
-  (_, i) => `b0000000-0000-0000-0000-${String(i + 1).padStart(12, '0')}`,
+  (_, i) => `b0000000-0000-4000-8000-${String(i + 1).padStart(12, '0')}`,
 );
 
 // Group IDs: d0-<index>
 const GROUP_IDS = Array.from(
   { length: 10 },
-  (_, i) => `d0000000-0000-0000-0000-${String(i + 1).padStart(12, '0')}`,
+  (_, i) => `d0000000-0000-4000-8000-${String(i + 1).padStart(12, '0')}`,
 );
 
 // ---------------------------------------------------------------------------

--- a/apps/api/src/modules/trips/groups/trips-groups.service.ts
+++ b/apps/api/src/modules/trips/groups/trips-groups.service.ts
@@ -67,7 +67,7 @@ export class TripsGroupsService {
   async listTripGroups(user: AuthenticatedUser, tripId: string): Promise<TripGroupResponseDto[]> {
     const trip = await this.db.query.trips.findFirst({ where: eq(trips.id, tripId) });
     if (!trip) throw new NotFoundException('Trip not found');
-    await this.tripsService.assertOrganizerRole(tripId, user.id, false);
+    await this.tripsService.assertOrganizerRole(tripId, user.id, true);
 
     const rows = await this.db.select().from(groupTrips).where(eq(groupTrips.tripId, tripId));
     return rows.map((r) => this.mapTripGroup(r));
@@ -80,7 +80,7 @@ export class TripsGroupsService {
   ): Promise<TripGroupResponseDto> {
     const trip = await this.db.query.trips.findFirst({ where: eq(trips.id, tripId) });
     if (!trip) throw new NotFoundException('Trip not found');
-    await this.tripsService.assertOrganizerRole(tripId, user.id, false);
+    await this.tripsService.assertOrganizerRole(tripId, user.id, true);
 
     const group = await this.db.query.groups.findFirst({
       where: and(eq(groups.id, dto.groupId), isNull(groups.deletedAt)),
@@ -101,7 +101,7 @@ export class TripsGroupsService {
   async removeTripGroup(user: AuthenticatedUser, tripId: string, groupId: string): Promise<void> {
     const trip = await this.db.query.trips.findFirst({ where: eq(trips.id, tripId) });
     if (!trip) throw new NotFoundException('Trip not found');
-    await this.tripsService.assertOrganizerRole(tripId, user.id, false);
+    await this.tripsService.assertOrganizerRole(tripId, user.id, true);
 
     const link = await this.db.query.groupTrips.findFirst({
       where: and(eq(groupTrips.tripId, tripId), eq(groupTrips.groupId, groupId)),

--- a/apps/api/src/modules/trips/participants/trip-participants.constants.ts
+++ b/apps/api/src/modules/trips/participants/trip-participants.constants.ts
@@ -1,0 +1,7 @@
+import { TripParticipantStatus, TripRole } from '@chamuco/shared-types';
+
+export const ORGANIZER_ROLES = [TripRole.ORGANIZER, TripRole.CO_ORGANIZER] as const;
+export const ACTIVE_STATUSES = [
+  TripParticipantStatus.ACCEPTED,
+  TripParticipantStatus.CONFIRMED,
+] as const;

--- a/apps/api/src/modules/trips/participants/trip-participants.service.ts
+++ b/apps/api/src/modules/trips/participants/trip-participants.service.ts
@@ -35,8 +35,7 @@ import type { ParticipantResponseDto } from './dto/participant-response.dto';
 import type { PendingParticipantResponseDto } from './dto/pending-participant-response.dto';
 import type { MyParticipationResponseDto } from './dto/my-participation-response.dto';
 import type { MyTripInvitationResponseDto } from './dto/my-trip-invitation-response.dto';
-const ORGANIZER_ROLES = [TripRole.ORGANIZER, TripRole.CO_ORGANIZER] as const;
-const ACTIVE_STATUSES = [TripParticipantStatus.ACCEPTED, TripParticipantStatus.CONFIRMED] as const;
+import { ACTIVE_STATUSES, ORGANIZER_ROLES } from './trip-participants.constants';
 
 const EXPORT_COLUMN_META: Record<ExportField, { header: string; width: number }> = {
   [ExportField.DISPLAY_NAME]: { header: 'Display name', width: 22 },
@@ -205,8 +204,8 @@ export class TripParticipantsService {
       where: and(
         eq(tripParticipants.tripId, tripId),
         eq(tripParticipants.userId, requestingUserId),
-        inArray(tripParticipants.status, [...ACTIVE_STATUSES]),
-        inArray(tripParticipants.role, [...ORGANIZER_ROLES]),
+        inArray(tripParticipants.status, ACTIVE_STATUSES),
+        inArray(tripParticipants.role, ORGANIZER_ROLES),
       ),
     });
 
@@ -260,7 +259,7 @@ export class TripParticipantsService {
       where: and(
         eq(tripParticipants.tripId, tripId),
         eq(tripParticipants.userId, requestingUserId),
-        inArray(tripParticipants.status, [...ACTIVE_STATUSES]),
+        inArray(tripParticipants.status, ACTIVE_STATUSES),
         eq(tripParticipants.role, TripRole.ORGANIZER),
       ),
     });
@@ -273,7 +272,7 @@ export class TripParticipantsService {
       where: and(
         eq(tripParticipants.tripId, tripId),
         eq(tripParticipants.userId, targetUserId),
-        inArray(tripParticipants.status, [...ACTIVE_STATUSES]),
+        inArray(tripParticipants.status, ACTIVE_STATUSES),
       ),
     });
     if (!targetParticipation) throw new NotFoundException('Active participant not found');
@@ -340,7 +339,7 @@ export class TripParticipantsService {
       where: and(
         eq(tripParticipants.tripId, tripId),
         eq(tripParticipants.userId, targetUserId),
-        inArray(tripParticipants.status, [...ACTIVE_STATUSES]),
+        inArray(tripParticipants.status, ACTIVE_STATUSES),
       ),
     });
     if (!targetParticipation) throw new NotFoundException('Active participant not found');
@@ -429,7 +428,7 @@ export class TripParticipantsService {
     const rows = await this.db.query.tripParticipants.findMany({
       where: and(
         eq(tripParticipants.tripId, tripId),
-        inArray(tripParticipants.status, [...ACTIVE_STATUSES]),
+        inArray(tripParticipants.status, ACTIVE_STATUSES),
       ),
     });
 
@@ -527,8 +526,8 @@ export class TripParticipantsService {
       where: and(
         eq(tripParticipants.tripId, tripId),
         eq(tripParticipants.userId, userId),
-        inArray(tripParticipants.status, [...ACTIVE_STATUSES]),
-        inArray(tripParticipants.role, [...ORGANIZER_ROLES]),
+        inArray(tripParticipants.status, ACTIVE_STATUSES),
+        inArray(tripParticipants.role, ORGANIZER_ROLES),
       ),
     });
     if (!participation)
@@ -542,7 +541,7 @@ export class TripParticipantsService {
       where: and(
         eq(tripParticipants.tripId, tripId),
         eq(tripParticipants.userId, userId),
-        inArray(tripParticipants.status, [...ACTIVE_STATUSES]),
+        inArray(tripParticipants.status, ACTIVE_STATUSES),
       ),
     });
     if (!participation)
@@ -550,16 +549,16 @@ export class TripParticipantsService {
   }
 
   private async assertNotSoleOrganizer(tripId: string, userId: string): Promise<void> {
-    const confirmedOrganizers = await this.db.query.tripParticipants.findMany({
+    const activeOrganizers = await this.db.query.tripParticipants.findMany({
       where: and(
         eq(tripParticipants.tripId, tripId),
-        inArray(tripParticipants.status, [...ACTIVE_STATUSES]),
+        inArray(tripParticipants.status, ACTIVE_STATUSES),
         eq(tripParticipants.role, TripRole.ORGANIZER),
       ),
       limit: 2,
     });
 
-    if (confirmedOrganizers.length === 1 && confirmedOrganizers[0]?.userId === userId) {
+    if (activeOrganizers.length === 1 && activeOrganizers[0]?.userId === userId) {
       throw new ConflictException(
         'Cannot remove or demote the last organizer. Transfer the role first.',
       );
@@ -595,7 +594,7 @@ export class TripParticipantsService {
       this.db.query.tripParticipants.findMany({
         where: and(
           eq(tripParticipants.tripId, tripId),
-          inArray(tripParticipants.status, [...ACTIVE_STATUSES]),
+          inArray(tripParticipants.status, ACTIVE_STATUSES),
         ),
       }),
     ]);

--- a/apps/api/src/modules/trips/participants/trip-participants.service.ts
+++ b/apps/api/src/modules/trips/participants/trip-participants.service.ts
@@ -205,7 +205,7 @@ export class TripParticipantsService {
       where: and(
         eq(tripParticipants.tripId, tripId),
         eq(tripParticipants.userId, requestingUserId),
-        eq(tripParticipants.status, TripParticipantStatus.CONFIRMED),
+        inArray(tripParticipants.status, [...ACTIVE_STATUSES]),
         inArray(tripParticipants.role, [...ORGANIZER_ROLES]),
       ),
     });
@@ -260,7 +260,7 @@ export class TripParticipantsService {
       where: and(
         eq(tripParticipants.tripId, tripId),
         eq(tripParticipants.userId, requestingUserId),
-        eq(tripParticipants.status, TripParticipantStatus.CONFIRMED),
+        inArray(tripParticipants.status, [...ACTIVE_STATUSES]),
         eq(tripParticipants.role, TripRole.ORGANIZER),
       ),
     });
@@ -527,7 +527,7 @@ export class TripParticipantsService {
       where: and(
         eq(tripParticipants.tripId, tripId),
         eq(tripParticipants.userId, userId),
-        eq(tripParticipants.status, TripParticipantStatus.CONFIRMED),
+        inArray(tripParticipants.status, [...ACTIVE_STATUSES]),
         inArray(tripParticipants.role, [...ORGANIZER_ROLES]),
       ),
     });
@@ -553,7 +553,7 @@ export class TripParticipantsService {
     const confirmedOrganizers = await this.db.query.tripParticipants.findMany({
       where: and(
         eq(tripParticipants.tripId, tripId),
-        eq(tripParticipants.status, TripParticipantStatus.CONFIRMED),
+        inArray(tripParticipants.status, [...ACTIVE_STATUSES]),
         eq(tripParticipants.role, TripRole.ORGANIZER),
       ),
       limit: 2,

--- a/apps/api/src/modules/trips/trips.service.spec.ts
+++ b/apps/api/src/modules/trips/trips.service.spec.ts
@@ -526,12 +526,13 @@ describe('TripsService', () => {
 
     it('computes feedbackOpenUntil on IN_PROGRESS→COMPLETED', async () => {
       mockTripsFindFirst
-        .mockResolvedValueOnce({ ...mockTripRow, status: TripStatus.IN_PROGRESS })
+        .mockResolvedValueOnce({ ...mockTripRow, status: TripStatus.IN_PROGRESS }) // transitionStatus fetch
+        .mockResolvedValueOnce({ ...mockTripRow, status: TripStatus.IN_PROGRESS }) // assertOrganizerRole existence check
         .mockResolvedValueOnce({
           ...mockTripRow,
           status: TripStatus.COMPLETED,
           endDate: '2026-12-08',
-        });
+        }); // fetchAndMapTrip
       const dto: TransitionTripStatusDto = { status: TripStatus.COMPLETED };
 
       const result = await service.transitionStatus(mockUser, 'trip-uuid', dto);

--- a/apps/api/src/modules/trips/trips.service.spec.ts
+++ b/apps/api/src/modules/trips/trips.service.spec.ts
@@ -65,6 +65,20 @@ const mockTripRow = {
   coverAsset: null,
 };
 
+const mockCoOrganizerParticipantAccepted = {
+  tripId: 'trip-uuid',
+  userId: 'user-uuid',
+  role: TripRole.CO_ORGANIZER,
+  status: TripParticipantStatus.ACCEPTED,
+  isTraveler: true,
+  didTravel: null,
+  initiatedAt: new Date('2026-01-01T00:00:00.000Z'),
+  confirmedAt: null,
+  updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+  initiatedBy: 'user-uuid',
+  decidedBy: 'other-uuid',
+};
+
 const mockOrganizerParticipant = {
   tripId: 'trip-uuid',
   userId: 'user-uuid',
@@ -349,6 +363,14 @@ describe('TripsService', () => {
       await expect(service.updateTrip(mockUser, 'trip-uuid', { name: 'X' })).rejects.toThrow(
         ForbiddenException,
       );
+    });
+
+    it('allows CO_ORGANIZER with ACCEPTED status to update trip', async () => {
+      mockTripParticipantsFindFirst.mockResolvedValue(mockCoOrganizerParticipantAccepted);
+
+      const result = await service.updateTrip(mockUser, 'trip-uuid', { name: 'Updated' });
+
+      expect(result.id).toBe('trip-uuid');
     });
 
     it('skips update when dto is empty', async () => {

--- a/apps/api/src/modules/trips/trips.service.ts
+++ b/apps/api/src/modules/trips/trips.service.ts
@@ -37,6 +37,7 @@ import type { UpdateTripDto } from './dto/update-trip.dto';
 import type { TripResponseDto } from './dto/trip-response.dto';
 import type { MyTripListItemResponseDto } from './dto/my-trip-list-item-response.dto';
 import type { TransitionTripStatusDto } from './dto/transition-trip-status.dto';
+import { ACTIVE_STATUSES } from './participants/trip-participants.constants';
 
 // TODO: migrate to system settings module when admin config is available
 const FEEDBACK_WINDOW_DAYS = parseInt(process.env['TRIP_FEEDBACK_WINDOW_DAYS'] ?? '7', 10) || 7;
@@ -63,10 +64,7 @@ export class TripsService {
     const memberships = await this.db.query.tripParticipants.findMany({
       where: and(
         eq(tripParticipants.userId, user.id),
-        inArray(tripParticipants.status, [
-          TripParticipantStatus.ACCEPTED,
-          TripParticipantStatus.CONFIRMED,
-        ]),
+        inArray(tripParticipants.status, ACTIVE_STATUSES),
       ),
     });
 
@@ -438,6 +436,9 @@ export class TripsService {
     userId: string,
     allowCoOrganizer: boolean,
   ): Promise<void> {
+    const trip = await this.db.query.trips.findFirst({ where: eq(trips.id, tripId) });
+    if (!trip) throw new NotFoundException('Trip not found');
+
     const roles = allowCoOrganizer
       ? [TripRole.ORGANIZER, TripRole.CO_ORGANIZER]
       : [TripRole.ORGANIZER];
@@ -446,10 +447,7 @@ export class TripsService {
       where: and(
         eq(tripParticipants.tripId, tripId),
         eq(tripParticipants.userId, userId),
-        inArray(tripParticipants.status, [
-          TripParticipantStatus.ACCEPTED,
-          TripParticipantStatus.CONFIRMED,
-        ]),
+        inArray(tripParticipants.status, ACTIVE_STATUSES),
         inArray(tripParticipants.role, roles),
       ),
     });

--- a/apps/api/src/modules/trips/trips.service.ts
+++ b/apps/api/src/modules/trips/trips.service.ts
@@ -446,7 +446,10 @@ export class TripsService {
       where: and(
         eq(tripParticipants.tripId, tripId),
         eq(tripParticipants.userId, userId),
-        eq(tripParticipants.status, TripParticipantStatus.CONFIRMED),
+        inArray(tripParticipants.status, [
+          TripParticipantStatus.ACCEPTED,
+          TripParticipantStatus.CONFIRMED,
+        ]),
         inArray(tripParticipants.role, roles),
       ),
     });

--- a/apps/api/src/modules/uploads/uploads.controller.spec.ts
+++ b/apps/api/src/modules/uploads/uploads.controller.spec.ts
@@ -1,6 +1,6 @@
 jest.mock('@google-cloud/storage', () => ({ Storage: jest.fn() }));
 
-import { BadRequestException, ForbiddenException, NotFoundException } from '@nestjs/common';
+import { BadRequestException, ForbiddenException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { AuthProvider, PlatformRole, ProfileVisibility } from '@chamuco/shared-types';
 import { UploadsController } from './uploads.controller';
@@ -38,7 +38,7 @@ const mockSignedUrlResult = {
 let mockIsAllowedContentType: jest.Mock;
 let mockGenerateSignedUploadUrl: jest.Mock;
 let mockGroupsFindById: jest.Mock;
-let mockTripsGetTrip: jest.Mock;
+let mockTripsAssertOrganizerRole: jest.Mock;
 
 describe('UploadsController', () => {
   let controller: UploadsController;
@@ -47,7 +47,7 @@ describe('UploadsController', () => {
     mockIsAllowedContentType = jest.fn().mockReturnValue(true);
     mockGenerateSignedUploadUrl = jest.fn().mockResolvedValue(mockSignedUrlResult);
     mockGroupsFindById = jest.fn().mockResolvedValue(null);
-    mockTripsGetTrip = jest.fn().mockResolvedValue(null);
+    mockTripsAssertOrganizerRole = jest.fn().mockResolvedValue(undefined);
 
     const module: TestingModule = await Test.createTestingModule({
       controllers: [UploadsController],
@@ -65,7 +65,7 @@ describe('UploadsController', () => {
         },
         {
           provide: TripsService,
-          useValue: { getTrip: mockTripsGetTrip },
+          useValue: { assertOrganizerRole: mockTripsAssertOrganizerRole },
         },
       ],
     }).compile();
@@ -151,23 +151,10 @@ describe('UploadsController', () => {
         );
       });
 
-      it('throws when trip does not exist for TRIP_COVER', async () => {
-        mockTripsGetTrip.mockRejectedValue(new NotFoundException('Trip not found'));
-        const dto: GenerateSignedUrlDto = {
-          uploadType: UploadType.TRIP_COVER,
-          contextId: 'trip-uuid',
-          contentType: 'image/jpeg',
-          fileSize: 500 * 1024,
-        };
-
-        await expect(controller.generateSignedUrl(mockAuthUser, dto)).rejects.toThrow(
-          NotFoundException,
+      it('throws ForbiddenException for TRIP_COVER when user is not an organizer', async () => {
+        mockTripsAssertOrganizerRole.mockRejectedValue(
+          new ForbiddenException('Only trip organizers can perform this action'),
         );
-        expect(mockGenerateSignedUploadUrl).not.toHaveBeenCalled();
-      });
-
-      it('throws ForbiddenException for TRIP_COVER when user is not the trip creator', async () => {
-        mockTripsGetTrip.mockResolvedValue({ id: 'trip-uuid', createdBy: 'other-user-uuid' });
         const dto: GenerateSignedUrlDto = {
           uploadType: UploadType.TRIP_COVER,
           contextId: 'trip-uuid',
@@ -178,11 +165,12 @@ describe('UploadsController', () => {
         await expect(controller.generateSignedUrl(mockAuthUser, dto)).rejects.toThrow(
           ForbiddenException,
         );
+        expect(mockTripsAssertOrganizerRole).toHaveBeenCalledWith('trip-uuid', 'user-uuid', true);
         expect(mockGenerateSignedUploadUrl).not.toHaveBeenCalled();
       });
 
-      it('returns a signed URL for TRIP_COVER when user is the trip creator', async () => {
-        mockTripsGetTrip.mockResolvedValue({ id: 'trip-uuid', createdBy: 'user-uuid' });
+      it('returns a signed URL for TRIP_COVER when user is the trip ORGANIZER', async () => {
+        mockTripsAssertOrganizerRole.mockResolvedValue(undefined);
         const dto: GenerateSignedUrlDto = {
           uploadType: UploadType.TRIP_COVER,
           contextId: 'trip-uuid',
@@ -193,6 +181,27 @@ describe('UploadsController', () => {
         const result = await controller.generateSignedUrl(mockAuthUser, dto);
 
         expect(result).toEqual(mockSignedUrlResult);
+        expect(mockTripsAssertOrganizerRole).toHaveBeenCalledWith('trip-uuid', 'user-uuid', true);
+        expect(mockGenerateSignedUploadUrl).toHaveBeenCalledWith(
+          UploadType.TRIP_COVER,
+          'trip-uuid',
+          'image/jpeg',
+        );
+      });
+
+      it('returns a signed URL for TRIP_COVER when user is a CO_ORGANIZER', async () => {
+        mockTripsAssertOrganizerRole.mockResolvedValue(undefined);
+        const dto: GenerateSignedUrlDto = {
+          uploadType: UploadType.TRIP_COVER,
+          contextId: 'trip-uuid',
+          contentType: 'image/jpeg',
+          fileSize: 500 * 1024,
+        };
+
+        const result = await controller.generateSignedUrl(mockAuthUser, dto);
+
+        expect(result).toEqual(mockSignedUrlResult);
+        expect(mockTripsAssertOrganizerRole).toHaveBeenCalledWith('trip-uuid', 'user-uuid', true);
         expect(mockGenerateSignedUploadUrl).toHaveBeenCalledWith(
           UploadType.TRIP_COVER,
           'trip-uuid',
@@ -219,6 +228,21 @@ describe('UploadsController', () => {
           expect(mockGenerateSignedUploadUrl).not.toHaveBeenCalled();
         },
       );
+
+      it('throws ForbiddenException for unknown upload type (exhaustiveness guard)', async () => {
+        const dto = {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          uploadType: 'UNKNOWN_TYPE' as any,
+          contextId: 'some-uuid',
+          contentType: 'image/jpeg',
+          fileSize: 500 * 1024,
+        };
+
+        await expect(controller.generateSignedUrl(mockAuthUser, dto)).rejects.toThrow(
+          ForbiddenException,
+        );
+        expect(mockGenerateSignedUploadUrl).not.toHaveBeenCalled();
+      });
     });
 
     describe('validation', () => {

--- a/apps/api/src/modules/uploads/uploads.controller.ts
+++ b/apps/api/src/modules/uploads/uploads.controller.ts
@@ -54,6 +54,7 @@ export class UploadsController {
   @ApiForbiddenResponse({
     description:
       'USER_AVATAR: contextId must match the authenticated user. ' +
+      'TRIP_COVER: caller must be ORGANIZER or CO_ORGANIZER of the trip. ' +
       'GROUP_COVER, GROUP_RESOURCE_DOCUMENT, TRIP_RESOURCE: not yet available ' +
       '(membership validation is pending implementation).',
   })
@@ -103,11 +104,7 @@ export class UploadsController {
         break;
       }
       case UploadType.TRIP_COVER: {
-        const trip = await this.tripsService.getTrip(contextId);
-        if (trip.createdBy !== user.id) {
-          // TODO: expand to check trip organizer role
-          throw new ForbiddenException('Only the trip creator can upload a trip cover.');
-        }
+        await this.tripsService.assertOrganizerRole(contextId, user.id, true);
         break;
       }
       case UploadType.GROUP_RESOURCE_DOCUMENT:


### PR DESCRIPTION
## Summary

CO_ORGANIZER was blocked from performing administrative actions the role should allow. Three independent bugs combined to cause this: a wrong authorization check on cover uploads, organizer guards that only accepted `CONFIRMED` participants (excluding users who accepted an invitation and have `ACCEPTED` status), and trip-group management endpoints hardcoded to ORGANIZER-only. A fourth issue caused local dev seed UUIDs to fail `@IsUUID()` validation because version/variant nibbles were `0`.

## Changes

**Cover upload authorization (`uploads.controller.ts`)**
- Replaced `trip.createdBy !== user.id` check with `assertOrganizerRole(..., true)`, which accepts both ORGANIZER and CO_ORGANIZER with any active status.

**Organizer guards accept `ACCEPTED` status (`trips.service.ts`, `trip-participants.service.ts`)**
- All five organizer guard queries (`assertOrganizerRole`, `assertTripOrganizer`, `removeParticipant` caller check, `updateParticipantRole` caller check, `assertNotSoleOrganizer`) now use `inArray(status, [ACCEPTED, CONFIRMED])` instead of `eq(status, CONFIRMED)`.
- Root cause: accepting a trip invitation sets `status = ACCEPTED`. When an organizer then promotes that user to CO_ORGANIZER, the `role` updates but `status` stays `ACCEPTED`. All guards rejected them until the organizer explicitly toggled their travel confirmation to `CONFIRMED`.

**Trip-group management open to CO_ORGANIZER (`trips-groups.service.ts`)**
- `listTripGroups`, `addTripGroup`, `removeTripGroup` changed from `allowCoOrganizer: false` to `true`.

**Seed UUIDs fixed (`seed-dev.ts`)**
- Version nibble `0` → `4`, variant nibble `0` → `8` across all four ID generators (avatar assets, cover assets, users, groups). These failed `@IsUUID()` because RFC 4122 requires version `[1-5]` and variant `[89ab]`.

## Testing

- Run `pnpm --filter api db:seed-dev` to re-seed local dev DB with valid UUIDs.
- Verify CO_ORGANIZER (promoted from a user who accepted an invitation) can: upload trip cover, edit trip details, add/edit/reorder destinations, link/unlink groups, remove participants.
- Verify ORGANIZER-only actions remain blocked for CO_ORGANIZER: delete trip, transition trip status.
- Edge case: CO_ORGANIZER whose travel confirmation was toggled to `CONFIRMED` by the organizer — still has full admin access (covered by both paths in `ACTIVE_STATUSES`).

## Notes

The `ACCEPTED` vs `CONFIRMED` distinction in `trip_participants`: `ACCEPTED` means the user accepted the invitation; `CONFIRMED` means the organizer confirmed they will travel. These are independent axes from the admin role — an `ACCEPTED` CO_ORGANIZER should have the same administrative capabilities as a `CONFIRMED` one.

Closes #466

🤖 Generated with [Claude Code](https://claude.com/claude-code)