### PR TITLE
fix(trips): show full title on mobile trip detail page

### DIFF
--- a/apps/web/src/app/trips/[id]/page.tsx
+++ b/apps/web/src/app/trips/[id]/page.tsx
@@ -161,36 +161,38 @@ export default function TripDetailPage({ params }: TripDetailPageProps) {
       </div>
 
       {/* Trip header */}
-      <div className="flex items-start gap-6 mb-6">
-        <div className="size-16 shrink-0 overflow-hidden rounded-xl bg-muted flex items-center justify-center">
-          {trip.coverUrl && (
-            <img src={trip.coverUrl} alt="" className="size-full object-cover" loading="lazy" />
-          )}
-        </div>
-
-        <div className="flex-1 min-w-0">
-          <div className="flex flex-wrap items-center gap-2">
-            <h1 className="text-2xl font-bold truncate">{trip.name}</h1>
-            <TripStatusBadge status={trip.status} />
-            <span className="shrink-0 rounded-full px-2.5 py-0.5 text-xs font-medium bg-muted text-muted-foreground">
-              {trip.visibility === TripVisibility.PUBLIC
-                ? t('visibility.public')
-                : t('visibility.private')}
-            </span>
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold wrap-break-word mb-3">{trip.name}</h1>
+        <div className="flex items-start gap-4">
+          <div className="size-20 shrink-0 overflow-hidden rounded-xl bg-muted flex items-center justify-center">
+            {trip.coverUrl && (
+              <img src={trip.coverUrl} alt="" className="size-full object-cover" loading="lazy" />
+            )}
           </div>
 
-          <div className="mt-2 flex items-center gap-2 text-sm text-muted-foreground">
-            <AirplaneTakeoffIcon className="size-3.5 shrink-0" aria-hidden="true" />
-            <span>{trip.startDate}</span>
-            <AirplaneLandingIcon className="size-3.5 shrink-0" aria-hidden="true" />
-            <span>{trip.endDate}</span>
-          </div>
+          <div className="flex-1 min-w-0 flex flex-col justify-center gap-1.5">
+            <div className="flex flex-wrap items-center gap-2">
+              <TripStatusBadge status={trip.status} />
+              <span className="shrink-0 rounded-full px-2.5 py-0.5 text-xs font-medium bg-muted text-muted-foreground">
+                {trip.visibility === TripVisibility.PUBLIC
+                  ? t('visibility.public')
+                  : t('visibility.private')}
+              </span>
+            </div>
 
-          <div className="mt-1 flex items-center gap-1 text-sm text-muted-foreground">
-            <UsersIcon className="size-3.5 shrink-0" aria-hidden="true" />
-            <span>
-              {t('detail.capacity')}: {trip.participantCapacity}
-            </span>
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <AirplaneTakeoffIcon className="size-3.5 shrink-0" aria-hidden="true" />
+              <span>{trip.startDate}</span>
+              <AirplaneLandingIcon className="size-3.5 shrink-0" aria-hidden="true" />
+              <span>{trip.endDate}</span>
+            </div>
+
+            <div className="flex items-center gap-1 text-sm text-muted-foreground">
+              <UsersIcon className="size-3.5 shrink-0" aria-hidden="true" />
+              <span>
+                {t('detail.capacity')}: {trip.participantCapacity}
+              </span>
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary

Trip titles were being silently truncated on mobile viewports (390px) because the `<h1>` lived inside a flex row alongside status and visibility badges — the `truncate` class prevented wrapping and the available width (~302px after the cover image) was not enough for longer names. Since the detail page is the canonical view for a trip, the full title should always be visible regardless of length.

## Changes

**Header layout restructure (`page.tsx`)**
- Moved `<h1>` outside the image/metadata flex row so it spans the full content width and wraps freely (`wrap-break-word`)
- Cover image resized from `size-16` to `size-20` (80px square) to align proportionally with the compact metadata block beside it
- Metadata block (status badge, visibility badge, dates, capacity) reorganised into a `flex-col` with `gap-1.5` beside the image

**Root cause**: `truncate` (`whitespace-nowrap overflow-hidden text-ellipsis`) + h1 inside a flex container = title gets clipped on narrow screens. Removed entirely on the detail page.

## Testing

- [ ] Trip with a short name renders correctly (no extra whitespace)
- [ ] Trip with a long name wraps across multiple lines without clipping
- [ ] Cover image renders as a square (80×80px) beside the metadata block
- [ ] Trip with no cover image shows the muted placeholder square
- [ ] Verified at 390px viewport (iPhone SE / 14) and desktop widths

Closes #465