### PR TITLE
style(trips): divider-separated task list

### DIFF
--- a/apps/web/src/app/trips/[id]/tasks/page.tsx
+++ b/apps/web/src/app/trips/[id]/tasks/page.tsx
@@ -161,7 +161,7 @@ export default function TripTasksPage({ params }: TripTasksPageProps) {
         {sharedTasks.length === 0 ? (
           <p className="text-sm text-muted-foreground">{t('tasks.sharedEmpty')}</p>
         ) : (
-          <ul className="space-y-2">
+          <ul className="divide-y divide-border overflow-hidden rounded-lg border border-border">
             {sharedTasks.map((task) => (
               <TripTaskItem
                 key={task.id}
@@ -183,7 +183,7 @@ export default function TripTasksPage({ params }: TripTasksPageProps) {
         {personalTasks.length === 0 ? (
           <p className="text-sm text-muted-foreground">{t('tasks.personalEmpty')}</p>
         ) : (
-          <ul className="space-y-2">
+          <ul className="divide-y divide-border overflow-hidden rounded-lg border border-border">
             {personalTasks.map((task) => (
               <TripTaskItem
                 key={task.id}

--- a/apps/web/src/components/ui/checkbox.tsx
+++ b/apps/web/src/components/ui/checkbox.tsx
@@ -10,7 +10,7 @@ function Checkbox({ className, ...props }: CheckboxPrimitive.Root.Props) {
     <CheckboxPrimitive.Root
       data-slot="checkbox"
       className={cn(
-        'peer relative flex size-4 shrink-0 items-center justify-center rounded-[4px] border border-input transition-colors outline-none group-has-disabled/field:opacity-50 after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 aria-invalid:aria-checked:border-primary dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:border-primary data-checked:bg-primary data-checked:text-primary-foreground dark:data-checked:bg-primary',
+        'peer relative flex size-4 shrink-0 items-center justify-center rounded-sm border border-input transition-colors outline-none group-has-disabled/field:opacity-50 after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 aria-invalid:aria-checked:border-primary dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:border-primary data-checked:bg-primary data-checked:text-primary-foreground dark:data-checked:bg-primary',
         className,
       )}
       {...props}

--- a/apps/web/src/components/ui/trip-task-item.tsx
+++ b/apps/web/src/components/ui/trip-task-item.tsx
@@ -67,7 +67,7 @@ export function TripTaskItem({ task, onToggle, onRename, onDelete }: TripTaskIte
 
   if (isEditing) {
     return (
-      <li className="flex items-center gap-2 rounded-lg border border-border bg-card p-3">
+      <li className="flex items-center gap-2 bg-card p-3">
         <Input
           value={draftTitle}
           onChange={(e) => setDraftTitle(e.target.value)}
@@ -96,7 +96,7 @@ export function TripTaskItem({ task, onToggle, onRename, onDelete }: TripTaskIte
   }
 
   return (
-    <li className="flex items-center gap-3 rounded-lg border border-border bg-card p-3">
+    <li className="flex items-center gap-3 pl-3 pr-1 py-1">
       <Checkbox
         checked={task.completed}
         onCheckedChange={() => void handleToggle(!task.completed)}


### PR DESCRIPTION
## Summary
- Replace per-item bordered/rounded task rows with a single bordered container + `divide-y` separators between rows — full boxed look was heavy.
- Minor checkbox radius tweak (`rounded-[4px]` → `rounded-sm`).

## Test plan
- [x] `pnpm --filter web test -- trip-task-item` passes
- [x] Husky pre-commit (lint, typecheck, tests) passed
- [ ] Manual visual check on /trips/:id/tasks