### PR TITLE
fix(trips): allow itinerary and destination edits while CONFIRMED

### DIFF
--- a/.claude/skills/take-issue/SKILL.md
+++ b/.claude/skills/take-issue/SKILL.md
@@ -10,7 +10,7 @@ The issue number is: $ARGUMENTS
 
 ## Execution
 
-Run the automated setup script:
+Run the automated setup script (path is relative to the **repo root**, not this skill's directory):
 
 ```bash
 ./scripts/take-issue.sh $ARGUMENTS

--- a/.claude/skills/to-review/SKILL.md
+++ b/.claude/skills/to-review/SKILL.md
@@ -11,7 +11,7 @@ Must be on an issue branch created with `gh issue develop` (branch name format: 
 
 ## Step 1 — Run preparation script
 
-Execute the automated preparation script:
+Execute the automated preparation script (path is relative to the **repo root**, not this skill's directory):
 
 ```bash
 ./scripts/to-review.sh
@@ -105,7 +105,7 @@ Save the PR URL from the output.
 
 ## Step 6 — Update issue status to "In Review"
 
-Use the status update script:
+Use the status update script (path relative to repo root):
 
 ```bash
 ./scripts/update-project-status.sh "${ISSUE_NUMBER}" "In Review"

--- a/apps/api/src/modules/trips/destinations/dto/INVENTORY.md
+++ b/apps/api/src/modules/trips/destinations/dto/INVENTORY.md
@@ -30,7 +30,7 @@
 ### Definitions
 
 - `DestinationResponseDto` (class) — Response shape for a trip destination; exposes `id`, `tripId`, `position`, `countryCode`, `city`, `label`, `itinerary`, and `createdAt`
-- `DestinationWriteResponseDto` (class) — Extends `DestinationResponseDto` with `requiresConfirmation` flag that is `true` when the trip is `IN_PROGRESS` (edit requires organizer confirmation and notifies participants)
+- `DestinationWriteResponseDto` (class) — Extends `DestinationResponseDto` with `requiresConfirmation` flag that is `true` when the trip is `CONFIRMED` or `IN_PROGRESS` (informational only, no confirmation/notification enforced yet — post-MVP)
 
 ### Exports
 

--- a/apps/api/src/modules/trips/destinations/dto/destination-response.dto.ts
+++ b/apps/api/src/modules/trips/destinations/dto/destination-response.dto.ts
@@ -32,7 +32,7 @@ export class DestinationResponseDto {
 export class DestinationWriteResponseDto extends DestinationResponseDto {
   @ApiProperty({
     description:
-      'True when trip is IN_PROGRESS — edit requires organizer confirmation and notifies participants.',
+      'True when trip is CONFIRMED or IN_PROGRESS. Informational only — no confirmation step or notification is enforced yet (post-MVP, Issues #343-354).',
     example: false,
   })
   requiresConfirmation!: boolean;

--- a/apps/api/src/modules/trips/dto/trip-response.dto.ts
+++ b/apps/api/src/modules/trips/dto/trip-response.dto.ts
@@ -62,7 +62,7 @@ export class TripResponseDto {
 
   @ApiProperty({
     description:
-      'True when status is CONFIRMED or IN_PROGRESS — edits require organizer confirmation and will notify participants.',
+      'True when status is CONFIRMED or IN_PROGRESS. Informational only — no confirmation step or notification is enforced yet (post-MVP, Issues #343-354).',
     example: false,
   })
   requiresConfirmation!: boolean;

--- a/apps/web/src/app/trips/[id]/page.tsx
+++ b/apps/web/src/app/trips/[id]/page.tsx
@@ -111,8 +111,7 @@ export default function TripDetailPage({ params }: TripDetailPageProps) {
   const isOrganizer = callerRole !== null && ORGANIZER_ROLES.includes(callerRole);
   const isDraft = trip.status === TripStatus.DRAFT;
   const isTerminal = trip.status === TripStatus.COMPLETED || trip.status === TripStatus.CANCELLED;
-  const isDestinationEditable =
-    isOrganizer && (trip.status === TripStatus.DRAFT || trip.status === TripStatus.OPEN);
+  const isDestinationEditable = isOrganizer && !isTerminal;
 
   return (
     <div className="p-8 max-w-2xl">

--- a/documentation/features/trips.md
+++ b/documentation/features/trips.md
@@ -61,14 +61,14 @@ This decision can be changed later by the organizer, but declaring it upfront en
 
 A trip progresses through the following statuses (enum: `TripStatus`):
 
-| Value         | Description                                                                                   |
-| ------------- | --------------------------------------------------------------------------------------------- |
-| `DRAFT`       | Trip is being planned. Not yet shared or open for invitations.                                |
-| `OPEN`        | Trip is open for invitations and participant confirmations.                                   |
-| `CONFIRMED`   | Trip is confirmed and edit-restricted. All strict pre-trip tasks must be resolved (post-MVP). |
-| `IN_PROGRESS` | Trip is currently happening (departure date has passed).                                      |
-| `COMPLETED`   | Trip has ended.                                                                               |
-| `CANCELLED`   | Trip was cancelled. Participants are notified.                                                |
+| Value         | Description                                                                                                                                                                       |
+| ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `DRAFT`       | Trip is being planned. Not yet shared or open for invitations.                                                                                                                    |
+| `OPEN`        | Trip is open for invitations and participant confirmations.                                                                                                                       |
+| `CONFIRMED`   | Trip is confirmed. Still editable — see [Changes While CONFIRMED or IN_PROGRESS](#changes-while-confirmed-or-in_progress). All strict pre-trip tasks must be resolved (post-MVP). |
+| `IN_PROGRESS` | Trip is currently happening (departure date has passed).                                                                                                                          |
+| `COMPLETED`   | Trip has ended.                                                                                                                                                                   |
+| `CANCELLED`   | Trip was cancelled. Participants are notified.                                                                                                                                    |
 
 ---
 
@@ -82,9 +82,11 @@ These boundaries determine when the trip transitions to `IN_PROGRESS` (start bou
 
 ---
 
-## Changes While IN_PROGRESS
+## Changes While CONFIRMED or IN_PROGRESS
 
-Once a trip enters `IN_PROGRESS` status, any modification (destinations, dates, participant list, settings) **requires explicit organizer confirmation** before it is saved. After a change is confirmed and applied, **all confirmed participants are notified** of what changed.
+Once a trip reaches `CONFIRMED` status (and while it remains `IN_PROGRESS`), it is not edit-restricted — organizers can still modify destinations, dates, participant list, and settings. The API marks these edits with `requiresConfirmation: true` so the client can flag them as sensitive changes.
+
+**Not yet implemented (post-MVP, Issues #343–#354):** an explicit organizer confirmation step before the edit is saved, and a notification to all confirmed participants after a change is applied. Until that lands, `requiresConfirmation` is informational only — edits save immediately and no notification is sent. A trip only becomes truly immutable at `COMPLETED` or `CANCELLED`.
 
 ---
 
@@ -214,7 +216,7 @@ Every trip must have at least one destination. Destinations are ordered — the 
 
 - At least one destination is required. A trip without destinations cannot be published (`OPEN`).
 - Positions must be contiguous and start at 1. Reordering destinations updates all affected `position` values atomically.
-- Destinations can be added, removed, or reordered while the trip is `DRAFT` or `OPEN`. Changes while `IN_PROGRESS` require organizer confirmation.
+- Destinations can be added, removed, or reordered while the trip is `DRAFT`, `OPEN`, `CONFIRMED`, or `IN_PROGRESS`. Changes while `CONFIRMED` or `IN_PROGRESS` are flagged via `requiresConfirmation` — see [Changes While CONFIRMED or IN_PROGRESS](#changes-while-confirmed-or-in_progress).
 
 ---
 


### PR DESCRIPTION
## Summary

Organizers reported being unable to edit trip destinations/itinerary once a trip reached `CONFIRMED` status. The backend guards already permitted edits at `CONFIRMED` (only `COMPLETED`/`CANCELLED` are truly immutable), but the trip detail page computed its destinations-editable flag from a `DRAFT`/`OPEN`-only allowlist, hiding the entire add/edit/delete/reorder UI for organizers on `CONFIRMED` (and `IN_PROGRESS`) trips. Fixed the frontend check to match the backend's actual allowed-statuses logic, and corrected documentation/Swagger text that inaccurately described `CONFIRMED` as edit-restricted or implied a confirmation/notification mechanism that doesn't exist yet.

## Changes

- **Frontend fix**: `apps/web/src/app/trips/[id]/page.tsx` — `isDestinationEditable` now uses `isOrganizer && !isTerminal` (blocking only `COMPLETED`/`CANCELLED`), matching the backend guard and the sibling itinerary-notes edit affordance on the same page.
- **Docs**: `documentation/features/trips.md` — `CONFIRMED` row no longer says "edit-restricted"; "Changes While IN_PROGRESS" renamed to "Changes While CONFIRMED or IN_PROGRESS" and now explicitly states the organizer-confirmation + participant-notification mechanism is post-MVP/not yet implemented (Issues #343-354), so `requiresConfirmation` is informational only today; destinations edit rule updated to include `CONFIRMED`.
- **Swagger/DTOs**: `destination-response.dto.ts` and `trip-response.dto.ts` — corrected `requiresConfirmation` descriptions (previously said "IN_PROGRESS" only, or implied a confirmation/notification step that doesn't exist).
- **INVENTORY.md**: updated the `requiresConfirmation` entry in `apps/api/src/modules/trips/destinations/dto/INVENTORY.md` to match.
- **Skill docs**: fixed `.claude/skills/take-issue/SKILL.md` and `.claude/skills/to-review/SKILL.md` — clarified that `./scripts/*.sh` paths are relative to the repo root, not the skill's own directory (caused a script-not-found error when run naively from the skill base dir).

## Testing

- `pnpm --filter api test` — full suite passes (92 relevant tests in `trips-destinations`, `trips.service`, `trips.controller` specs), no behavior change on the backend (guard logic untouched).
- Pre-commit gates (format, lint, typecheck, unit tests, coverage) passed on commit.
- Manually traced the full edit path (frontend UI gate → API service calls → controller → service guard) to confirm no other status check remains for `CONFIRMED` on destinations, per-destination itinerary text, or trip-level `itinerary_notes`.

## Notes

Building the actual organizer-confirmation step and participant-notification (the deeper feature implied by `requiresConfirmation`) is out of scope here — that's tracked under the existing post-MVP epic (Issues #343-354) and now explicitly documented as pending in `trips.md`.

Closes #484